### PR TITLE
Introducing a "Build workflow"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Outputs directories
 dist/
+repo/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Outputs directories
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+sudo: required
+dist: xenial
+
+services:
+  - docker
+  
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ notifications:
 sudo: required
 dist: xenial
 
+install:
+  - curl -L https://git.io/get_helm.sh | bash -s -- -v v2.16.1
+
 services:
   - docker
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
+dist: xenial
+sudo: required
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-sudo: required
-dist: xenial
+services:
+  - docker
 
 env:
   global:
@@ -13,9 +15,6 @@ env:
 
 install:
   - curl -L https://git.io/get_helm.sh | bash -s -- -v v2.16.1
-
-services:
-  - docker
   
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 
 install:
   - curl -L https://git.io/get_helm.sh | bash -s -- -v v2.16.1
-  
+
 script:
+  # validating if the chart was bumped
+  # - git diff --quiet HEAD origin/master || git diff HEAD origin/master -- Chart.yaml | grep -qE "version:.*"
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ notifications:
 sudo: required
 dist: xenial
 
+env:
+  global:
+    - TMPDIR=/tmp
+
 install:
   - curl -L https://git.io/get_helm.sh | bash -s -- -v v2.16.1
 

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,29 @@ all: clean lint build deploy
 
 # Ensure the Helm chart and its metadata are valid
 lint: helm $(SHIM_DIR)
+	@echo "== Linting Chart..."
 	@helm lint $(SHIM_DIR)
+	@echo "== Linting Finished"
 
 # Generates an artefact containing the Helm Chart in the distribution directory
 build: helm $(DIST_DIR) $(SHIM_DIR)
+	@echo "== Building Chart..."
 	@helm package $(SHIM_DIR) --destination=$(DIST_DIR)
+	@echo "== Building Finished"
 
 # Prepare the Helm repository with the latest packaged charts
 deploy: build $(DIST_DIR) $(HELM_REPO)
