### PR TITLE
chore(release): 🚀 publish v30.1.0

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 30.0.2
+version: 30.1.0
 # renovate: image=traefik
 appVersion: v3.1.2
 kubeVersion: ">=1.22.0-0"
@@ -25,5 +25,10 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/v2.3/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - "fix(Traefik Hub): missing RBACs for Traefik Hub"
-    - "chore(release): 🚀 publish v30.0.2"
+    - "fix: disable default HTTPS listener for gateway"
+    - "fix(Gateway API): wildcard support in hostname"
+    - "fix(Gateway API): use Standard channel by default"
+    - "feat: ✨ rework namespaced RBAC with `disableClusterScopeResources`"
+    - "chore(release): 🚀 publish v30.1.0"
+    - "chore(deps): update traefik docker tag to v3.1.2"
+    - "chore(deps): update traefik docker tag to v3.1.1"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 30.0.2](https://img.shields.io/badge/Version-30.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.2](https://img.shields.io/badge/AppVersion-v3.1.2-informational?style=flat-square)
+![Version: 30.1.0](https://img.shields.io/badge/Version-30.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.1.2](https://img.shields.io/badge/AppVersion-v3.1.2-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Publish a new version of this Chart

### Motivation

1. Traefik Proxy v3.1.1 & v3.1.2 has been released
2. Gateway API support has been improved
3. Namespace RBAC is now simpler and easier with `disableClusterScopeResources` introduced with this [upstream PR](https://github.com/traefik/traefik/pull/10946).

### Known issues

There is an invalid error log, without any consequences, see https://github.com/traefik/traefik/issues/11007