### PR TITLE
fix: 🐛 improve error message on additional service without ports

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -11,12 +11,10 @@
 {{- $exposedPorts := false -}}
 {{- range $portName, $config := $.Values.ports -}}
   {{- if $config -}}
-    {{- if $config.http3 -}}
-    {{- if $config.http3.enabled -}}
+    {{- if ($config.http3).enabled -}}
       {{- if (not $config.tls.enabled) -}}
         {{- fail "ERROR: You cannot enable http3 without enabling tls" -}}
       {{- end -}}
-    {{- end -}}
     {{- end -}}
     {{- if eq (toString $config.protocol) "UDP" -}}
       {{ $_ := set $udpPorts $portName $config -}}
@@ -31,7 +29,7 @@
 {{- end -}}
 
 {{- if (eq $exposedPorts false) -}}
-  {{- fail "You need to expose at least one port or set enabled=false to service" -}}
+  {{- fail (printf "ERROR: Cannot create Service %s without ports" $fullname) -}}
 {{- end -}}
 
 {{- if and $exposedPorts (or $tcpPorts $service.single) }}

--- a/traefik/tests/service-config-custom_test.yaml
+++ b/traefik/tests/service-config-custom_test.yaml
@@ -46,7 +46,7 @@ tests:
             internal: false
     asserts:
       - failedTemplate:
-          errorMessage: "You need to expose at least one port or set enabled=false to service"
+          errorMessage: "ERROR: Cannot create Service RELEASE-NAME-traefik-internal without ports"
   - it: should have customized annotations when specified via values
     set:
       service:

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -24,7 +24,7 @@ tests:
             default: false
     asserts:
       - failedTemplate:
-          errorMessage: "You need to expose at least one port or set enabled=false to service"
+          errorMessage: "ERROR: Cannot create Service RELEASE-NAME-traefik without ports"
   - it: should be a type LoadBalancer by default
     asserts:
       - equal:
@@ -273,19 +273,6 @@ tests:
     - equal:
         path: spec.ports[2].protocol
         value: UDP
-  - it: should fail when there is no exposed port
-    set:
-      ports:
-        web:
-          expose:
-            default: false
-        websecure:
-          expose:
-            default: false
-    asserts:
-    - failedTemplate:
-        errorMessage: "You need to expose at least one port or set enabled=false to service"
-        documentIndex: 1
   - it: should not be possible to use http3 without enabling tls
     set:
       ports:


### PR DESCRIPTION
### Motivation

See https://github.com/traefik/traefik-helm-chart/issues/1103

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