+	@echo "== Deploying Chart..."
 	@cp $(DIST_DIR)/*tgz $(HELM_REPO)/
 	@helm repo index $(HELM_REPO)
+	@echo "== Deploying Finished"
 
 # Cleanup leftovers and distribution dir
 clean:
+	@echo "== Cleaning..."
 	@rm -rf $(DIST_DIR)
 	@unlink $(SHIM_DIR) >/dev/null 2>&1 || true
+	@echo "== Cleaning Finished"
 	
 ################################## Technical targets
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+## Workflow for "building" the Helm chart
+DIST_DIR ?= $(CURDIR)/dist
+SHIM_DIR ?= $(TMPDIR)/traefik
+
+all: lint build #test deploy # Future targets
+
+lint: helm $(SHIM_DIR)
+	@helm lint $(TMPDIR)/traefik
+
+build: helm $(DIST_DIR) $(SHIM_DIR)
+	@helm package $(SHIM_DIR) --destination=$(DIST_DIR)
+
+$(DIST_DIR):
+	@mkdir -p $(DIST_DIR)
+
+helm:
+	@command -v helm >/dev/null || ( echo "ERROR: Helm binary not found. Exiting." && exit 1)
+
+# This target is phony to ensure there is no conflict with other dir named "traefik"
+$(SHIM_DIR):
+	@## Helm v2 require directory to have the same name as the chart
+	@unlink $(SHIM_DIR) || ( echo "ERROR: $(SHIM_DIR) already exists. Exiting." && exit 1)
+	@ln -s $(CURDIR) $(SHIM_DIR) || ( echo "ERROR: cannot link $(CURDIR) to $(SHIM_DIR). Exiting." && exit 1)
+
+.PHONY: all helm lint build $(SHIM_DIR)

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ $(HELM_REPO):
 
 helm:
 	@command -v helm >/dev/null || ( echo "ERROR: Helm binary not found. Exiting." && exit 1)
+	@helm init --client
 
 # This target is phony to ensure there is no conflict with other dir named "traefik"
 $(SHIM_DIR):

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(HELM_REPO):
 
 helm:
 	@command -v helm >/dev/null || ( echo "ERROR: Helm binary not found. Exiting." && exit 1)
-	@helm init --client
+	@helm init --client-only
 
 # This target is phony to ensure there is no conflict with other dir named "traefik"
 $(SHIM_DIR):

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,41 @@
-## Workflow for "building" the Helm chart
+
 DIST_DIR ?= $(CURDIR)/dist
 SHIM_DIR ?= $(TMPDIR)/traefik
+HELM_REPO ?= $(CURDIR)/repo
 
-all: lint build #test deploy # Future targets
+################################## Functionnal targets
 
+# Default Target: run all
+all: clean lint build deploy
+
+# Ensure the Helm chart and its metadata are valid
 lint: helm $(SHIM_DIR)
 	@helm lint $(TMPDIR)/traefik
 
+# Generates an artefact containing the Helm Chart in the distribution directory
 build: helm $(DIST_DIR) $(SHIM_DIR)
 	@helm package $(SHIM_DIR) --destination=$(DIST_DIR)
 
+# Prepare the Helm repository with the latest packaged charts
+deploy: build $(DIST_DIR) $(HELM_REPO)
+	@cp $(DIST_DIR)/*tgz $(HELM_REPO)/
+	@helm repo index $(HELM_REPO)
+
+# Cleanup leftovers and distribution dir
+clean:
+	@rm -rf $(DIST_DIR)
+	@unlink $(SHIM_DIR) >/dev/null 2>&1 || true
+	
+################################## Technical targets
+
 $(DIST_DIR):
 	@mkdir -p $(DIST_DIR)
+
+
+## This directory is git-ignored for now, 
+## and should become a worktree on the branch gh-pages in the future
+$(HELM_REPO):
+	@mkdir -p $(HELM_REPO)
 
 helm:
 	@command -v helm >/dev/null || ( echo "ERROR: Helm binary not found. Exiting." && exit 1)
@@ -19,7 +43,7 @@ helm:
 # This target is phony to ensure there is no conflict with other dir named "traefik"
 $(SHIM_DIR):
 	@## Helm v2 require directory to have the same name as the chart
-	@unlink $(SHIM_DIR) || ( echo "ERROR: $(SHIM_DIR) already exists. Exiting." && exit 1)
+	@[ -L $(SHIM_DIR) ] && unlink $(SHIM_DIR) || true
 	@ln -s $(CURDIR) $(SHIM_DIR) || ( echo "ERROR: cannot link $(CURDIR) to $(SHIM_DIR). Exiting." && exit 1)
 
-.PHONY: all helm lint build $(SHIM_DIR)
+.PHONY: all helm lint build deploy clean $(SHIM_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 DIST_DIR ?= $(CURDIR)/dist
+TMPDIR ?= /tmp
 SHIM_DIR ?= $(TMPDIR)/traefik
 HELM_REPO ?= $(CURDIR)/repo
 
@@ -10,7 +11,7 @@ all: clean lint build deploy
 
 # Ensure the Helm chart and its metadata are valid
 lint: helm $(SHIM_DIR)
-	@helm lint $(TMPDIR)/traefik
+	@helm lint $(SHIM_DIR)
 
 # Generates an artefact containing the Helm Chart in the distribution directory
 build: helm $(DIST_DIR) $(SHIM_DIR)


### PR DESCRIPTION
The goal of this PR is to introduce a "build workflow" for this Helm chart.

It provides a standard workflow, that can be run by Travis (tested here: https://travis-ci.com/dduportal/traefik-helm-chart/branches) for ensuring that any contribution on this chart in the future will be valid.

This workflow is (for now) the following

- A "lint" phase, to ensure that there is no obvious error on the charts.
  * Implementation is only a "helm lint" for today
- A "build" phase which generates an artefact of type `tgz archive` for the helm on a local directory.
- A "deploy" phase which copy the generated artefact in a dummy directory (git ignored for today: it is a placeholder) to simulate a future "helm repository" (e.g. a directory containing an `index.yaml`, a list of tgz, served by a public web server in https as github pages, netlify or s3 bucket).

Of course, there are big many steps that are not treated here to avoid a big dangling PR. The proposal is to go tiny steps by tiny steps.

Some thoughs on the next steps:

- Adding a test phase (at least a smoke test which ensures that the `helm install ./` command without any custom value is ALWAYS working)
- Use Github Pages with a `gh-pages` branch , where the helm repo would be served and deploy. 
- Adding more linting rules (my most loved one: if it is a PR, then check that the Chart version was bumped or fail the build immediately...)
- Generates and distribute the "YAML" manifest from the helm chart, by using `hem template <...>`. This would allow distributing Traefik in Kubernetes in another way, without risking a shift between hel mchart and "bare YAML". It would open the door for people who want to use Kustomize instead of Helm.