### PR TITLE
Clarify additionalArguments with logs.level

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.1.2
+version: 8.1.3
 appVersion: 2.2.0
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -50,9 +50,9 @@ globalArguments:
 # Configure Traefik static configuration
 # Additional arguments to be passed at Traefik's binary
 # All available options available on https://docs.traefik.io/reference/static-configuration/cli/
-## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--global.checknewversion=true}"`
+## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--logs.level=DEBUG}"`
 additionalArguments: []
-#  - "--providers.kubernetesingress"
+#  - "--providers.kubernetesingress, --logs.level=DEBUG"
 
 # Environment variables to be passed to Traefik's binary
 env: []

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -52,7 +52,8 @@ globalArguments:
 # All available options available on https://docs.traefik.io/reference/static-configuration/cli/
 ## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--logs.level=DEBUG}"`
 additionalArguments: []
-#  - "--providers.kubernetesingress, --logs.level=DEBUG"
+#  - "--providers.kubernetesingress"
+# - "--logs.level=DEBUG"
 
 # Environment variables to be passed to Traefik's binary
 env: []

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -53,7 +53,7 @@ globalArguments:
 ## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--logs.level=DEBUG}"`
 additionalArguments: []
 #  - "--providers.kubernetesingress"
-# - "--logs.level=DEBUG"
+#  - "--logs.level=DEBUG"
 
 # Environment variables to be passed to Traefik's binary
 env: []


### PR DESCRIPTION
This PR adds an example with `logs.level` used in the [Traefik documentation](https://docs.traefik.io/getting-started/install-traefik/#use-the-helm-chart).