### PR TITLE
hpa, dashboard via standard ingress

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 5.6.0
+version: 5.7.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/dashboard-ingress.yaml
+++ b/traefik/templates/dashboard-ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.dashboard.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  {{- if .Values.dashboard.ingress }}
+  {{- range $key, $value := .Values.dashboard.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  annotations:
+  {{- if .Values.dashboard.ingress }}
+  {{- range $key, $value := .Values.dashboard.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.dashboard.ingress.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "traefik.fullname" . }}-dashboard
+          servicePort: traefik
+  {{- if .Values.dashboard.ingress.tls }}
+  tls:
+{{ toYaml .Values.dashboard.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}

--- a/traefik/templates/dashboard-service.yaml
+++ b/traefik/templates/dashboard-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.dashboard.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "traefik.fullname" . }}-dashboard
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  {{- with .Values.dashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $type := default "ClusterIP" .Values.dashboard.service.type }}
+  type: {{ $type }}
+  {{- with .Values.dashboard.service.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  selector:
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+  {{- $config := .Values.ports.traefik }}
+  - port: {{ default $config.port $config.exposedPort }}
+    name: "traefik"
+    targetPort: "traefik"
+    {{- if $config.nodePort }}
+    nodePort: {{ $config.nodePort }}
+    {{- end }}
+  {{- if eq $type "LoadBalancer" }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 2 }}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -20,7 +20,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  {{- if not .Values.autoscaling }}
   replicas: {{ default 1 .Values.deployment.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "traefik.name" . }}

--- a/traefik/templates/hpa.yaml
+++ b/traefik/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.autoscaling }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "traefik.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -113,6 +113,48 @@ service:
     # - 192.168.0.1/32
     # - 172.16.0.0/16
 
+dashboard:
+  ingress:
+    enabled: false
+    domain: traefik.example.com
+    # annotations:
+    #   key: value
+    # labels:
+    #   key: value
+    # tls:
+      # - hosts:
+      #   - traefik.example.com
+      #   secretName: traefik-default-cert
+  service:
+    enabled: false
+    type: ClusterIP
+    # Additional annotations (e.g. for cloud provider specific config)
+    annotations: {}
+    # Additional entries here will be added to the service spec. Cannot contains
+    # type, selector or ports entries.
+    spec: {}
+      # externalTrafficPolicy: Cluster
+      # loadBalancerIP: "1.2.3.4"
+      # clusterIP: "2.3.4.5"
+    loadBalancerSourceRanges: {}
+      # - 192.168.0.1/32
+      # - 172.16.0.0/16
+
+## Create HorizontalPodAutoscaler object.
+##
+# autoscaling:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       targetAverageUtilization: 60
+#   - type: Resource
+#     resource:
+#       name: memory
+#       targetAverageUtilization: 60
+
 logs:
   loglevel: WARN
 


### PR DESCRIPTION
This allow for exposing the dashboard via a standard `Ingress` object *without exposing the service to the `LoadBalancer` service for actual inbound traffic.

Additionally introduces an `hpa` for automatic scaling.

Fixes #48 