### PR TITLE
Update reference to using kubectl proxy to kubectl port-forward

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 9.1.0
+version: 9.1.1
 appVersion: 2.2.8
 keywords:
   - traefik

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -175,7 +175,7 @@ ports:
     #
     # You SHOULD NOT expose the traefik port on production deployments.
     # If you want to access it from outside of your cluster,
-    # use `kubectl proxy` or create a secure ingress
+    # use `kubectl port-forward` or create a secure ingress
     expose: false
     # The exposed port for this service
     exposedPort: 9000


### PR DESCRIPTION
With the traefik port not-exposed, the `kubectl proxy` command won't work to access it. Rather port-forward should be used to forward port 9000 for access at http://localhost:9000/dashboard/