### PR TITLE
Add sidecar support

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,3 +81,6 @@ spec:
           - "--ping=true"
           - "--providers.kubernetescrd"
           - "--log.level={{ .Values.logs.loglevel }}"
+      {{- if .Values.sidecar }}
+{{ toYaml .Values.sidecar | indent 6 }}
+      {{- end }}


### PR DESCRIPTION
Adds support to run a sidecar along traefik and addresses https://github.com/containous/traefik-helm-chart/issues/19
This can be useful if one is running an forward-auth service  but want it to run alongside traefik to mitigate any network latency.

In the values file it can be defined like so

```
sidecar:
- image: foo/forward-auth-service
  name: forward-auth-service
  ...
```
Then you would have a middleware that uses this sidecar ie:

```
apiVersion: traefik.containo.us/v1alpha1
kind: Middleware
metadata:
  name: ext-auth
spec:
  forwardAuth:
    address: http://localhost:8080/validate
```

```