### PR TITLE
chore(ci): 🔧 👷 suspend e2e testing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,9 +1,6 @@
 name: 🧑‍🔬 E2E tests
 on:
   workflow_call:
-  push:
-    branches:
-      - master
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### What does this PR do?

Suspend e2e testing.

### Motivation

There is no interest to launch them in their current state. We shall resume them as soon as we can take the time to fix them.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

