### PR TITLE
Add OpenAPI v3 schemas to CRDs

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.1.0
+version: 8.2.0
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/crds/ingressroute.yaml
+++ b/traefik/crds/ingressroute.yaml
@@ -1,10 +1,132 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutes.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              routes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    match:
+                      type: string
+                    kind:
+                      type: string
+                    priority:
+                      type: integer
+                    services:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          sticky:
+                            type: object
+                            properties:
+                              cookie:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  secure:
+                                    type: boolean
+                                  httpOnly:
+                                    type: boolean
+                          namespace:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          weight:
+                            type: integer
+                          responseForwarding:
+                            type: object
+                            properties:
+                              flushInterval:
+                                type: string
+                          passHostHeader:
+                            type: boolean
+                          healthCheck:
+                            type: object
+                            properties:
+                              path:
+                                type: string
+                              host:
+                                type: string
+                              scheme:
+                                type: string
+                              intervalSeconds:
+                                type: integer
+                              timeoutSeconds:
+                                type: integer
+                              headers:
+                                type: object
+                          strategy:
+                            type: string
+                          scheme:
+                            type: string
+                          port:
+                            type: integer
+                    middlewares:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                          - name
+                          - namespace
+              entryPoints:
+                type: array
+                items:
+                  type: string
+              tls:
+                type: object
+                properties:
+                  secretName:
+                    type: string
+                  options:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  store:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  certResolver:
+                    type: string
+                  domains:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        main:
+                          type: string
+                        sans:
+                          type: array
+                          items:
+                            type: string
   names:
     kind: IngressRoute
     plural: ingressroutes

--- a/traefik/crds/ingressroutetcp.yaml
+++ b/traefik/crds/ingressroutetcp.yaml
@@ -1,10 +1,80 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutetcps.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              routes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    match:
+                      type: string
+                    services:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          port:
+                            type: integer
+                          weight:
+                            type: integer
+                          terminationDelay:
+                            type: integer
+              entryPoints:
+                type: array
+                items:
+                  type: string
+              tls:
+                type: object
+                properties:
+                  secretName:
+                    type: string
+                  passthrough:
+                    type: boolean
+                  options:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  store:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                  certResolver:
+                    type: string
+                  domains:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        main:
+                          type: string
+                        sans:
+                          type: array
+                          items:
+                            type: string
   names:
     kind: IngressRouteTCP
     plural: ingressroutetcps

--- a/traefik/crds/ingressrouteudp.yaml
+++ b/traefik/crds/ingressrouteudp.yaml
@@ -1,11 +1,42 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressrouteudps.traefik.containo.us
-
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              routes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    services:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          port:
+                            type: integer
+                          weight:
+                            type: integer
+              entryPoints:
+                type: array
+                items:
+                  type: string
   names:
     kind: IngressRouteUDP
     plural: ingressrouteudps

