### PR TITLE
Correct storage class key name

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.0.1
+version: 6.0.2
 appVersion: 2.1.3
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/pvc.yaml
+++ b/traefik/templates/pvc.yaml
@@ -19,7 +19,7 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{- if .Values.persistence.storageClass }}
-  storageClass: {{ .Values.persistence.storageClass | quote }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Updated the key name for the storage class to allow the storage class to be set.

Documentation for the pvc resource [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes)