### PR TITLE
Fix PDB with minAvailable set

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.4.0
+version: 8.4.1
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/tests/poddisruptionbudget-config_test.yaml
+++ b/traefik/tests/poddisruptionbudget-config_test.yaml
@@ -1,0 +1,30 @@
+suite: PodDisruptionBudget configuration
+templates:
+  - poddisruptionbudget.yaml
+tests:
+  - it: should be disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should have minAvailable set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - isEmpty:
+          path: spec.maxUnavailable
+  - it: should have maxUnavailable set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isEmpty:
+          path: spec.minAvailable

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -18,7 +18,7 @@ deployment:
 # Pod disruption budget
 podDisruptionBudget:
   enabled: false
-  maxUnavailable: 1
+  # maxUnavailable: 1
   # minAvailable: 0
 
 # Create an IngressRoute for the dashboard


### PR DESCRIPTION
Fixes #194 by making `podDisruptionBudget.maxUnavailable` not set by default. It shouldn't default to one or the other enabled by default. Also adds a test for PodDisruptionBudget.