### PR TITLE
Change default values of arrays from objects to actual arrays

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.0.0
+version: 6.0.1
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -51,13 +51,13 @@ additionalArguments: []
 #  - "--providers.kubernetesingress"
 
 # Secret to be set as environment variables to be passed to Traefik's binary
-secretEnv: {}
+secretEnv: []
   # - name: SOME_VAR
   #   secretName: my-secret-name
   #   secretKey: my-secret-key
 
 # Environment variables to be passed to Traefik's binary
-env: {}
+env: []
   # - name: SOME_VAR
   #   value: some-var-value
   # - name: SOME_OTHER_VAR
@@ -109,7 +109,7 @@ service:
     # externalTrafficPolicy: Cluster
     # loadBalancerIP: "1.2.3.4"
     # clusterIP: "2.3.4.5"
-  loadBalancerSourceRanges: {}
+  loadBalancerSourceRanges: []
     # - 192.168.0.1/32
     # - 172.16.0.0/16
 


### PR DESCRIPTION
Some default values in `values.yaml` are initialized with `{}`, while they should be `[]` in my opinion. When this is not the case, everything works fine when you override them, but you'll get a warning like:

```
coalesce.go:196: warning: cannot overwrite table with non table for env (map[])
```

Fixes https://github.com/containous/traefik-helm-chart/issues/74