### PR TITLE
remove trailing `-` from template

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   type: {{ $type }}
   {{- with .Values.service.spec }}
   {{- toYaml . | nindent 2 }}
-  {{- end -}}
+  {{- end }}
   selector:
     app: {{ template "traefik.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
removing the whitespace after this `.Values.service.spec` block creates invalid yaml (i'm guessing it pulls the `selector: ` up on to the previous line and throws off the tab alignments).

before: 
```
$ helm template traefik .
Error: YAML parse error on traefik/templates/service.yaml: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
```
after:
```
$ helm template traefik .
<rendered templates>
```