### PR TITLE
docs(example): multiple gateways example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1456,7 +1456,7 @@ hub:
     maxRequestBodySize: 10485760 # optional, default to 1MiB
 ```
 
-## Deploy multiple Gateways with a single traefik deployment/daemonset
+## Deploy multiple Gateways with a single Traefik Deployment/DaemonSet
 
 This example exposes two Gateways (e.g., `internal` and `external`) from a single Traefik installation.
 


### PR DESCRIPTION
### What does this PR do?

Add multiple gateways with single traefik deployment example


### Motivation

I've encountered the same problem. I searched the on the internet and the issues as well, and most of the answers were deploying multiple traefik charts into different namespace. 

- https://community.traefik.io/t/multiple-gateways-with-traefik-helm-chart/25862
- #1426

I didn't like this solution, and then I tried to investigate the chart a little bit, and end up with this solution

I'd like to share my worked solution, since there is no official example yet.
https://github.com/traefik/traefik-helm-chart/issues/1426#issuecomment-2935302634

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed


