### PR TITLE
Cleanup

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 5.6.0
+version: 6.0.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -91,15 +91,17 @@ spec:
             readOnly: true
           {{- end }}
         args:
-          - "--global.checknewversion={{ .Values.additional.checkNewVersion }}"
-          - "--global.sendanonymoususage={{ .Values.additional.sendAnonymousUsage}}"
+          {{- with .Values.globalArguments }}
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}
           {{- range $name, $config := .Values.ports }}
           - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
           {{- end }}
           - "--api.dashboard=true"
           - "--ping=true"
           - "--providers.kubernetescrd"
-          - "--log.level={{ .Values.logs.loglevel }}"
           {{- with .Values.additionalArguments }}
           {{- range . }}
           - {{ . | quote }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -2,19 +2,6 @@ suite: Traefik configuration
 templates:
   - deployment.yaml
 tests:
-  - it: should have log level of WARN by default
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--log.level=WARN"
-  - it: should have log level of SUPERMAN when specified through values
-    set:
-      logs:
-        loglevel: SUPERMAN
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--log.level=SUPERMAN"
   - it: should have no additional arguments by default (testing with providers.kubernetesingress)
     asserts:
       - notContains:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -18,14 +18,9 @@ ingressRoute:
   dashboard:
     enabled: true
 
-additional:
-  checkNewVersion: true
-  sendAnonymousUsage: true
-
 rollingUpdate:
   maxUnavailable: 1
   maxSurge: 1
-
 
 #
 # Add volumes to the traefik pod.
@@ -43,9 +38,14 @@ volumes: []
 #   mountPath: "/config"
 #   type: configMap
 
+globalArguments:
+  - "--global.checknewversion"
+  - "--global.sendanonymoususage"
+
 #
-# Configure Traefik entry points
+# Configure Traefik static configuration
 # Additional arguments to be passed at Traefik's binary
+# All available options available on https://docs.traefik.io/reference/static-configuration/cli/
 ## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--global.checknewversion=true}"`
 additionalArguments: []
 #  - "--providers.kubernetesingress"
@@ -63,7 +63,7 @@ env: {}
   # - name: SOME_OTHER_VAR
   #   value: some-other-var-value
 
-#
+# Configure ports
 ports:
   # The name of this one can't be changed as it is used for the readiness and
   # liveness probes, but you can adjust its config to your liking
@@ -94,7 +94,7 @@ ports:
     # hostPort: 8443
     expose: true
     exposedPort: 443
-  # nodePort: 32443
+    # nodePort: 32443
 
 # Options for the main traefik service, where the entrypoints traffic comes
 # from.
@@ -112,9 +112,6 @@ service:
   loadBalancerSourceRanges: {}
     # - 192.168.0.1/32
     # - 172.16.0.0/16
-
-logs:
-  loglevel: WARN
 
 # Enable persistence using Persistent Volume Claims
 # ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
### Description

This PR remove the log property because it possible to manage the log level with the `additionalArguments` in the `values.yaml` file.

We don't want to create a 1:1 mapping of the Traefik static configuration in the helm chart `values.yaml` file.

The full list of all static configuration options is available on https://docs.traefik.io/reference/static-configuration/cli/