### PR TITLE
Add option to disable RBAC and ServiceAccount

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.1.4
+version: 8.2.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.2.0
+version: 8.3.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -31,3 +31,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "traefik.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "traefik.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -33,12 +33,8 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+The name of the service account to use
 */}}
 {{- define "traefik.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
 {{- default (include "traefik.fullname" .) .Values.serviceAccount.name -}}
-{{- else -}}
-{{- default "default" .Values.serviceAccount.name -}}
-{{- end -}}
 {{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
           - "--ping=true"
           - "--providers.kubernetescrd"
           - "--providers.kubernetesingress"
+          {{- if and .Values.rbac.enabled .Values.rbac.namespaced}}
+          - "--providers.kubernetescrd.namespaces={{ .Release.Namespace }}"
+          - "--providers.kubernetesingress.namespaces={{ .Release.Namespace }}"
+          {{- end }}
           {{- with .Values.additionalArguments }}
           {{- range . }}
           - {{ . | quote }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "traefik.fullname" . }}
+      serviceAccountName: {{ include "traefik.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
       hostNetwork: {{ .Values.hostNetwork }}
       containers:

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,4 +1,9 @@
+{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.clusterScope }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}
@@ -46,3 +51,4 @@ rules:
       - get
       - list
       - watch
+{{- end -}}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.rbac.enabled -}}
-{{- if .Values.rbac.clusterScope }}
-kind: ClusterRole
-{{- else }}
+{{- if .Values.rbac.namespaced }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -1,4 +1,9 @@
+{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.clusterScope }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}
@@ -9,9 +14,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.rbac.clusterScope }}
   kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
   name: {{ template "traefik.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "traefik.fullname" . }}
+    name: {{ include "traefik.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.rbac.enabled -}}
-{{- if .Values.rbac.clusterScope }}
-kind: ClusterRoleBinding
-{{- else }}
+{{- if .Values.rbac.namespaced }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -14,10 +14,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.rbac.clusterScope }}
-  kind: ClusterRole
-  {{- else }}
+  {{- if .Values.rbac.namespaced }}
   kind: Role
+  {{- else }}
+  kind: ClusterRole
   {{- end }}
   name: {{ template "traefik.fullname" . }}
 subjects:

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) -}}
-kind: ClusterRole
+{{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) }}
-kind: ClusterRoleBinding
+{{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "traefik.fullname" . }}
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "traefik.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if not .Values.serviceAccount.name -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/traefik/templates/rbac/serviceaccount.yaml
+++ b/traefik/templates/rbac/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ template "traefik.fullname" . }}
+  name: {{ include "traefik.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ template "traefik.name" . }}
     helm.sh/chart: {{ template "traefik.chart" . }}
@@ -11,3 +12,4 @@ metadata:
   {{- with .Values.serviceAccountAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end -}}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1,4 +1,4 @@
-suite: RBAC
+suite: RBAC Configuration
 tests:
   - it: should create default RBAC related objects
     asserts:
@@ -46,7 +46,7 @@ tests:
   - it: should create RBAC related objects at namespace scope
     set:
       rbac:
-        clusterScope: false
+        namespaced: true
     asserts:
       - isKind:
           of: Role

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1,4 +1,4 @@
-suite: RBAC Configuration
+suite: RBAC configuration
 tests:
   - it: should create default RBAC related objects
     asserts:
@@ -8,10 +8,12 @@ tests:
       - isKind:
           of: ClusterRoleBinding
         template: rbac/clusterrolebinding.yaml
-      - equal:
-          path: roleRef.kind
-          value: ClusterRole
-        template: rbac/clusterrolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/rolebinding.yaml
       - isKind:
           of: ServiceAccount
         template: rbac/serviceaccount.yaml
@@ -31,8 +33,6 @@ tests:
     set:
       rbac:
         enabled: false
-      serviceAccount:
-        create: false
     asserts:
       - hasDocuments:
           count: 0
@@ -42,7 +42,10 @@ tests:
         template: rbac/clusterrolebinding.yaml
       - hasDocuments:
           count: 0
-        template: rbac/serviceaccount.yaml
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/rolebinding.yaml
   - it: should create RBAC related objects at namespace scope
     set:
       rbac:
@@ -50,22 +53,23 @@ tests:
     asserts:
       - isKind:
           of: Role
-        template: rbac/clusterrole.yaml
+        template: rbac/role.yaml
       - isKind:
           of: RoleBinding
-        template: rbac/clusterrolebinding.yaml
-      - equal:
-          path: roleRef.kind
-          value: Role
+        template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrole.yaml
+      - hasDocuments:
+          count: 0
         template: rbac/clusterrolebinding.yaml
   - it: should create ServiceAccount with custom name
     set:
       serviceAccount:
         name: foobar
     asserts:
-      - equal:
-          path: metadata.name
-          value: foobar
+      - hasDocuments:
+          count: 0
         template: rbac/serviceaccount.yaml
       - equal:
           path: spec.template.spec.serviceAccountName

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1,0 +1,77 @@
+suite: RBAC
+tests:
+  - it: should create default RBAC related objects
+    asserts:
+      - isKind:
+          of: ClusterRole
+        template: rbac/clusterrole.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: rbac/clusterrolebinding.yaml
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+        template: rbac/clusterrolebinding.yaml
+      - isKind:
+          of: ServiceAccount
+        template: rbac/serviceaccount.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-traefik
+        template: rbac/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-traefik
+        template: deployment.yaml
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-traefik
+        template: rbac/clusterrolebinding.yaml
+  - it: should not create RBAC related objects when disabled
+    set:
+      rbac:
+        enabled: false
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrole.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/serviceaccount.yaml
+  - it: should create RBAC related objects at namespace scope
+    set:
+      rbac:
+        clusterScope: false
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/clusterrole.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/clusterrolebinding.yaml
+      - equal:
+          path: roleRef.kind
+          value: Role
+        template: rbac/clusterrolebinding.yaml
+  - it: should create ServiceAccount with custom name
+    set:
+      serviceAccount:
+        name: foobar
+    asserts:
+      - equal:
+          path: metadata.name
+          value: foobar
+        template: rbac/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: foobar
+        template: deployment.yaml
+      - equal:
+          path: subjects[0].name
+          value: foobar
+        template: rbac/clusterrolebinding.yaml

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -63,7 +63,7 @@ tests:
       - hasDocuments:
           count: 0
         template: rbac/clusterrolebinding.yaml
-  - it: should create ServiceAccount with custom name
+  - it: should use existing ServiceAccount
     set:
       serviceAccount:
         name: foobar

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -10,3 +10,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--the.force.is.with.me=true"
+  - it: should have namespace restriction if rbac is namespaced
+    set:
+      rbac:
+        namespaced: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.namespaces=NAMESPACE"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.namespaces=NAMESPACE"
+

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -165,6 +165,19 @@ persistence:
 # affinity is left as default.
 hostNetwork: false
 
+# Whether Role Based Access Control objects like roles and rolebindings should be created
+rbac:
+  # If set to true, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
+  # If set to false, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
+  clusterScope: true
+  enabled: true
+
+# Whether to create the ServiceAccount
+serviceAccount:
+  create: true
+  # The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  name:
+
 # Additional serviceAccount annotations (e.g. for oidc authentication)
 serviceAccountAnnotations: {}
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -172,11 +172,11 @@ rbac:
   namespaced: false
   enabled: true
 
-# Whether to create the ServiceAccount
+# The service account the pods will use to interact with the Kubernates API
 serviceAccount:
-  create: true
-  # The name of the service account to use. If not set and create is true, a name is generated using the fullname template
-  name:
+  # If set, an existing service account is used
+  # If not set, a service account is created automatically using the fullname template
+  name: ""
 
 # Additional serviceAccount annotations (e.g. for oidc authentication)
 serviceAccountAnnotations: {}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -167,10 +167,11 @@ hostNetwork: false
 
 # Whether Role Based Access Control objects like roles and rolebindings should be created
 rbac:
+  enabled: true
+
   # If set to false, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
   # If set to true, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
   namespaced: false
-  enabled: true
 
 # The service account the pods will use to interact with the Kubernates API
 serviceAccount:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -167,9 +167,9 @@ hostNetwork: false
 
 # Whether Role Based Access Control objects like roles and rolebindings should be created
 rbac:
-  # If set to true, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
-  # If set to false, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
-  clusterScope: true
+  # If set to false, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
+  # If set to true, installs namespace-specific Role and RoleBinding and requires provider configuration be set to that same namespace
+  namespaced: false
   enabled: true
 
 # Whether to create the ServiceAccount


### PR DESCRIPTION
- Adds `rbac.enabled` to control whether ClusterRole and ClusterRoleBinding are created or not
- Adds `rbac.namespaced` to control whether Role/Rolebinding or ClusterRole/ClusterRoleBinding are created or not
- Adds `serviceAccount.name` to control whether ServiceAccount is created or not
- Adds tests for all combinations of new settings

Besides the `namespaced` property, these options are all the standard options that `helm create` provides out of the box.

The use case for disabling rbac and serviceAccount is some cloud providers don't allow RBAC related components being created. Specifically in our case, Google Cloud Marketplace [does not allow](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md#declare-rbac-requirements-and-disable-rbac-in-the-chart) any RBAC be created and will create them via another mechanism.

The use case behind the `rbac.namespaced` setting is that we want to deploy a different Traefik per namespace so our chart is more self-contained and secured. Also, our operations team locks down the cluster so we can't deploy cluster level components. Setting `rbac.namespaced=true` and setting `providers.kubernetesIngress.namespaces=mynamespace` in the Traefik config allows us to reduce the permission of Traefik and have it watch only our specific namespace.

To reduce duplication, I put the if/else for namespaced inside the clusterrole and clusterrolebinding. I can duplicate them to separate role/rolebinding files if you prefer that instead.