### PR TITLE
fix: 🐛 http3 support on traefik v3

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -550,8 +550,10 @@
           {{- end }}
           {{- if $config.http3 }}
           {{- if $config.http3.enabled }}
+          {{- if semverCompare "<3.0.0-0" (default $.Chart.AppVersion $.Values.image.tag)}}
           - "--experimental.http3=true"
-          {{- if semverCompare ">=2.6.0" (default $.Chart.AppVersion $.Values.image.tag)}}
+          {{- end }}
+          {{- if semverCompare ">=2.6.0-0" (default $.Chart.AppVersion $.Values.image.tag)}}
           {{- if $config.http3.advertisedPort }}
           - "--entrypoints.{{ $entrypoint }}.http3.advertisedPort={{ $config.http3.advertisedPort }}"
           {{- else }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -372,6 +372,21 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--entrypoints.websecure.http3"
+  - it: should use default entrypoint port without experimental flag when http3 enabled on v3
+    set:
+      image:
+        tag: v3.0.0-beta2
+      ports:
+        websecure:
+          http3:
+            enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.http3=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entrypoints.websecure.http3"
   - it: should not have http3 config flag by default
     asserts:
       - notContains:


### PR DESCRIPTION
### What does this PR do?

Remove `--experimental.http3=true` cli arg when enabling http3 on Traefik v3.

### Motivation

It's been removed in this version, detailed [here](https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#http3).
Fixes #853 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed