### PR TITLE
Add option to disable providers

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.2.0
+version: 8.2.1
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.2.2
+version: 8.5.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.5.0
+version: 8.6.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.2.1
+version: 8.2.2
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -112,10 +112,10 @@ spec:
           {{- end }}
           - "--api.dashboard=true"
           - "--ping=true"
-          {{- .Values.providers.kubernetesCRD.enabled }}
+          {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
           {{- end }}
-          {{- .Values.providers.kubernetesIngress.enabled }}
+          {{- if .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
           {{- end }}
           {{- with .Values.additionalArguments }}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -112,8 +112,12 @@ spec:
           {{- end }}
           - "--api.dashboard=true"
           - "--ping=true"
+          {{- .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
+          {{- end }}
+          {{- .Values.providers.kubernetesIngress.enabled }}
           - "--providers.kubernetesingress"
+          {{- end }}
           {{- with .Values.additionalArguments }}
           {{- range . }}
           - {{ . | quote }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -50,9 +50,9 @@ globalArguments:
 # Configure Traefik static configuration
 # Additional arguments to be passed at Traefik's binary
 # All available options available on https://docs.traefik.io/reference/static-configuration/cli/
-## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress,--log.level=DEBUG}"`
+## Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress.ingressclass=traefik-internal,--log.level=DEBUG}"`
 additionalArguments: []
-#  - "--providers.kubernetesingress"
+#  - "--providers.kubernetesingress.ingressclass=traefik-internal"
 #  - "--log.level=DEBUG"
 
 # Environment variables to be passed to Traefik's binary

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -28,6 +28,16 @@ rollingUpdate:
   maxUnavailable: 1
   maxSurge: 1
 
+
+#
+# Configure providers
+#
+providers:
+  kubernetesCRD:
+    enabled: true
+  kubernetesIngress:
+    enabled: true
+
 #
 # Add volumes to the traefik pod.
 # This can be used to mount a cert pair or a configmap that holds a config.toml file.


### PR DESCRIPTION
Add options `providers.kubernetesCRD.enabled` and `providers.kubernetesIngress.enabled` to enable and disable providers. 

Default both providers are enabled. 