### PR TITLE
chore(deps): 🔗 add missing label on renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,9 @@
   "semanticCommits": "enabled",
   "gitAuthor": "traefiker <30906710+traefiker@users.noreply.github.com>",
   "rebaseWhen": "conflicted",
+  "labels": [
+    "📌 dependencies"
+  ],
   "enabledManagers": ["github-actions", "regex"],
   "regexManagers": [
     {


### PR DESCRIPTION
### What does this PR do?

It configures renovate to add "📌 dependencies" label on PR managed by renovate.

### Motivation

It's the label [already used](https://github.com/traefik/traefik-helm-chart/pulls?q=is%3Apr+label%3A%22%F0%9F%93%8C+dependencies%22+is%3Aclosed) and it was lost in recent work on renovate config.
