### PR TITLE
configurable match rule for dashboard

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.4
+version: 8.0.5
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.3
+version: 8.0.4
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.0.2
+version: 8.0.3
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/dashboard-hook-ingressroute.yaml
+++ b/traefik/templates/dashboard-hook-ingressroute.yaml
@@ -20,7 +20,7 @@ spec:
   entryPoints:
     - traefik
   routes:
-  - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+  - match: {{ .Values.ingressRoute.dashboard.match_rule }}
     kind: Rule
     services:
     - name: api@internal

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
         volumeMounts:
           - name: data
             mountPath: {{ .Values.persistence.path }}
+            {{- if .Values.persistence.subPath }}
+            subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
           {{- range .Values.volumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -118,6 +118,10 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -50,3 +50,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: "150Mi"
+  - it: should not have data volumeMount subPath by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+  - it: should have data volumeMount subPath when specified in config
+    set:
+      persistence:
+        subPath: "subdir/traefik"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+          value: "subdir/traefik"

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -58,3 +58,18 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.containous/powpow
           value: podAnnotations
+  - it: should have envFrom with specified values
+    set:
+      envFrom:
+        - configMapRef:
+            name: config-map-name
+        - secretRef:
+            name: secret-name
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: config-map-name
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: secret-name
+

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -71,6 +71,12 @@ env: []
 #       name: secret-name
 #       key: secret-key
 
+envFrom: []
+# - configMapRef:
+#     name: config-map-name
+# - secretRef:
+#     name: secret-name
+
 # Configure ports
 ports:
   # The name of this one can't be changed as it is used for the readiness and

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -23,6 +23,10 @@ ingressRoute:
     annotations: {}
     # Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)
     labels: {}
+    # Setup Match rule for dashboard.
+    # E.g. if exposed publicly you might need to filter by Host header too
+    # match_rule: Host(`mytraefik.test`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
+    match_rule: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
 
 rollingUpdate:
   maxUnavailable: 1

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -152,6 +152,7 @@ persistence:
   # storageClass: ""
   path: /data
   annotations: {}
+  # subPath: "" # only mount a subpath of the Volume into the pod
 
 # If hostNetwork is true, runs traefik in the host network namespace
 # To prevent unschedulabel pods due to port collisions, if hostNetwork=true


### PR DESCRIPTION
as suggested in this comment https://github.com/containous/traefik-helm-chart/issues/143#issuecomment-610795188

If the dashboard tends to be exposed insecurely using usual Service chances high that it will be hosted using own URL.
So IngressRoute, if needed, should be able to filter traffic by Host header too.