### PR TITLE
Fix typo in proposed additionalArguments to match documentation

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -50,10 +50,10 @@ globalArguments:
 # Configure Traefik static configuration
 # Additional arguments to be passed at Traefik's binary
 # All available options available on https://docs.traefik.io/reference/static-configuration/cli/
-## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--logs.level=DEBUG}"`
+## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--log.level=DEBUG}"`
 additionalArguments: []
 #  - "--providers.kubernetesingress"
-#  - "--logs.level=DEBUG"
+#  - "--log.level=DEBUG"
 
 # Environment variables to be passed to Traefik's binary
 env: []


### PR DESCRIPTION
https://docs.traefik.io/observability/logs/#level suggests that the appropriate config path is `log.level`.  I've further confirmed this by trying to set `logs.level` as a container argument and receiving the error `2020/05/15 18:21:33 command traefik error: failed to decode configuration from flags: field not found, node: logs`.  `log.level` appears to work as expected where `logs.level` failed.

Note that I have not tested this helm chart myself but instead manually configured using similar Kubernetes YAML.  My apologies if this violates contribution guidelines... I figured it's better to suggest this change and hope y'all appreciate it than to move along having only fixed my own problem.