### PR TITLE
Add ability to set serviceAccount annotations

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.3.0
+version: 6.4.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -2,3 +2,8 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ template "traefik.fullname" . }}
+  annotations:
+  {{- range $key, $value := .Values.serviceAccountAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -6,4 +6,3 @@ metadata:
   {{- range $key, $value := .Values.serviceAccountAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{- end }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -135,6 +135,9 @@ persistence:
 # affinity is left as default.
 hostNetwork: false
 
+# Additional serviceAccount annotations (e.g. for oidc authentication)
+serviceAccountAnnotations: {}
+
 resources: {}
   # requests:
   #   cpu: "100m"


### PR DESCRIPTION
This comes in useful when dealing with the Route53 dns challenge provider on AWS.