### PR TITLE
Add hostIp to port configuration

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.9.2
+version: 8.10.0
 appVersion: 2.2.8
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -88,6 +88,9 @@ spec:
           {{- if $config.hostPort }}
           hostPort: {{ $config.hostPort }}
           {{- end }}
+          {{- if $config.hostIP }}
+          hostIP: {{ $config.hostIP }}
+          {{- end }}
           protocol: {{ default "TCP" $config.protocol | quote }}
         {{- end }}
         {{- with .Values.securityContext }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -112,6 +112,12 @@ ports:
     port: 9000
     # Use hostPort if set.
     # hostPort: 9000
+    #
+    # Use hostIP if set. If not set, Kubernetes will default to 0.0.0.0, which
+    # means it's listening on all your interfaces and all your IPs. You may want
+    # to set this value if you need traefik to listen on specific interface
+    # only.
+    # hostIP: 192.168.100.10
 
     # Defines whether the port is exposed if service.type is LoadBalancer or
     # NodePort.


### PR DESCRIPTION
This change is necessary to support configurations where traefik is deployed multiple times on a single node with multiple IP addresses.

This way one ingress controller can listen on public and the other on the private network.