### PR TITLE
Allow kind override (daemonset)

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1beta1
 {{- end }}
-kind: Deployment
+kind: {{ .Values.deployment.kind }}
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
           - {{ . | quote }}
           {{- end }}
           {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindend 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -79,10 +79,6 @@ spec:
           - {{ . | quote }}
           {{- end }}
           {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
           {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindend 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,5 @@ resources: {}
   # limits:
   #   cpu: "300m"
   #   memory: "150Mi"
-affinity: {}
 nodeSelector: {}
 tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -79,5 +79,6 @@ resources: {}
   # limits:
   #   cpu: "300m"
   #   memory: "150Mi"
+affinity: {}
 nodeSelector: {}
 tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,8 @@ image:
 # Configure the deployment
 #
 deployment:
+  # What kind of object you want to create
+  kind: Deployment
   # Number of pods of the deployment
   replicas: 1
 


### PR DESCRIPTION
Very basic PR here, just allowing to set affinity settings (like nodeSelector) and allow to override `kind: Deployment` (for use DaemonSet if you want)

Not sure if I need to update the version in Chart.yaml (from 2.2.2 to 2.2.3?)

Thanks!