### PR TITLE
Fix error "nil pointer evaluating interface {}.externalTrafficPolicy"

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,7 +9,11 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   type: LoadBalancer
+  {{- if .Values.service }}
+  {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ default "Cluster" .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- end }}
   selector:
     app: {{ template "traefik.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

This PR closes #23 by fixing the Service template, which now checks for existence for `Value.service` and `Value.service.externalTrafficPolicy` .