### PR TITLE
fix(entryPoint): allow scheme to be unset on redirect

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -625,7 +625,7 @@
                 {{- fail $errorMsg }}
               {{- end }}
               {{- $toPort := index $.Values.ports .to }}
-              {{- if and (($toPort.tls).enabled) (ne .scheme "https") }}
+              {{- if and (($toPort.tls).enabled) .scheme (ne .scheme "https") }}
                 {{- $errorMsg := printf "ERROR: Cannot redirect %s to %s without setting scheme to https" $entrypoint .to }}
                 {{- fail $errorMsg }}
               {{- end }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -290,7 +290,41 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: redirectTo syntax has been removed in v34 of this Chart. See Release notes or EXAMPLES.md for new syntax."
-  - it: should fail when redirect on websecure without https scheme
+  - it: should fail when redirect on websecure with tls enabled and non-https scheme
+    set:
+      ports:
+        web:
+          redirections:
+            entryPoint:
+              to: websecure
+              scheme: http
+        websecure:
+          exposedPort: 443
+          tls:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Cannot redirect web to websecure without setting scheme to https"
+  - it: should redirect on websecure with tls enabled and https scheme
+    set:
+      ports:
+        web:
+          redirections:
+            entryPoint:
+              to: websecure
+              scheme: https
+        websecure:
+          exposedPort: 443
+          tls:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.web.http.redirections.entryPoint.scheme=https"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.web.http.redirections.entryPoint.to=:443"
+  - it: should not fail when redirect on websecure with unset scheme
     set:
       ports:
         web:
@@ -299,9 +333,15 @@ tests:
               to: websecure
         websecure:
           exposedPort: 443
+          tls:
+            enabled: true
     asserts:
-      - failedTemplate:
-          errorMessage: "ERROR: Cannot redirect web to websecure without setting scheme to https"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.web.http.redirections.entryPoint.scheme="
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.web.http.redirections.entryPoint.to=:443"
   - it: should fail when redirect on non-existent entrypoint
     set:
       ports:


### PR DESCRIPTION
### What does this PR do?

Allows ``scheme`` to not be set when redirect on websecure


### Motivation

Fixes #1345 


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

