### PR TITLE
fix!: 🐛 set allowEmptyServices to true by default

### DIFF
--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -21,7 +21,9 @@ tests:
             - --metrics.prometheus=true
             - --metrics.prometheus.entrypoint=metrics
             - --providers.kubernetescrd
+            - --providers.kubernetescrd.allowEmptyServices=true
             - --providers.kubernetesingress
+            - --providers.kubernetesingress.allowEmptyServices=true
             - --entryPoints.websecure.http.tls=true
             - --log.level=INFO
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -260,7 +260,7 @@ providers:
     # -- Allows to reference ExternalName services in IngressRoute
     allowExternalNameServices: false
     # -- Allows to return 503 when there is no endpoints available
-    allowEmptyServices: false
+    allowEmptyServices: true
     # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
     ingressClass:
     # labelSelector: environment=production,method=traefik
@@ -275,7 +275,7 @@ providers:
     # -- Allows to reference ExternalName services in Ingress
     allowExternalNameServices: false
     # -- Allows to return 503 when there is no endpoints available
-    allowEmptyServices: false
+    allowEmptyServices: true
     # -- When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed.
     ingressClass:
     # labelSelector: environment=production,method=traefik


### PR DESCRIPTION
### What does this PR do?

Set `allowEmptyServices` to true by default on Kubernetes CRD & Ingress providers.
It's not needed on Gateway API provider : spec already enforce http error code. 

### Motivation

It will be set by default in the next major version of Traefik Proxy.
See https://github.com/traefik/traefik/issues/10406

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

