### PR TITLE
Allow Traefik SVC Account to read and watch traefik CRDs

### DIFF
--- a/templates/rbac/clusterrole.yaml
+++ b/templates/rbac/clusterrole.yaml
@@ -28,3 +28,14 @@ rules:
       - ingresses/status
     verbs:
       - update
+- apiGroups:
+    - traefik.containo.us
+  resources:
+    - ingressroutes
+    - ingressroutetcps
+    - middlewares
+    - tlsoptions
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

The initial Helm Chart does not allow Traefik to watch/get/list Traefiks CRDs.
If you create an Ingressroute, Traefik is not able to pick it and prints log error messages when receiving the event:

```text
ed to list *v1alpha1.Middleware: middlewares.traefik.containo.us is forbidden: User "system:serviceaccount:default:kind-lightningbug-traefik" cannot list resource "middlewares" in API group "traefik.containo.us" at the cluster scope
E1003 10:43:45.979201       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190718183610-8e956561bbf5/tools/cache/reflector.go:98: Failed to list *v1alpha1.IngressRouteTCP: ingressroutetcps.traefik.containo.us is forbidden: User "system:serviceaccount:default:kind-lightningbug-traefik" cannot list resource "ingressroutetcps" in API group "traefik.containo.us" at the cluster scope
E1003 10:43:45.980270       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190718183610-8e956561bbf5/tools/cache/reflector.go:98: Failed to list *v1alpha1.IngressRoute: ingressroutes.traefik.containo.us is forbidden: User "system:serviceaccount:default:kind-lightningbug-traefik" cannot list resource "ingressroutes" in API group "traefik.containo.us" at the cluster scope
E1003 10:43:45.981576       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190718183610-8e956561bbf5/tools/cache/reflector.go:98: Failed to list *v1alpha1.TLSOption: tlsoptions.traefik.containo.us is forbidden: User "system:serviceaccount:default:kind-lightningbug-traefik" cannot list resource "tlsoptions" in API group "traefik.containo.us" at the cluster scope
```

Credits to @jlevesy 