### PR TITLE
Add Service Monitor

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 3.5.0
+version: 3.6.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -70,6 +70,11 @@ spec:
           - "--ping=true"
           - "--providers.kubernetescrd"
           - "--log.level={{ .Values.logs.loglevel }}"
+          {{- if .Values.metrics.prometheus.enabled -}}
+          - "--metrics.prometheus=true"
+          - "--entryPoints.metrics.address=:9100"
+          - "--metrics.prometheus.entryPoint=metrics"
+          {{- end -}}
           {{- with .Values.additionalArguments }}
           {{- range . }}
           - {{ . | quote }}

--- a/traefik/templates/service-prometheus.yaml
+++ b/traefik/templates/service-prometheus.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "traefik.fullname" . }}-prometheus
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+  - port: 9100
+    name: metrics
+    targetPort: metrics
+{{- end }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if ( .Values.metrics.serviceMonitor )  }}
+{{- if and ( .Values.metrics.serviceMonitor.enabled ) ( .Values.metrics.prometheus.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: {{ template "traefik.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "traefik.fullname" . }}
+{{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - port: metrics
+    path: /metrics
+{{- if .Values.metrics.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+  jobLabel: {{ template "traefik.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "traefik.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}
+{{- end }}

--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -20,7 +20,7 @@ spec:
   - port: metrics
     path: /metrics
 {{- if .Values.metrics.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
 {{- end }}
   jobLabel: {{ template "traefik.fullname" . }}
   namespaceSelector:

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -8,15 +8,19 @@ tests:
       - equal:
           path: spec.type
           value: ClusterIP
+        template: service-prometheus.yaml
       - equal:
           path: spec.ports[0].port
           value: 9100
+        template: service-prometheus.yaml
       - equal:
           path: spec.ports[0].name
           value: metrics
+        template: service-prometheus.yaml
       - equal:
           path: spec.ports[0].targetPort
           value: metrics
+        template: service-prometheus.yaml
     set:
       metrics.prometheus.enabled: true
   - it: should have ServiceMonitor configured
@@ -24,6 +28,19 @@ tests:
       - isKind:
           of: ServiceMonitor
         template: servicemonitor.yaml
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+        template: servicemonitor.yaml
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 15s
+        template: servicemonitor.yaml
     set:
-      metrics.prometheus.enabled: true
-      metrics.prometheus.serviceMonitor: true
+      metrics:
+        prometheus:
+          enabled: true
+        serviceMonitor:
+          enabled: true
+          namespace: monitoring
+          interval: 15s

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -1,0 +1,29 @@
+suite: Metrics configuration
+templates:
+  - service-prometheus.yaml
+  - servicemonitor.yaml
+tests:
+  - it: should have kind Service configured correctly
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 9100
+      - equal:
+          path: spec.ports[0].name
+          value: metrics
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics
+    set:
+      metrics.prometheus.enabled: true
+  - it: should have ServiceMonitor configured
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        template: servicemonitor.yaml
+    set:
+      metrics.prometheus.enabled: true
+      metrics.prometheus.serviceMonitor: true

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -95,3 +95,18 @@ resources: {}
 affinity: {}
 nodeSelector: {}
 tolerations: []
+
+metrics:
+  # When enabled Traefik is started with the flag "--metrics.prometheus=true"
+  prometheus:
+    enabled: false
+
+  serviceMonitor:
+    # When set true and if Prometheus Operator is installed then use a ServiceMonitor to configure scraping
+    enabled: false
+    # Set the namespace the ServiceMonitor should be deployed
+    # namespace: monitoring
+    # Set how frequently Prometheus should scrape
+    # interval: 30s
+    # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+    # labels:


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

This PR adds the Service Monitor useful when Traefik is deployed in a cluster where Prometheus Operator is deployed.

Prometheus metrics flags have been added to Traefik command.

The approach follows the one from the stable Helm chart.