### PR TITLE
Ability to add custom labels to dashboard's IngressRoute

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.1
+version: 8.0.2
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -5,14 +5,17 @@ metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-  {{- with .Values.ingressRoute.dashboard.annotations }}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- with .Values.ingressRoute.dashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.ingressRoute.dashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   entryPoints:
     - traefik

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -21,6 +21,8 @@ ingressRoute:
     enabled: true
     # Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
     annotations: {}
+    # Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)
+    labels: {}
 
 rollingUpdate:
   maxUnavailable: 1


### PR DESCRIPTION
Need in this arose here: https://github.com/containous/traefik-helm-chart/issues/143#issuecomment-610942558
Helps when you have multiple Traefiks in the same namespace and you want to access their dashboards individually using PortForward