--- a/traefik/crds/middlewares.yaml
+++ b/traefik/crds/middlewares.yaml
@@ -1,10 +1,412 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: middlewares.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              addPrefix:
+                type: object
+                properties:
+                  prefix:
+                    type: string
+              stripPrefix:
+                type: object
+                properties:
+                  prefixes:
+                    type: array
+                    items:
+                      type: string
+                  forceSlash:
+                    type: boolean
+              stripPrefixRegex:
+                type: object
+                properties:
+                  regex:
+                    type: array
+                    items:
+                      type: string
+              replacePath:
+                type: object
+                properties:
+                  path:
+                    type: string
+              replacePathRegex:
+                type: object
+                properties:
+                  regex:
+                    type: string
+                  replacement:
+                    type: string
+              chain:
+                type: object
+                properties:
+                  middlewares:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+              ipWhiteList:
+                type: object
+                properties:
+                  sourceRange:
+                    type: array
+                    items:
+                      type: string
+                  ipStrategy:
+                    type: object
+                    properties:
+                      depth:
+                        type: integer
+                      excludedIPs:
+                        type: array
+                        items:
+                          type: string
+              headers:
+                type: object
+                properties:
+                  customRequestHeaders:
+                    type: object
+                  customResponseHeaders:
+                    type: object
+                  accessControlAllowCredentials:
+                    type: boolean
+                  accessControlAllowHeaders:
+                    type: array
+                    items:
+                      type: string
+                  accessControlAllowMethods:
+                    type: array
+                    items:
+                      type: string
+                  accessControlAllowOrigin:
+                    type: string
+                  accessControlAllowOriginList:
+                    type: array
+                    items:
+                      type: string
+                  accessControlExposeHeaders:
+                    type: array
+                    items:
+                      type: string
+                  accessControlMaxAge:
+                    type: integer
+                  addVaryHeader:
+                    type: boolean
+                  allowedHosts:
+                    type: array
+                    items:
+                      type: string
+                  hostsProxyHeaders:
+                    type: array
+                    items:
+                      type: string
+                  sslRedirect:
+                    type: boolean
+                  sslTemporaryRedirect:
+                    type: boolean
+                  sslHost:
+                    type: string
+                  sslProxyHeaders:
+                    type: object
+                  sslForceHost:
+                    type: boolean
+                  stsSeconds:
+                    type: integer
+                  stsIncludeSubdomains:
+                    type: boolean
+                  stsPreload:
+                    type: boolean
+                  forceSTSheader:
+                    type: boolean
+                  frameDeny:
+                    type: boolean
+                  customFrameOptionsValue:
+                    type: string
+                  contentTypeNosniff:
+                    type: boolean
+                  browserXssFilter:
+                    type: boolean
+                  customBrowserXSSValue:
+                    type: string
+                  contentSecurityPolicy:
+                    type: string
+                  publicKey:
+                    type: string
+                  referrerPolicy:
+                    type: string
+                  featurePolicy:
+                    type: string
+                  isDevelopment:
+                    type: boolean
+              errors:
+                type: object
+                properties:
+                  status:
+                    type: array
+                    items:
+                      type: string
+                  service:
+                    type: object
+                    properties:
+                      sticky:
+                        type: object
+                        properties:
+                          cookie:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              secure:
+                                type: boolean
+                              httpOnly:
+                                type: boolean
+                      namespace:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      weight:
+                        type: integer
+                      responseForwarding:
+                        type: object
+                        properties:
+                          flushInterval:
+                            type: string
+                      passHostHeader:
+                        type: boolean
+                      healthCheck:
+                        type: object
+                        properties:
+                          path:
+                            type: string
+                          host:
+                            type: string
+                          scheme:
+                            type: string
+                          intervalSeconds:
+                            type: integer
+                          timeoutSeconds:
+                            type: integer
+                          headers:
+                            type: object
+                      strategy:
+                        type: string
+                      scheme:
+                        type: string
+                      port:
+                        type: integer
+                  query:
+                    type: string
+              rateLimit:
+                type: object
+                properties:
+                  average:
+                    type: integer
+                  burst:
+                    type: integer
+                  sourceCriterion:
+                    type: object
+                    properties:
+                      ipStrategy:
+                        type: object
+                        properties:
+                          depth:
+                            type: integer
+                          excludedIPs:
+                            type: array
+                            items:
+                              type: string
+                      requestHeaderName:
+                        type: string
+                      requestHost:
+                        type: boolean
+              redirectRegex:
+                type: object
+                properties:
+                  regex:
+                    type: string
+                  replacement:
+                    type: string
+                  permanent:
+                    type: boolean
+              redirectScheme:
+                type: object
+                properties:
+                  scheme:
+                    type: string
+                  port:
+                    type: string
+                  permanent:
+                    type: boolean
+              basicAuth:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                  realm:
+                    type: string
+                  removeHeader:
+                    type: boolean
+                  headerField:
+                    type: string
+              digestAuth:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                  removeHeader:
+                    type: boolean
+                  realm:
+                    type: string
+                  headerField:
+                    type: string
+              forwardAuth:
+                type: object
+                properties:
+                  address:
+                    type: string
+                  trustForwardHeader:
+                    type: boolean
+                  authResponseHeaders:
+                    type: array
+                    items:
+                      type: string
+                  tls:
+                    type: object
+                    properties:
+                      caSecret:
+                        type: string
+                      caOptional:
+                        type: boolean
+                      certSecret:
+                        type: string
+                      insecureSkipVerify:
+                        type: boolean
+              inFlightReq:
+                type: object
+                properties:
+                  amount:
+                    type: integer
+                  sourceCriterion:
+                    type: object
+                    properties:
+                      ipStrategy:
+                        type: object
+                        properties:
+                          depth:
+                            type: integer
+                          excludedIPs:
+                            type: array
+                            items:
+                              type: string
+                      requestHeaderName:
+                        type: string
+                      requestHost:
+                        type: boolean
+              buffering:
+                type: object
+                properties:
+                  maxRequestBodyBytes:
+                    type: integer
+                  memRequestBodyBytes:
+                    type: integer
+                  maxResponseBodyBytes:
+                    type: integer
+                  memResponseBodyBytes:
+                    type: integer
+                  retryExpression:
+                    type: string
+              circuitBreaker:
+                type: object
+                properties:
+                  expression:
+                    type: string
+              compress:
+                type: object
+                properties:
+                  excludedContentTypes:
+                    type: array
+                    items:
+                      type: string
+              passTLSClientCert:
+                type: object
+                properties:
+                  pem:
+                    type: boolean
+                  info:
+                    type: object
+                    properties:
+                      notAfter:
+                        type: boolean
+                      notBefore:
+                        type: boolean
+                      sans:
+                        type: boolean
+                      subject:
+                        type: object
+                        properties:
+                          country:
+                            type: boolean
+                          province:
+                            type: boolean
+                          locality:
+                            type: boolean
+                          organization:
+                            type: boolean
+                          commonName:
+                            type: boolean
+                          serialNumber:
+                            type: boolean
+                          domainComponent:
+                            type: boolean
+                      issuer:
+                        type: object
+                        properties:
+                          country:
+                            type: boolean
+                          province:
+                            type: boolean
+                          locality:
+                            type: boolean
+                          organization:
+                            type: boolean
+                          commonName:
+                            type: boolean
+                          serialNumber:
+                            type: boolean
+                          domainComponent:
+                            type: boolean
+                      serialNumber:
+                        type: boolean
+              retry:
+                type: object
+                properties:
+                  attempts:
+                    type: integer
+              contentType:
+                type: object
+                properties:
+                  autoDetect:
+                    type: boolean
   names:
     kind: Middleware
     plural: middlewares

