### PR TITLE
fix: add missing flag arg

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -416,6 +416,9 @@
           - "--experimental.fastProxy.debug"
             {{- end }}
           {{- end }}
+          {{- if .Values.experimental.otlpLogs }}
+          - "--experimental.otlpLogs=true"
+          {{- end }}
           {{- range $pluginName, $plugin := .Values.experimental.plugins }}
           {{- if or (ne (typeOf $plugin) "map[string]interface {}") (not (hasKey $plugin "moduleName")) (not (hasKey $plugin "version")) }}
             {{- fail  (printf "ERROR: plugin %s is missing moduleName/version keys !" $pluginName) }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -1139,3 +1139,16 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.pluginregistry.sources.plugin2.github.token=ghp_xxxxxxxxxxxxxxxxxxxx"
+  - it: should enable experimental otlpLogs when specified
+    set:
+      experimental:
+        otlpLogs: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.otlpLogs=true"
+  - it: should not enable experimental otlpLogs by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--experimental.otlpLogs=true"


### PR DESCRIPTION
### What does this PR do?

https://github.com/traefik/traefik-helm-chart/pull/1531 added support for the experimental OTLP logs exporter, but it forgot to add the flag arg that allows the binary to use this feature. this PR adds that flag.

see config in first section [here](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opentelemetry_1)


### Motivation

I want to use the exporter


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

