### PR TITLE
Add values to mount secrets or configmaps as volumes to the traefik pod

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 4.1.0
+version: 4.1.1
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -66,6 +66,12 @@ spec:
           containerPort: {{ $config.port }}
           protocol: TCP
         {{- end }}
+        volumeMounts:
+        {{- range .Values.volumes }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          readOnly: true
+        {{- end }}
         args:
           - "--global.checknewversion={{ .Values.additional.checkNewVersion }}"
           - "--global.sendanonymoususage={{ .Values.additional.sendAnonymousUsage}}"
@@ -85,6 +91,17 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      volumes:
+      {{- range .Values.volumes }}
+      - name: {{ .name }}
+        {{- if eq .type "secret" }}
+        secret:
+          secretName: {{ .name }}
+        {{- else if eq .type "configMap" }}
+        configMap:
+          name: {{ .name }}
+        {{- end }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -30,12 +30,12 @@ rollingUpdate:
 # - "--tls.certificates.certFile=/certs/tls.crt"
 # - "--tls.certificates.keyFile=/certs/tls.key"
 volumes: []
-#- name: public-cert
-#  mountPath: "/certs"
-#  type: secret
-#- name: configs
-#  mountPath: "/config"
-#  type: configMap
+# - name: public-cert
+#   mountPath: "/certs"
+#   type: secret
+# - name: configs
+#   mountPath: "/config"
+#   type: configMap
 
 #
 # Configure Traefik entry points

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -20,6 +20,23 @@ rollingUpdate:
   maxUnavailable: 1
   maxSurge: 1
 
+
+#
+# Add volumes to the traefik pod.
+# This can be used to mount a cert pair or a configmap that holds a config.toml file.
+# After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg:
+# additionalArguments:
+# - "--providers.file.filename=/config/dynamic.toml"
+# - "--tls.certificates.certFile=/certs/tls.crt"
+# - "--tls.certificates.keyFile=/certs/tls.key"
+volumes: []
+#- name: public-cert
+#  mountPath: "/certs"
+#  type: secret
+#- name: configs
+#  mountPath: "/config"
+#  type: configMap
+
 #
 # Configure Traefik entry points
 # Additional arguments to be passed at Traefik's binary


### PR DESCRIPTION
Building on #15 and using the additionalArguments from #34, this PR allows to mount either secrets or configMaps as volumes to the traefik pod. This can make it easy to load a dynamic toml config or set a default cert for all ingresses