### PR TITLE
Add podAnnotations to the deployment

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 4.0.0
+version: 4.1.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
       {{- end }}
   template:
     metadata:
+      {{- if .Values.deployment.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ template "traefik.name" . }}
         chart: {{ template "traefik.chart" . }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -9,6 +9,8 @@ image:
 deployment:
   # Number of pods of the deployment
   replicas: 1
+  # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
+  podAnnotations: {}
 
 additional:
   checkNewVersion: true


### PR DESCRIPTION
This is a small change to add podAnnotations to the deployment so several hooks can do their job.