### PR TITLE
added additionalContainers option to chart

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.7.3
+version: 8.8.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.7.2
+version: 8.7.3
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -137,6 +137,9 @@ spec:
         envFrom:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- if .Values.deployment.additionalContainers }}
+        {{- toYaml .Values.deployment.additionalContainers | nindent 6 }}
+      {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -14,6 +14,8 @@ deployment:
   annotations: {}
   # Additional pod annotations (e.g. for mesh injection or prometheus scraping)
   podAnnotations: {}
+  # Additional containers (e.g. for metric offloading sidecars)
+  additionalContainers: {}
 
 # Pod disruption budget
 podDisruptionBudget:


### PR DESCRIPTION
Fixes #213 
Addresses "additionalContainer" for https://github.com/containous/traefik-helm-chart/pull/202

This follows a fairly common pattern across helm charts exposing the ability for operators to define sidecars and init containers (which is being worked on in https://github.com/containous/traefik-helm-chart/pull/212)

Re: PR#202, emptyDir can be handled shared between `/tmp`, or possibly through `additionalVolumes`, which is another common approach for exposing common administrative tasks to chart consumers.