### PR TITLE
Remove secretsEnv value key

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.3.0
+version: 6.4.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.5.0
+version: 7.0.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefik
-version: 6.4.0
+version: 6.5.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -117,13 +117,6 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          {{- range .Values.secretEnv }}
-          - name: {{ .name }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ .secretName }}
-                key: {{ .secretKey }}
-          {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -52,18 +52,20 @@ globalArguments:
 additionalArguments: []
 #  - "--providers.kubernetesingress"
 
-# Secret to be set as environment variables to be passed to Traefik's binary
-secretEnv: []
-  # - name: SOME_VAR
-  #   secretName: my-secret-name
-  #   secretKey: my-secret-key
-
 # Environment variables to be passed to Traefik's binary
 env: []
-  # - name: SOME_VAR
-  #   value: some-var-value
-  # - name: SOME_OTHER_VAR
-  #   value: some-other-var-value
+# - name: SOME_VAR
+#   value: some-var-value
+# - name: SOME_VAR_FROM_CONFIG_MAP
+#   valueFrom:
+#     configMapRef:
+#       name: configmap-name
+#       key: config-key
+# - name: SOME_SECRET
+#   valueFrom:
+#     secretKeyRef:
+#       name: secret-name
+#       key: secret-key
 
 # Configure ports
 ports:


### PR DESCRIPTION
There doesn't seem to be any reason why this separation would be needed as you can probably notice from the examples I've updated in the commented section.

The reason why I propose this change in the first place is because helm will fail to create a release if only providing values via `secretsEnv` since an empty `env` value will cause it to not render an `env:` section for the container.