### PR TITLE
expose hostnetwork option

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 5.4.0
+version: 5.5.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
     spec:
       serviceAccountName: {{ template "traefik.fullname" . }}
       terminationGracePeriodSeconds: 60
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
       - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         name: {{ template "traefik.fullname" . }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -123,6 +123,12 @@ persistence:
   path: /data
   annotations: {}
 
+# If hostNetwork is true, runs traefik in the host network namespace
+# To prevent unschedulabel pods due to port collisions, if hostNetwork=true
+# and replicas>1, a pod anti-affinity is recommended and will be set if the
+# affinity is left as default.
+hostNetwork: false
+
 resources: {}
   # requests:
   #   cpu: "100m"
@@ -131,5 +137,17 @@ resources: {}
   #   cpu: "300m"
   #   memory: "150Mi"
 affinity: {}
+# # This example pod anti-affinity forces the scheduler to put traefik pods
+# # on nodes where no other traefik pods are scheduled.
+# # It should be used when hostNetwork: true to prevent port conflicts
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#     - labelSelector:
+#         matchExpressions:
+#         - key: app
+#           operator: In
+#           values:
+#           - {{ template "traefik.name" . }}
+#       topologyKey: failure-domain.beta.kubernetes.io/zone
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
What:
adds hostNetwork and an example anti-affinity for hostnetwork compatibility.

Why:
I want traefik to bind to the node ports 80/443, but a NodePort service can only bind to ports >3000 (unless k8s is specifically configured to allow a different NodePort range which is not recommended). The only option in this situation is to run the pod in the host network namespace...       
But if the pod is running in the host network, we can't schedule more than one per node, because the port will become in-use as soon as the first pod starts, so it is necessary to spread them out among the nodes when we have more than one pod replica.

Closes #99 