### PR TITLE
Ports, service, args and dashboard configuration + minor style changes

### DIFF
--- a/templates/dashboard-hook-ingressroute.yaml
+++ b/templates/dashboard-hook-ingressroute.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.ingress.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -18,3 +19,4 @@ spec:
     services:
     - name:  {{ template "traefik.fullname" . }}-dashboard
       port: 80
+{{- end }}

--- a/templates/dashboard-service.yaml
+++ b/templates/dashboard-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
   - port: 80
     name: traefik
     targetPort: traefik
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,3 +81,8 @@ spec:
           - "--ping=true"
           - "--providers.kubernetescrd"
           - "--log.level={{ .Values.logs.loglevel }}"
+          {{- with .Values.additionalArguments }}
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -17,6 +17,12 @@ spec:
     matchLabels:
       app: {{ template "traefik.name" . }}
       release: {{ .Release.Name }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      {{- with .Values.rollingUpdate }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       labels:
@@ -31,18 +37,16 @@ spec:
       - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         name: {{ template "traefik.fullname" . }}
         resources:
-        {{- if .Values.yaml }}
-        {{- if .Values.yaml.resources }}
-{{ toYaml .Values.yaml.resources | indent 10 }}
-        {{- end }}
-        {{- if .Values.yaml.tolerations }}
+          {{- with .Values.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- with .Values.tolerations }}
         tolerations:
-{{ toYaml .Values.yaml.tolerations | indent 8 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if .Values.yaml.nodeSelector }}
+        {{- with .Values.nodeSelector }}
         nodeSelector:
-{{ toYaml .Values.yaml.nodeSelector | indent 10 }}
-        {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         readinessProbe:
           httpGet:
@@ -63,19 +67,15 @@ spec:
           successThreshold: 1
           timeoutSeconds: 2
         ports:
-        - name: web
-          containerPort: {{ .Values.ports.web.port }}
+        {{- range $name, $config := .Values.ports }}
+        - name: {{ $name | quote }}
+          containerPort: {{ $config.port }}
           protocol: TCP
-        - name: websecure
-          containerPort: {{ .Values.ports.websecure.port }}
-          protocol: TCP
-        - name: traefik
-          containerPort: {{ .Values.ports.traefik.port }}
-          protocol: TCP
+        {{- end }}
         args:
-          - "--entryPoints.web.address=:{{ .Values.ports.web.port }}"
-          - "--entryPoints.websecure.address=:{{ .Values.ports.websecure.port }}"
-          - "--entryPoints.traefik.address=:{{ .Values.ports.traefik.port }}"
+          {{- range $name, $config := .Values.ports }}
+          - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
+          {{- end }}
           - "--api.dashboard=true"
           - "--api.insecure=true"
           - "--ping=true"

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,20 +7,24 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-spec:
-  type: LoadBalancer
-  {{- if .Values.service }}
-  {{- if .Values.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ default "Cluster" .Values.service.externalTrafficPolicy }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+spec:
+  {{- $type := default "LoadBalancer" .Values.service.type }}
+  type: {{ $type }}
+  {{- with .Values.service.spec }}
+  {{- toYaml . | nindent 2 }}
   {{- end }}
   selector:
     app: {{ template "traefik.name" . }}
     release: {{ .Release.Name }}
   ports:
-  - port: 80
-    name: web
-    targetPort: web
-  - port: 443
-    name: websecure
-    targetPort: websecure
+  {{- range $name, $config := .Values.ports }}
+  {{- if $config.expose }}
+  - port: {{ default $config.port $config.exposedPort }}
+    name: {{ $name }}
+    targetPort: {{ $name }}
+  {{- end }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,31 +2,81 @@
 image:
   name: traefik
   tag: 2.0.5
+
+#
+# Configure the deployment
 #
 deployment:
+  # Number of pods of the deployment
   replicas: 1
+
+rollingUpdate:
+  maxUnavailable: 1
+  maxSurge: 1
+
+# Additional arguments to be passed at the startup of traeffik
+additionalArguments: []
+#  - "--argument1"
+
+#
+# Configure Traefik entrypoints
 #
 ports:
-  web:
-    port: 8000
-  websecure:
-    port: 8443
+  # The name of this one can't be changed as it is used for the readiness and
+  # liveness probes, but you can adjust its config to your liking
   traefik:
     port: 9000
-#
-#service:
-#  externalTrafficPolicy: Cluster
+    # Defines whether the port is exposed if service.type is LoadBalancer or
+    # NodePort.
+    #
+    # You SHOULD NOT expose the traefik port on production deployments. If you
+    # want to access it from outside of your cluster, use `kubectl proxy` or
+    # create a secure ingress
+    expose: false
+    # The exposed port for this service
+    exposedPort: 9000
+  web:
+    port: 8000
+    expose: true
+    exposedPort: 80
+  websecure:
+    port: 8443
+    expose: true
+    exposedPort: 443
+
+# Options for the main traefik service, where the entrypoints traffic comes
+# from.
+service:
+  type: LoadBalancer
+  # Additional annotations (e.g. for cloud provider specific config)
+  annotations: {}
+  # Additional entries here will be added to the service spec. Cannot contains
+  # type, selector or ports entries.
+  spec: {}
+    # externalTrafficPolicy: Cluster
+    # loadBalancerIp: "1.2.3.4"
+    # clusterIP: "2.3.4.5"
+
+dashboard:
+  service:
+    # Create a service exposing the traefik port in the cluster using a
+    # ClusterIP
+    enabled: true
+  ingress:
+    # Expose the dashboard and api service via an ingress route at /dashboard
+    # and /api This is not secure and SHOULD NOT be enabled on production
+    # deployments
+    enabled: true
 
 logs:
   loglevel: INFO
 #
-yaml:
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "50Mi"
-    limits:
-      cpu: "300m"
-      memory: "150Mi"
-#  nodeSelector: {}
-#  tolerations: []
+resources: {}
+  # requests:
+  #   cpu: "100m"
+  #   memory: "50Mi"
+  # limits:
+  #   cpu: "300m"
+  #   memory: "150Mi"
+nodeSelector: {}
+tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ rollingUpdate:
   maxUnavailable: 1
   maxSurge: 1
 
-# Additional arguments to be passed at the startup of traeffik
+# Additional arguments to be passed at Traefik's binary
 additionalArguments: []
 #  - "--argument1"
 

--- a/values.yaml
+++ b/values.yaml
@@ -15,8 +15,8 @@ rollingUpdate:
   maxSurge: 1
 
 # Additional arguments to be passed at Traefik's binary
-additionalArguments: []
-#  - "--argument1"
+additionalArguments: 
+#  - "--providers.kubernetesingress"
 
 #
 # Configure Traefik entrypoints


### PR DESCRIPTION
The PR contains various improvements, allowing to :

- Configure the deployment/traefik/service ports to add extra entrypoints
- Disable the dashboard service and ingress
- Tune the rolling update config
- Use other service types for the main service
- Add arguments to traefik's startup

It also include minor changes in value to reflect the community standards I've observed in the official helm repo. I might be wrong on that one.

PS: Sorry for the all-in-one PR