### PR TITLE
Fix additional /tcp path on redirect https globally using additionalArguments

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.9.0
+version: 8.10.0
 appVersion: 2.2.1
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- range $name, $config := .Values.ports }}
-          - "--entryPoints.{{$name}}.address=:{{ $config.port }}/{{ default "tcp" $config.protocol | lower }}"
+          - "--entryPoints.{{$name}}.address=:{{ $config.port }}"
           {{- end }}
           - "--api.dashboard=true"
           - "--ping=true"


### PR DESCRIPTION
Hi

This should fix #208 

I'm pretty sure that this also will be related with #188 

Additional details explained in https://github.com/containous/traefik-helm-chart/issues/208#issuecomment-656673347

This PR expected to be failed when the test include `/tcp` in these lines
https://github.com/containous/traefik-helm-chart/blob/master/traefik/tests/ports-config_test.yaml#L22
https://github.com/containous/traefik-helm-chart/blob/master/traefik/tests/ports-config_test.yaml#L43
https://github.com/containous/traefik-helm-chart/blob/master/traefik/tests/ports-config_test.yaml#L63
https://github.com/containous/traefik-helm-chart/blob/master/traefik/tests/ports-config_test.yaml#L89
https://github.com/containous/traefik-helm-chart/blob/master/traefik/tests/ports-config_test.yaml#L117

Should I remove the `/tcp` part in the test, or maybe it has some functionalities?
Because on my case (and maybe some other people case), this `/tcp` add additional path when we need redirect 🤔 
And this `/tcp` thing also doesn't exist on this [Kubernetes and Let's Encrypt guides](https://docs.traefik.io/user-guides/crd-acme/#deployments)