### PR TITLE
fix: prevent blank lines in args

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -789,7 +789,7 @@
               {{- end }}
             {{- end }}
           {{- end }}
-          {{- if .Values.certificatesResolvers -}}
+          {{- if $.Values.certificatesResolvers -}}
           {{- include "traefik.yaml2CommandLineArgs" (dict "path" "certificatesresolvers" "content" $.Values.certificatesResolvers) | nindent 10 }}
           {{- end }}
           {{- with .Values.additionalArguments }}


### PR DESCRIPTION
### What does this PR do?

Fixes #1496

### Motivation

When certificatesResolvers is not configured, the current template still generates blank lines in the deployment's args section, creating gaps in the YAML list. This results in inconsistent formatting and can cause parsing issues with various tools including GitOps platforms.

### More

 Yes, I updated the tests accordingly
 Yes, I updated the schema accordingly
 Yes, I ran make test and all the tests passed