### PR TITLE
fix(Traefik Hub): add strict check on admission cert

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -219,7 +219,10 @@ Key: {{ index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls
 Hash: {{ sha1sum (index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls.crt") }}
 {{- else -}}
     {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
-    {{- if and $cert (hasKey $cert.data "tls.crt") (hasKey $cert.data "tls.key") -}}
+    {{- if $cert }}
+        {{ if or (not (hasKey $cert.data "tls.crt")) (not (hasKey $cert.data "tls.key")) -}}
+            {{- fail (printf "ERROR: secret %s/%s exists but doesn't contain any certificate data. Please remove it or change hub.apimanagement.admission.secretName." (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName) }}
+        {{- end -}}
     {{/* reusing value of existing cert */}}
 Cert: {{ index $cert.data "tls.crt" }}
 Key: {{ index $cert.data "tls.key" }}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -219,7 +219,7 @@ Key: {{ index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls
 Hash: {{ sha1sum (index $.Values.hub.apimanagement.admission.customWebhookCertificate "tls.crt") }}
 {{- else -}}
     {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
-    {{- if $cert -}}
+    {{- if and $cert (hasKey $cert.data "tls.crt") (hasKey $cert.data "tls.key") -}}
     {{/* reusing value of existing cert */}}
 Cert: {{ index $cert.data "tls.crt" }}
 Key: {{ index $cert.data "tls.key" }}


### PR DESCRIPTION
Add strict cert check to prevent issues when lookup fails because of server side mode or dry run

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Ensures that the value returned from the secret look up has the correct keys inside of it

### Motivation

<!-- What inspired you to submit this pull request? -->
Cause issues for ArgoCD deployments that tried to ignore changes on the cert. The issue happens because the helm template is not run on the server and is not aware of the secrets available. Therefore, it tries to re-create certs which causes ArgoCD to go out of sync and cause an infinite cycle of unnecessary restarts 

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

