### PR TITLE
fix: spec of tolerations and nodeSelector

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 2.2.1
+version: 2.2.2
 appVersion: 2.1.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,9 +81,9 @@ spec:
           {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,9 +81,9 @@ spec:
           {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,14 +40,6 @@ spec:
           {{- with .Values.resources }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-        {{- with .Values.tolerations }}
-        tolerations:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.nodeSelector }}
-        nodeSelector:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /ping
@@ -87,3 +79,11 @@ spec:
           - {{ . | quote }}
           {{- end }}
           {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}


### PR DESCRIPTION
Both `nodeSelector` and `tolerations` are a field of PodSpec, not from container.