### PR TITLE
Add ability to add annotations to deployment

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.0.2
+version: 6.1.0
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -19,6 +19,12 @@ metadata:
     chart: {{ template "traefik.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  {{- if .Values.deployment.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.deployment.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   replicas: {{ default 1 .Values.deployment.replicas }}
   selector:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -10,6 +10,8 @@ deployment:
   enabled: true
   # Number of pods of the deployment
   replicas: 1
+  # Addtional deployment annotations (e.g. for jaeger-operator sidecar injection)
+  annotations: {}
   # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
   podAnnotations: {}
 


### PR DESCRIPTION
The jaeger operator automatically injects sidecars to any deployment annotated with "sidecar.jaegertracing.io/inject" (described [here](https://www.jaegertracing.io/docs/1.17/operator/#auto-injecting-jaeger-agent-sidecars)). It would be beneficial to allow the helm chart to support this.

Not sure if we need a minor or patch version bump, I'll leave that to your discretion.

Closes #113 
