### PR TITLE
Support hostPort

### DIFF
--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
         - name: {{ $name | quote }}
           containerPort: {{ $config.port }}
           protocol: TCP
+          {{- if $config.hostPort }}
+          hostPort: {{ $config.hostPort }}
+          {{- end }}
         {{- end }}
         args:
           - "--global.checknewversion={{ .Values.additional.checkNewVersion }}"


### PR DESCRIPTION
I wish to scale traefik to one replica per host (origin),  and use a hostPort of 443/80 then use a cloudflare load balancer to balance between my hosts (origins)