### PR TITLE
Allow exposing dashboard via configurable entrypoints

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 4.1.2
+version: 4.1.3
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -1,18 +1,17 @@
-{{- if .Values.dashboard.ingressRoute }}
+{{- if .Values.dashboard.ingressRouteEntrypoints }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
-    helm.sh/hook: "post-install"
+    helm.sh/hook: "post-install,post-upgrade"
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
-  entryPoints:
-    - web
+  entryPoints: {{- toYaml .Values.dashboard.ingressRouteEntrypoints | nindent 4 }}
   routes:
   - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
     kind: Rule

--- a/traefik/tests/dashboard-config_test.yaml
+++ b/traefik/tests/dashboard-config_test.yaml
@@ -17,19 +17,18 @@ tests:
           content:
             --api.dashboard=false
         template: deployment.yaml
-  - it: should NOT have the dashboard exposed through an IngressRoute by default
+  - it: should ONLY have the dashboard exposed via traefik entrypoint by default
+    asserts:
+      - equal:
+        path: spec.entryPoints
+        value:
+          - traefik
+        template: dashboard-hook-ingressroute.yaml
+  - it: should NOT create IngressRoute for dashboard if no entrypoints are specified
+    set:
+      dashboard:
+        ingressRoute: []
     asserts:
       - hasDocuments:
           count: 0
-        template: dashboard-hook-ingressroute.yaml
-  - it: should have an IngressRoute defined for exposing the dashboard when specifid via values
-    set:
-      dashboard:
-        ingressRoute: true
-    asserts:
-      - hasDocuments:
-          count: 1
-        template: dashboard-hook-ingressroute.yaml
-      - isKind:
-          of: IngressRoute
         template: dashboard-hook-ingressroute.yaml

--- a/traefik/tests/dashboard-config_test.yaml
+++ b/traefik/tests/dashboard-config_test.yaml
@@ -20,9 +20,9 @@ tests:
   - it: should ONLY have the dashboard exposed via traefik entrypoint by default
     asserts:
       - equal:
-        path: spec.entryPoints
-        value:
-          - traefik
+          path: spec.entryPoints
+          value:
+            - traefik
         template: dashboard-hook-ingressroute.yaml
   - it: should NOT create IngressRoute for dashboard if no entrypoints are specified
     set:

--- a/traefik/tests/dashboard-config_test.yaml
+++ b/traefik/tests/dashboard-config_test.yaml
@@ -27,7 +27,7 @@ tests:
   - it: should NOT create IngressRoute for dashboard if no entrypoints are specified
     set:
       dashboard:
-        ingressRoute: []
+        ingressRouteEntrypoints: []
     asserts:
       - hasDocuments:
           count: 0

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -97,9 +97,13 @@ dashboard:
   enable: true
 
   # Expose the dashboard and api through an ingress route at /dashboard
-  # and /api This is not secure and SHOULD NOT be enabled on production
-  # deployments
-  ingressRoute: false
+  # and /api on the given entrypoint. If not entrypoints specified, the
+  # ingress route is not created. It's recommended to only specify
+  # unexposed entrypoints (e.g. traefik). You can then use something like
+  #   kubectl port-forward traefik-nnnnnnn 9000:9000
+  # to make the dashboard available at http://localhost:9000/dashboard
+  ingressRouteEntrypoints:
+    - traefik
 
 logs:
   loglevel: WARN

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -97,11 +97,11 @@ dashboard:
   enable: true
 
   # Expose the dashboard and api through an ingress route at /dashboard
-  # and /api on the given entrypoint. If not entrypoints specified, the
+  # and /api on the given entrypoint. If no entrypoints specified, the
   # ingress route is not created. It's recommended to only specify
   # unexposed entrypoints (e.g. traefik). You can then use something like
   #   kubectl port-forward traefik-nnnnnnn 9000:9000
-  # to make the dashboard available at http://localhost:9000/dashboard
+  # to make the dashboard available at http://localhost:9000/dashboard/
   ingressRouteEntrypoints:
     - traefik
 


### PR DESCRIPTION
It's common practice to access privileged interfaces via `kubectl` proxy and port-forwarding tools. This PR exposes the dashboard via the unexposed default `traefik` entrypoint which is available on port 9000 on the traefik pods. This change makes the helm chart more plug and play without negatively affecting security.

Fixes #79