### PR TITLE
add annotations to ingressRoute

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v2
+apiVersion: v1
 name: traefik
-version: 7.1.0
+version: 7.2.1
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -5,10 +5,8 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-  {{- if .Values.ingressRoute.annotations }}
-  {{- range $key, $value := .Values.ingressRoute.annotations }}
-    {{ $key | quote }}: {{ $value | quote }}
-  {{- end }}
+  {{- with .Values.ingressRoute.dashboard.annotations }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app: {{ template "traefik.name" . }}

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
+  {{- if .Values.ingressRoute.annotations }}
+  {{- range $key, $value := .Values.ingressRoute.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -19,6 +19,8 @@ deployment:
 ingressRoute:
   dashboard:
     enabled: true
+    # Addtional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
+    annotations: {}
 
 rollingUpdate:
   maxUnavailable: 1


### PR DESCRIPTION
I will try use this helm chart with two traefik deployment. e.g. 
**traefik-internal** (namespace **traefik-internal**) with set **ingressclass=traefik-internal**
**traefik-external** (namespace **traefik-external**) with set **ingressclass=traefik-external**
if i will try open dashboard, i got 404 error. 
If set ingressclass in additionalArguments then need set annotations (**"kubernetes.io/ingress.class": "traefik-internal"** or **"kubernetes.io/ingress.class": "traefik-external"**) in IngressRoute. After add annotations dashboard is work. 

i check in helm3: 
`helm template traefik-internal traefik --set ingressRoute.annotations."kubernetes\.io\/ingress\.class"="traefik-internal"`

I use this fix in my k8s cluster with many namespaces, traefik with kubernetescrd and kubernetesingress enabled. 