### PR TITLE
fix: use `targetPort` instead of `port` on ServiceMonitor

### DIFF
--- a/traefik/templates/servicemonitor.yaml
+++ b/traefik/templates/servicemonitor.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   jobLabel: {{ .Values.metrics.prometheus.serviceMonitor.jobLabel | default .Release.Name }}
   endpoints:
-    - port: metrics
+    - targetPort: metrics
       path: /{{ .Values.metrics.prometheus.entryPoint }}
       {{- with .Values.metrics.prometheus.serviceMonitor.honorLabels }}
       honorLabels: {{ . }}

--- a/traefik/tests/servicemonitor-config_test.yaml
+++ b/traefik/tests/servicemonitor-config_test.yaml
@@ -37,7 +37,7 @@ tests:
       - contains:
           path: spec.endpoints
           content:
-            port: metrics
+            targetPort: metrics
             path: /metrics
             enableHttp2: true
             followRedirects: true


### PR DESCRIPTION
### What does this PR do?

fixes #852 


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

