### PR TITLE
Daemonset support

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 3.5.0
+version: 3.5.1
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      {{- with .Values.rollingUpdate }}
+      {{- with .Values.daemonset.rollingUpdate }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
   template:

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if (eq .Values.controller.kind "DaemonSet") }}
+{{- if (eq .Values.kind "DaemonSet") }}
 
 apiVersion: apps/v1
 kind: DaemonSet

--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -1,7 +1,7 @@
-{{- if (eq .Values.controller.kind "Deployment") }}
+{{- if (eq .Values.controller.kind "DaemonSet") }}
 
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
@@ -10,12 +10,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
-  replicas: {{ default 1 .Values.deployment.replicas }}
   selector:
     matchLabels:
       app: {{ template "traefik.name" . }}
       release: {{ .Release.Name }}
-  strategy:
+  updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       {{- with .Values.rollingUpdate }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if (eq .Values.controller.kind "Deployment") }}
+{{- if (eq .Values.kind "Deployment") }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      {{- with .Values.rollingUpdate }}
+      {{- with .Values.deployment.rollingUpdate }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
   template:

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -27,7 +27,7 @@ tests:
           value: 0
       - equal:
           path: spec.strategy.rollingUpdate.minReadySeconds
-          value: 1
+          value: 30
       - equal:
           path: spec.strategy.rollingUpdate.vegetaForce
           value: 9000

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -1,8 +1,16 @@
-suite: Daemonset configuration
+suite: DaemonSet configuration
 templates:
   - daemonset.yaml
 tests:
+  - it: should be of type DaemonSet
+    set:
+      kind: DaemonSet
+    asserts:
+    - isKind:
+        of: DaemonSet
   - it: should have a rollingUpdate strategy with default values
+    set:
+      kind: DaemonSet
     asserts:
       - equal:
           path: spec.updateStrategy.type
@@ -15,10 +23,12 @@ tests:
           value: 30
   - it: should have a custom merged rollingUpdate strategy with specified values
     set:
-      rollingUpdate:
-        maxUnavailable: 3
-        minReadySeconds: 60
-        vegetaForce: 9000
+      kind: DaemonSet
+      daemonset:
+        rollingUpdate:
+          maxUnavailable: 3
+          minReadySeconds: 60
+          vegetaForce: 9000
     asserts:
       - equal:
           path: spec.updateStrategy.type

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -1,0 +1,33 @@
+suite: Daemonset configuration
+templates:
+  - daemonset.yaml
+tests:
+  - it: should have a rollingUpdate strategy with default values
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.minReadySeconds
+          value: 30
+  - it: should have a custom merged rollingUpdate strategy with specified values
+    set:
+      rollingUpdate:
+        maxUnavailable: 0
+        vegetaForce: 9000
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.minReadySeconds
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.vegetaForce
+          value: 9000

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -5,29 +5,30 @@ tests:
   - it: should have a rollingUpdate strategy with default values
     asserts:
       - equal:
-          path: spec.strategy.type
+          path: spec.updateStrategy.type
           value: RollingUpdate
       - equal:
-          path: spec.strategy.rollingUpdate.maxUnavailable
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
           value: 1
       - equal:
-          path: spec.strategy.rollingUpdate.minReadySeconds
+          path: spec.updateStrategy.rollingUpdate.minReadySeconds
           value: 30
   - it: should have a custom merged rollingUpdate strategy with specified values
     set:
       rollingUpdate:
-        maxUnavailable: 0
+        maxUnavailable: 3
+        minReadySeconds: 60
         vegetaForce: 9000
     asserts:
       - equal:
-          path: spec.strategy.type
+          path: spec.updateStrategy.type
           value: RollingUpdate
       - equal:
-          path: spec.strategy.rollingUpdate.maxUnavailable
-          value: 0
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: 3
       - equal:
-          path: spec.strategy.rollingUpdate.minReadySeconds
-          value: 30
+          path: spec.updateStrategy.rollingUpdate.minReadySeconds
+          value: 60
       - equal:
-          path: spec.strategy.rollingUpdate.vegetaForce
+          path: spec.updateStrategy.rollingUpdate.vegetaForce
           value: 9000

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -7,7 +7,7 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
-  - it: should have the sepcified amount of replicas when specified via values
+  - it: should have the specified amount of replicas when specified via values
     set:
       deployment:
         replicas: 3

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -2,13 +2,20 @@ suite: Deployment configuration
 templates:
   - deployment.yaml
 tests:
+  - it: should be of type Deployment
+    set:
+      kind: Deployment
+    asserts:
+    - isKind:
+        of: Deployment
   - it: should have 1 replica by default
     asserts:
       - equal:
           path: spec.replicas
           value: 1
-  - it: should have the specified amount of replicas when specified via values
+  - it: should have the sepcified amount of replicas when specified via values
     set:
+      kind: Deployment
       deployment:
         replicas: 3
     asserts:
@@ -28,9 +35,11 @@ tests:
           value: 1
   - it: should have a custom merged rollingUpdate strategy with specified values
     set:
-      rollingUpdate:
-        maxUnavailable: 4
-        vegetaForce: 9000
+      kind: Deployment
+      deployment:
+        rollingUpdate:
+          maxUnavailable: 4
+          vegetaForce: 9000
     asserts:
       - equal:
           path: spec.strategy.type

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -3,6 +3,9 @@ image:
   name: traefik
   tag: 2.1.3
 
+## DaemonSet or Deployment
+kind: Deployment
+
 #
 # Configure the deployment
 #

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -12,14 +12,18 @@ kind: Deployment
 deployment:
   # Number of pods of the deployment
   replicas: 1
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 1
+
+daemonset:
+  rollingUpdate:
+    maxUnavailable: 1
+    minReadySeconds: 30
 
 additional:
   checkNewVersion: true
   sendAnonymousUsage: true
-
-rollingUpdate:
-  maxUnavailable: 1
-  maxSurge: 1
 
 #
 # Configure Traefik entry points


### PR DESCRIPTION
Based on #56, this PR adds support for daemonset. It has the following changes:
- Separate template for Deployment / DaemonSet
- Added test cases for Daemonset
- There is one breaking change, which is, rollingUpdate is moved under deployment and daemonset, since the specs are slightly different.

As a side note, aware of https://github.com/helm/charts/pull/11813#issuecomment-530001942 , but needed it for our use case, which is quite similar to https://github.com/helm/charts/pull/11813#issuecomment-530790527