### PR TITLE
Add extra containers and emptydir volume

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.7.0
+version: 8.8.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.5.0
+version: 8.7.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -131,6 +131,14 @@ spec:
         envFrom:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+{{- if .Values.extraContainers }}
+      initContainers:
+{{ toYaml .Values.extraContainers | indent 8 }}
+{{- end }}         
+{{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+{{- end }}        
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}
@@ -147,6 +155,8 @@ spec:
           {{- else if eq .type "configMap" }}
           configMap:
             name: {{ .name }}
+          {{- else if eq .type "emptyDir" }}
+          emptyDir: {}
           {{- end }}
         {{- end }}
       {{- with .Values.affinity }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -47,6 +47,9 @@ volumes: []
 # - name: configs
 #   mountPath: "/config"
 #   type: configMap
+# - name: configs
+#   mountPath: "/config"
+#   type: emptyDir
 
 globalArguments:
   - "--global.checknewversion"
@@ -233,3 +236,18 @@ securityContext:
 
 podSecurityContext:
   fsGroup: 65532
+
+
+extraContainers: []
+  # - name: echo
+  #   image: busybox
+  #   imagePullPolicy: Always
+  #   args:
+  #     - echo
+  #     - hello
+extraInitContainers:
+  - name: echo
+    image: busybox
+    args:
+      - sleep
+      - 1

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -256,9 +256,9 @@ extraContainers: []
   #   args:
   #     - echo
   #     - hello
-extraInitContainers:
-  - name: echo
-    image: busybox
-    args:
-      - sleep
-      - 1
+extraInitContainers: []
+  # - name: echo
+  #   image: busybox
+  #   args:
+  #     - sleep
+  #     - 1


### PR DESCRIPTION
This PR adds:
* the ability to use extraContainers and extraInitContainers to traefik
* the ability to use emptyDir volumes. 

The purpose of the emptyDir volume is to share a volume with an extraContainer. 

## extraContainers and extraInitContainers

Example:
```yaml
extraContainers:
  - name: echo
     image: busybox
     imagePullPolicy: Always
     args:
       - echo
       - hello
extraInitContainers:
  - name: echo
    image: busybox
    args:
      - sleep
      - 1 
```

## EmptyDir volume

Example:
```yaml
volumes: 
- name: configs
   mountPath: "/config"
   type: emptyDir
```