### PR TITLE
Add image pull policy

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.9.0
+version: 8.10.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ template "traefik.fullname" . }}
         resources:
           {{- with .Values.resources }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -146,3 +146,11 @@ tests:
         - equal:
             path: spec.additionalContainers[0].name
             value: bar
+  - it: should have imagePullPolicy with specified value
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -2,6 +2,7 @@
 image:
   name: traefik
   tag: 2.2.1
+  pullPolicy: IfNotPresent
 
 #
 # Configure the deployment


### PR DESCRIPTION
This PR add option `image.pullPolicy` to allow setting traefik app deployment container `imagePullPolicy` value, defaults to `IfNotPresent`.