### PR TITLE
Fixed loadBalancerIP spec into values.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 2.2.2
+version: 2.2.3
 appVersion: 2.1.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/values.yaml
+++ b/values.yaml
@@ -55,7 +55,7 @@ service:
   # type, selector or ports entries.
   spec: {}
     # externalTrafficPolicy: Cluster
-    # loadBalancerIp: "1.2.3.4"
+    # loadBalancerIP: "1.2.3.4"
     # clusterIP: "2.3.4.5"
 
 dashboard:


### PR DESCRIPTION
Fixes: #53 

When using the `values.yaml`, the user will tend to uncomment some attributes to be used in the Helm chart. 

Currently the `values.yaml` generates a YAML with an incorrect syntax when specifying a `loadBalancerIP` entry.

```yaml
# helm install --name traefik-v22 \
#       --namespace=traefik-v2 ./traefik-helm-chart \
#       --debug --dry-run \
#       --set service.spec.loadBalancerIp=192.168.168.44

[....]

# Source: traefik/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: traefik-v22
  labels:
    app: traefik
    chart: "traefik-2.2.2"
    release: "traefik-v22"
    heritage: "Tiller"
spec:
  type: LoadBalancer
  loadBalancerIp: 192.168.168.44 <----- error when deploying
  
  selector:
    app: traefik
    release: traefik-v22
  ports:
  - port: 80
    name: web
    targetPort: "web"
  - port: 443
    name: websecure
    targetPort: "websecure"
```

With the patch, it should be:

```yaml
# helm install --name traefik-v22 \
#       --namespace=traefik-v2 ./traefik-helm-chart \
#       --debug --dry-run \
#       --set service.spec.loadBalancerIP=192.168.168.44

[....]

# Source: traefik/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: traefik-v22
  labels:
    app: traefik
    chart: "traefik-2.2.2"
    release: "traefik-v22"
    heritage: "Tiller"
spec:
  type: LoadBalancer
  loadBalancerIP: 192.168.168.44 <----should work fine (note the IP in caps)
  
  selector:
    app: traefik
    release: traefik-v22
  ports:
  - port: 80
    name: web
    targetPort: "web"
  - port: 443
    name: websecure
    targetPort: "websecure"
```