### PR TITLE
Enable configuration of global checknewversion and sendanonymoususage

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 3.3.3
+version: 3.4.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
           protocol: TCP
         {{- end }}
         args:
-          - "--global.checknewversion=true"
-          - "--global.sendanonymoususage=true"
+          - "--global.checknewversion={{ .Values.deployment.checkNewVersion }}"
+          - "--global.sendanonymoususage={{ .Values.deployment.sendAnonymousUsage}}"
           {{- range $name, $config := .Values.ports }}
           - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
           {{- end }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
           protocol: TCP
         {{- end }}
         args:
-          - "--global.checknewversion={{ .Values.deployment.checkNewVersion }}"
-          - "--global.sendanonymoususage={{ .Values.deployment.sendAnonymousUsage}}"
+          - "--global.checknewversion={{ .Values.additional.checkNewVersion }}"
+          - "--global.sendanonymoususage={{ .Values.additional.sendAnonymousUsage}}"
           {{- range $name, $config := .Values.ports }}
           - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
           {{- end }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -9,6 +9,8 @@ image:
 deployment:
   # Number of pods of the deployment
   replicas: 1
+
+additional:
   checkNewVersion: true
   sendAnonymousUsage: true
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -9,6 +9,8 @@ image:
 deployment:
   # Number of pods of the deployment
   replicas: 1
+  checkNewVersion: true
+  sendAnonymousUsage: true
 
 rollingUpdate:
   maxUnavailable: 1


### PR DESCRIPTION
I am unable to configure these as this chart is currently using hard-coded values.

This change enables them to be configured, and the new values are exposed the same as they are in the stable helm chart.

I don't know why it shows 11 commits as I rebased against upstream and my changes are confined to a single commit.  If anyone has any suggestions on how to best resolve this, I'd greatly appreciate it.