### PR TITLE
rbac does not need "pods" per documentation

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.0
+version: 8.0.1
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -11,7 +11,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
       - services
       - endpoints
       - secrets


### PR DESCRIPTION
Originally requested documentation to be updated:
https://github.com/containous/traefik/pull/6653
I was informed it was the chart that was incorrect -- and that I should send my PR over here 😅