### PR TITLE
Make helm chart work with UDP routes.

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.0
+version: 8.1.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           {{- if $config.hostPort }}
           hostPort: {{ $config.hostPort }}
           {{- end }}
-          protocol: TCP
+          protocol: {{ $config.protocol }}
         {{- end }}
         volumeMounts:
           - name: data
@@ -101,6 +101,9 @@ spec:
           {{- end }}
           {{- end }}
           {{- range $name, $config := .Values.ports }}
+          {{- if eq $config.protocol "UDP" }}
+          - "--entryPoints.{{$name}}.address=:{{ $config.port }}/udp"
+          {{- end }}
           - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
           {{- end }}
           - "--api.dashboard=true"

--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -1,45 +1,50 @@
 {{- if .Values.service.enabled -}}
+{{- $global := . }}
+{{- range $name, $config := $global.Values.ports }}
+{{- if .expose }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ template "traefik.fullname" $global }}-{{ $name }}
   labels:
-    app.kubernetes.io/name: {{ template "traefik.name" . }}
-    helm.sh/chart: {{ template "traefik.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "traefik.name" $global }}
+    helm.sh/chart: {{ template "traefik.chart" $global }}
+    app.kubernetes.io/managed-by: {{ $global.Release.Service }}
+    app.kubernetes.io/instance: {{ $global.Release.Name }}
   annotations:
-  {{- with .Values.service.annotations }}
-  {{- toYaml . | nindent 4 }}
+  {{- with $global.Values.service.annotations }}
+  {{- toYaml $global | nindent 4 }}
   {{- end }}
 spec:
-  {{- $type := default "LoadBalancer" .Values.service.type }}
+  {{- $type := default "LoadBalancer" $global.Values.service.type }}
   type: {{ $type }}
-  {{- with .Values.service.spec }}
-  {{- toYaml . | nindent 2 }}
+  {{- with $global.Values.service.spec }}
+  {{- toYaml $global | nindent 2 }}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ template "traefik.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "traefik.name" $global }}
+    app.kubernetes.io/instance: {{ $global.Release.Name }}
   ports:
-  {{- range $name, $config := .Values.ports }}
   {{- if $config.expose }}
   - port: {{ default $config.port $config.exposedPort }}
     name: {{ $name }}
     targetPort: {{ $name | quote }}
+    protocol: {{ $config.protocol }}
     {{- if $config.nodePort }}
     nodePort: {{ $config.nodePort }}
     {{- end }}
   {{- end }}
-  {{- end }}
   {{- if eq $type "LoadBalancer" }}
-  {{- with .Values.service.loadBalancerSourceRanges }}
+  {{- with $global.Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-  {{- toYaml . | nindent 2 }}
+  {{- toYaml $global | nindent 2 }}
   {{- end -}}
   {{- end -}}
-  {{- with .Values.service.externalIPs }}
+  {{- with $global.Values.service.externalIPs }}
   externalIPs:
-  {{- toYaml . | nindent 2 }}
+  {{- toYaml $global | nindent 2 }}
   {{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -87,11 +87,13 @@ ports:
     expose: false
     # The exposed port for this service
     exposedPort: 9000
+    protocol: TCP
   web:
     port: 8000
     # hostPort: 8000
     expose: true
     exposedPort: 80
+    protocol: TCP
     # Use nodeport if set. This is useful if you have configured Traefik in a
     # LoadBalancer
     # nodePort: 32080
@@ -100,6 +102,7 @@ ports:
     # hostPort: 8443
     expose: true
     exposedPort: 443
+    protocol: TCP
     # nodePort: 32443
 
 # Options for the main traefik service, where the entrypoints traffic comes


### PR DESCRIPTION
This is a first attempt to fix #125 

The ugly part is that it is not possible to run the `TCP` and `UDP` routes in the same `LoadBalancer`, so instead I have to loop over the ports and will create a service for each `port`.