### PR TITLE
feat: .Values.service.annotations added for LB tune up

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ NOTE: THIS CHART IS IN INCUBATOR STATUS, DO NOT USE IN A PRODUCTION ENVIRONMENT
 ## Configuration
 
 The following table lists the configurable parameters of the Traefik chart and their default values.
+```
 | Parameter                              | Description                                                                                                                  | Default                                           |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | `service.annotations`                  |  Extra parameters to manage cloud load balancers. More [details](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws) |             []               |
+```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ external load balancer (e.g. AWS or GKE)
 - You control DNS for the domain(s) you intend to route through Traefik
 
 NOTE: THIS CHART IS IN INCUBATOR STATUS, DO NOT USE IN A PRODUCTION ENVIRONMENT
+
+## Configuration
+
+The following table lists the configurable parameters of the Traefik chart and their default values.
+| Parameter                              | Description                                                                                                                  | Default                                           |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `service.annotations`                  |  Extra parameters to manage cloud load balancers. More [details](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws) |             []               |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,6 +7,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  {{- if .Values.service }}
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
In case when TLS is terminated by ELB service annotations needed to pass cloud provider's params.