### PR TITLE
Add Support for subPath in data volumeMount

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.2
+version: 8.0.3
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
         volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.path }}
+            {{- if .Values.persistence.subPath }}
+            subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
           {{- range .Values.volumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -50,3 +50,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: "150Mi"
+  - it: should not have data volumeMount subPath by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+  - it: should have data volumeMount subPath when specified in config
+    set:
+      persistence:
+        subPath: "subdir/traefik"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+          value: "subdir/traefik"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -152,6 +152,7 @@ persistence:
   # storageClass: ""
   path: /data
   annotations: {}
+  # subPath: "" # only mount a subpath of the Volume into the pod
 
 # If hostNetwork is true, runs traefik in the host network namespace
 # To prevent unschedulabel pods due to port collisions, if hostNetwork=true


### PR DESCRIPTION
If the PVC is requesting a shared PV it would be nice to not give traefik full root level access to the volume. (Useful if the PVC is accessing a nfs volume, for example)  

This would add the option to limit traefik to an arbitrary ```subPath``` on a volume.