### PR TITLE
Dont redirect to websecure by default

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 8.13.0
+version: 8.13.1
 appVersion: 2.2.8
 description: A Traefik based Kubernetes ingress controller
 keywords:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -188,7 +188,7 @@ ports:
     # Port Redirections
     # Added in 2.2, you can make permanent redirects via entrypoints.
     # https://docs.traefik.io/routing/entrypoints/#redirection
-    redirectTo: websecure
+    # redirectTo: websecure
   websecure:
     port: 8443
     # hostPort: 8443


### PR DESCRIPTION
As this can be breaking, I think we should have not the redirect by default. Thoughts?