### PR TITLE
Add env section and make dashboard ingress more flexible

### DIFF
--- a/templates/dashboard-hook-ingressroute.yaml
+++ b/templates/dashboard-hook-ingressroute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dashboard.ingressRoute }}
+{{- if .Values.dashboard.ingressRoute.enabled }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -14,11 +14,21 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   entryPoints:
-    - web
+  {{- range .Values.dashboard.ingressRoute.entryPoints }}
+    - {{ . }}
+  {{- end }} 
   routes:
-  - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+  - match: {{ .Values.ingressRoute.match }}
     kind: Rule
     services:
     - name: api@internal
       kind: TraefikService
+    middlewares:
+    {{- range .Values.dashboard.ingressRoute.middlewares }}
+      - name: {{ .name }}
+        namespace: {{ .namespace }}
+    {{- end }}
+  tls:
+    certResolver: {{ .Values.dashboard.ingressRoute.certResolver }}
+    options: {}
 {{- end -}}

--- a/templates/dashboard-hook-ingressroute.yaml
+++ b/templates/dashboard-hook-ingressroute.yaml
@@ -18,7 +18,7 @@ spec:
     - {{ . }}
   {{- end }} 
   routes:
-  - match: {{ .Values.ingressRoute.match }}
+  - match: {{ .Values.dashboard.ingressRoute.match }}
     kind: Rule
     services:
     - name: api@internal

--- a/templates/dashboard-hook-ingressroute.yaml
+++ b/templates/dashboard-hook-ingressroute.yaml
@@ -4,7 +4,9 @@ kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
-    helm.sh/hook: "post-install"
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: "before-hook-creation"
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -66,6 +66,15 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
+        env:
+        {{ $secretfullname := include "traefik.fullname" . }}
+        {{- range .Values.env }} 
+          - name: {{ .name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secretfullname }}
+                key: {{ .name }}
+        {{- end }}
         ports:
         {{- range $name, $config := .Values.ports }}
         - name: {{ $name | quote }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+{{- range .Values.env }} 
+  {{ .name }}: {{ printf "%v" .value | b64enc  }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,13 @@ dashboard:
     certResolver: default
     match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
 
+# Environment variables that will be placed into a secret
+# This can be useful when loading cloud provider variables for acme
+# env:
+#  - name: name
+#    value: value
+env: []
+
 logs:
   loglevel: WARN
 #

--- a/values.yaml
+++ b/values.yaml
@@ -55,7 +55,13 @@ dashboard:
   # Expose the dashboard and api through an ingress route at /dashboard
   # and /api This is not secure and SHOULD NOT be enabled on production
   # deployments
-  ingressRoute: true
+  ingressRoute:
+    enabled: false
+    entryPoints:
+      - websecure
+    middlewares: []
+    certResolver: default
+    match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
 
 logs:
   loglevel: WARN


### PR DESCRIPTION
- Add env section to inject variables into a secret and then load them inside the pod. This for cloud provider environment variables when using acme
- Adjust ingressroute to make it more flexible