### PR TITLE
Add externalTrafficPolicy for LB service

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: {{ default "Cluster" .Values.service.externalTrafficPolicy }}
   selector:
     app: {{ template "traefik.name" . }}
     release: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,8 +14,8 @@ ports:
   traefik:
     port: 9000
 #
-service:
-  externalTrafficPolicy: Cluster
+#service:
+#  externalTrafficPolicy: Cluster
 
 logs:
   loglevel: INFO

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,9 @@ ports:
   traefik:
     port: 9000
 #
+service:
+  externalTrafficPolicy: Cluster
+
 logs:
   loglevel: INFO
 #


### PR DESCRIPTION
If `service.type` is NodePort or LoadBalancer, set `externalTrafficPolicy` to Local to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport)