### PR TITLE
fix(schema): :bug: targetPort can also be a string

### DIFF
--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1031,6 +1031,7 @@
                         "targetPort": {
                             "minimum": 0,
                             "type": [
+                                "string",
                                 "integer",
                                 "null"
                             ]
@@ -1194,6 +1195,7 @@
                         "targetPort": {
                             "minimum": 0,
                             "type": [
+                                "string",
                                 "integer",
                                 "null"
                             ]

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -606,7 +606,7 @@ ports:
       default: true
     exposedPort: 80
     ## -- Different target traefik port on the cluster, useful for IP type LB
-    targetPort:  # @schema type:[integer, null]; minimum:0
+    targetPort:  # @schema type:[string, integer, null]; minimum:0
     # The port protocol (TCP/UDP)
     protocol: TCP
     # -- See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
@@ -645,7 +645,7 @@ ports:
       default: true
     exposedPort: 443
     ## -- Different target traefik port on the cluster, useful for IP type LB
-    targetPort:  # @schema type:[integer, null]; minimum:0
+    targetPort:  # @schema type:[string, integer, null]; minimum:0
     ## -- The port protocol (TCP/UDP)
     protocol: TCP
     # -- See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)


### PR DESCRIPTION
### What does this PR do?

This PR makes it possible to configure `targetPort` with a named port.


### Motivation

Being compliant with [kubernetes specs](https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports).


### More

- [ ] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

