### PR TITLE
chore(ci): 🔧 👷 switch helm-changelog to traefik version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: lint test
 
-IMAGE_HELM_UNITTEST=docker.io/helmunittest/helm-unittest:3.14.3-0.4.4
 IMAGE_CHART_TESTING=quay.io/helmpack/chart-testing:v3.10.1
-IMAGE_HELM_DOCS=jnorwood/helm-docs:v1.13.1
 IMAGE_HELM_CHANGELOG=ghcr.io/traefik/helm-changelog:v0.3.0
+IMAGE_HELM_DOCS=jnorwood/helm-docs:v1.13.1
+IMAGE_HELM_UNITTEST=docker.io/helmunittest/helm-unittest:3.14.3-0.4.4
 
 traefik/tests/__snapshot__:
 	@mkdir traefik/tests/__snapshot__


### PR DESCRIPTION
### What does this PR do?

Switch `helm-changelog` from my account to traefik account.

### Motivation

It should not stay on a personal account.

### More

Linked to https://github.com/traefik/traefikee-helm-chart/pull/144