--- a/traefik/crds/tlsoptions.yaml
+++ b/traefik/crds/tlsoptions.yaml
@@ -1,10 +1,50 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsoptions.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              minVersion:
+                type: string
+              maxVersion:
+                type: string
+              cipherSuites:
+                type: array
+                items:
+                  type: string
+              curvePreferences:
+                type: array
+                items:
+                  type: string
+              clientAuth:
+                type: object
+                properties:
+                  secretNames:
+                    type: array
+                    items:
+                      type: string
+                  clientAuthType:
+                    type: string
+                    enum:
+                      - NoClientCert
+                      - RequestClientCert
+                      - VerifyClientCertIfGiven
+                      - RequireAndVerifyClientCert
+              sniStrict:
+                type: boolean
+              preferServerCipherSuites:
+                type: boolean
   names:
     kind: TLSOption
     plural: tlsoptions

--- a/traefik/crds/tlsstores.yaml
+++ b/traefik/crds/tlsstores.yaml
@@ -1,11 +1,25 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsstores.traefik.containo.us
-
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              defaultCertificate:
+                type: object
+                properties:
+                  secretName:
+                    type: string
   names:
     kind: TLSStore
     plural: tlsstores

--- a/traefik/crds/traefikservices.yaml
+++ b/traefik/crds/traefikservices.yaml
@@ -1,10 +1,194 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: traefikservices.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              weighted:
+                type: object
+                properties:
+                  services:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        sticky:
+                          type: object
+                          properties:
+                            cookie:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                secure:
+                                  type: boolean
+                                httpOnly:
+                                  type: boolean
+                        namespace:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        weight:
+                          type: integer
+                        responseForwarding:
+                          type: object
+                          properties:
+                            flushInterval:
+                              type: string
+                        passHostHeader:
+                          type: boolean
+                        healthCheck:
+                          type: object
+                          properties:
+                            path:
+                              type: string
+                            host:
+                              type: string
+                            scheme:
+                              type: string
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds:
+                              type: integer
+                            headers:
+                              type: object
+                        strategy:
+                          type: string
+                        scheme:
+                          type: string
+                        port:
+                          type: integer
+                  sticky:
+                    type: object
+                    properties:
+                      cookie:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          secure:
+                            type: boolean
+                          httpOnly:
+                            type: boolean
+              mirroring:
+                type: object
+                properties:
+                  weight:
+                    type: integer
+                  responseForwarding:
+                    type: object
+                    properties:
+                      flushInterval:
+                        type: string
+                  passHostHeader:
+                    type: boolean
+                  healthCheck:
+                    type: object
+                    properties:
+                      path:
+                        type: string
+                      host:
+                        type: string
+                      scheme:
+                        type: string
+                      intervalSeconds:
+                        type: integer
+                      timeoutSeconds:
+                        type: integer
+                      headers:
+                        type: object
+                  strategy:
+                    type: string
+                  scheme:
+                    type: string
+                  port:
+                    type: integer
+                  sticky:
+                    type: object
+                    properties:
+                      cookie:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          secure:
+                            type: boolean
+                          httpOnly:
+                            type: boolean
+                  namespace:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  mirrors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        kind:
+                          type: string
+                        namespace:
+                          type: string
+                        sticky:
+                          type: object
+                          properties:
+                            cookie:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                secure:
+                                  type: boolean
+                                httpOnly:
+                                  type: boolean
+                        port:
+                          type: integer
+                        scheme:
+                          type: string
+                        strategy:
+                          type: string
+                        healthCheck:
+                          type: object
+                          properties:
+                            path:
+                              type: string
+                            host:
+                              type: string
+                            scheme:
+                              type: string
+                            intervalSeconds:
+                              type: integer
+                            timeoutSeconds:
+                              type: integer
+                            headers:
+                              type: object
+                        passHostHeader:
+                          type: boolean
+                        responseForwarding:
+                          type: object
+                          properties:
+                            flushInterval:
+                              type: string
+                        weight:
+                          type: integer
+                        percent:
+                          type: integer
   names:
     kind: TraefikService
     plural: traefikservices


### PR DESCRIPTION
This allows upgrading to `apiextensions/v1` and I believe should solve containous/traefik#5473 and containous/traefik#6109. These were lovingly built by hand from the source code of traefik.

Things I'm unsure of:
1. Are these schemas correct/comprehensive? I'm particularly interested in any enum values that could be encoded.
2. Should they be behind a config option for k8s < 1.16?
3. Extra printer columns?
4. Can/should this schema generation be automated?