### PR TITLE
fix(rbac): do not create clusterrole for namespace deployment on Traefik v3

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -562,6 +562,9 @@
           {{- if .Values.providers.kubernetesIngress.ingressClass }}
           - "--providers.kubernetesingress.ingressClass={{ .Values.providers.kubernetesIngress.ingressClass }}"
           {{- end }}
+          {{- if and .Values.providers.kubernetesIngress.disableIngressClassLookup (semverCompare ">=3.0.0-0" (include "imageVersion" $) ) }}
+          - "--providers.kubernetesingress.disableIngressClassLookup=true"
+          {{- end }}
           {{- end }}
           {{- if .Values.experimental.kubernetesGateway.enabled }}
           - "--providers.kubernetesgateway"

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rbac.enabled (or .Values.providers.kubernetesIngress.enabled (not .Values.rbac.namespaced)) -}}
+{{- if not (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.disableIngressClassLookup (semverCompare ">=3.0.0-0" (include "imageVersion" $))) -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,6 +107,7 @@ rules:
       - tlsroutes/status
     verbs:
       - update
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/traefik/templates/rbac/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.rbac.enabled (or .Values.providers.kubernetesIngress.enabled (not .Values.rbac.namespaced)) -}}
+{{- if not (and .Values.rbac.namespaced .Values.providers.kubernetesIngress.disableIngressClassLookup (semverCompare ">=3.0.0-0" (include "imageVersion" $))) -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,4 +15,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "traefik.serviceAccountName" . }}
     namespace: {{ template "traefik.namespace" . }}
+{{- end -}}
 {{- end -}}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -487,3 +487,59 @@ tests:
               - get
               - list
               - watch
+  - it: cluster rbac should not be created when rbac is namespaced, disableIngressClassLookup is true and version is v3
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          disableIngressClassLookup: true
+      image:
+        tag: v3.0.0-beta3
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/role.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrole.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrolebinding.yaml
+  - it: both cluster and namespace rbac should be created when rbac is namespaced, kubernetesIngress is enabled and version is v2
+    set:
+      rbac:
+        namespaced: true
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/role.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/rolebinding.yaml
+      - isKind:
+          of: ClusterRole
+        template: rbac/clusterrole.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: rbac/clusterrolebinding.yaml
+  - it: cluster rbac should be created when version is v3
+    set:
+      image:
+        tag: v3.0.0-beta3
+    asserts:
+      - isKind:
+          of: ClusterRole
+        template: rbac/clusterrole.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: rbac/clusterrolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/rolebinding.yaml

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -462,3 +462,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.periodSeconds
           value: 5
+  - it: should not set disableIngressClassLookup if version is not v3 and disableIngressClassLookup is true
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          disableIngressClassLookup: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.disableIngressClassLookup=true"
+  - it: should set disableIngressClassLookup if version is v3 and disableIngressClassLookup is true
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngress:
+          disableIngressClassLookup: true
+      image:
+        tag: v3.0.0-beta3
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.disableIngressClassLookup=true"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -250,6 +250,9 @@ providers:
     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces.
     namespaces: []
     # - "default"
+    # Disable cluster IngressClass Lookup - Requires Traefik V3.
+    # When combined with rbac.namespaced: true, ClusterRole will not be created and ingresses must use kubernetes.io/ingress.class annotation instead of spec.ingressClassName.
+    disableIngressClassLookup: false
     # IP used for Kubernetes Ingress endpoints
     publishedService:
       enabled: false
@@ -899,7 +902,8 @@ hostNetwork: false
 rbac:
   enabled: true
   # If set to false, installs ClusterRole and ClusterRoleBinding so Traefik can be used across namespaces.
-  # If set to true, installs Role and RoleBinding. Providers will only watch target namespace.
+  # If set to true, installs Role and RoleBinding instead of ClusterRole/ClusterRoleBinding. Providers will only watch target namespace.
+  # When combined with providers.kubernetesIngress.disableIngressClassLookup: true and Traefik V3, ClusterRole to watch IngressClass is also disabled.
   namespaced: false
   # Enable user-facing roles
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles


### PR DESCRIPTION
A namespace scoped deployment should not create cluster scoped rbac. 