### PR TITLE
Disable dashboard ingressRoute by default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 2.2.3
+version: 3.0.0
 appVersion: 2.1.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -65,7 +65,7 @@ dashboard:
   # Expose the dashboard and api through an ingress route at /dashboard
   # and /api This is not secure and SHOULD NOT be enabled on production
   # deployments
-  ingressRoute: true
+  ingressRoute: false
 
 logs:
   loglevel: WARN


### PR DESCRIPTION
Settings explicitly not secure for production deployment should never be enabled by default. Having this enabled by default WILL result in production deployments of Traefik which have this dashboard IngressRoute enabled. Please consider accepting this change and having the dashboard ingress route require a value be set by the user of the chart.