### PR TITLE
Add Compress middleware

### DIFF
--- a/traefik/templates/middlewares/compress.yaml
+++ b/traefik/templates/middlewares/compress.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.middlewares.compress.enabled }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    helm.sh/hook: "post-install"
+spec:
+  compress: {}
+{{- end -}}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -82,6 +82,10 @@ dashboard:
   # deployments
   ingressRoute: false
 
+middlewares:
+  compress:
+    enabled: false
+
 logs:
   loglevel: WARN
 #


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

This PR adds the `Compress` middleware.

I haven't found a way to configure this middleware via command flags. The recommended way to configure `Compress` in Kubernetes is to add an object of Kind `Middleware`.

Please advice here whether there is a different direction recommended.