### PR TITLE
Enable aplicom entry point and default cert

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -32,10 +32,23 @@ spec:
         heritage: {{ .Release.Service | quote }}
     spec:
       serviceAccountName: {{ template "traefik.fullname" . }}
+      volumes:
+        - name: config
+          configMap:
+            name: traefik-conf
+        - name: tls
+          secret:
+            secretName: aplicom-server-cert
       terminationGracePeriodSeconds: 60
       containers:
       - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         name: {{ template "traefik.fullname" . }}
+        volumeMounts:
+          - name: config
+            mountPath: /etc/traefik/traefik.yml
+            subPath: traefik.yml
+          - name: tls
+            mountPath: /tls
         resources:
           {{- with .Values.resources }}
           {{- toYaml . | nindent 10 }}
@@ -87,3 +100,39 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: traefik-conf
+  namespace: traefik
+data:
+  traefik.yml: |
+    global:
+      checkNewVersion: false
+      sendAnonymousUsage: false
+    log:
+      level: "{{ .Values.logs.loglevel }}"
+    ping: true
+    entryPoints:
+      traefik:
+        address: ":{{ .Values.ports.traefik.port }}"
+      aplicom-entry:
+        address: ":{{ .Values.ports.aplicom.port }}"
+    api:
+      dashboard: "{{ .Values.dashboard.enable }}"
+    providers:
+      kubernetesCRD: {}
+      file:
+        filename: /etc/traefik/traefik.yml
+        watch: true
+    tls:
+      stores:
+        default:
+          defaultCertificate:
+            certFile: /tls/tls.crt
+            keyFile: /tls/tls.key
+      options:
+        default:
+          minVersion: VersionTLS12

--- a/values.yaml
+++ b/values.yaml
@@ -35,15 +35,10 @@ ports:
     # use `kubectl proxy` or create a secure ingress
     expose: false
     # The exposed port for this service
-    exposedPort: 9000
-  web:
-    port: 8000
+  aplicom:
+    port: 5144
     expose: true
-    exposedPort: 80
-  websecure:
-    port: 8443
-    expose: true
-    exposedPort: 443
+    exposedPort: 5144
 
 # Options for the main traefik service, where the entrypoints traffic comes
 # from.
@@ -53,19 +48,17 @@ service:
   annotations: {}
   # Additional entries here will be added to the service spec. Cannot contains
   # type, selector or ports entries.
-  spec: {}
-    # externalTrafficPolicy: Cluster
-    # loadBalancerIp: "1.2.3.4"
-    # clusterIP: "2.3.4.5"
+  spec:
+    loadBalancerIP: 34.77.237.30
 
 dashboard:
   # Enable the dashboard on Traefik
-  enable: true
+  enable: false
 
   # Expose the dashboard and api through an ingress route at /dashboard
   # and /api This is not secure and SHOULD NOT be enabled on production
   # deployments
-  ingressRoute: true
+  ingressRoute: false
 
 logs:
   loglevel: WARN


### PR DESCRIPTION
Traefik version 2.1 is not available as stable chart. This is a modified fork of https://github.com/containous/traefik-helm-chart. This repo is used as a submodule in gke-cluster until we get a stable version from Traefik that supports TCP routing and mTLS.

Must uses static traefik config file since Traefik default tls settings not allowed when passing as args.
Sendanonymoususage(https://docs.traefik.io/contributing/data-collection/) is disable(normally hardcoded to yes). DefaultCertificate is used when SNI is not matched and Aplicom devices do not support SNI so it will get the DefaultCertificate.

Enable aplicom entry point. Aplicom-ingress will make use of this entry point.