### PR TITLE
fix: remove null annotations on dashboard `IngressRoute`

### DIFF
--- a/traefik/templates/dashboard-ingressroute.yaml
+++ b/traefik/templates/dashboard-ingressroute.yaml
@@ -4,10 +4,10 @@ kind: IngressRoute
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   namespace: {{ template "traefik.namespace" . }}
+{{- with .Values.ingressRoute.dashboard.annotations }}
   annotations:
-    {{- with .Values.ingressRoute.dashboard.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+{{- end }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
     {{- with .Values.ingressRoute.dashboard.labels }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -86,3 +86,25 @@ tests:
         options:
           name: tls-options
           namespace: default
+- it: should not allow to create null annotations
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+  asserts:
+  - isNull:
+      path: metadata.annotations
+- it: should insert annotations correctly
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        annotations:
+          foo: bar
+          fis: fas
+  asserts:
+  - equal:
+      path: metadata.annotations
+      value:
+        foo: bar
+        fis: fas


### PR DESCRIPTION
### What does this PR do?

This PR removes empty annotations: from generated yaml.


### Motivation

described in this issue https://github.com/traefik/traefik-helm-chart/issues/1019


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed


