### PR TITLE
fix: add missing api flag for dashboard

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -32,6 +32,7 @@ Kubernetes: `>=1.22.0-0`
 | affinity | object | `{}` | on nodes where no other traefik pods are scheduled. It should be used when hostNetwork: true to prevent port conflicts |
 | api.basePath | string | `""` | Configure API basePath |
 | api.dashboard | bool | `true` | Enable the dashboard |
+| api.enabled | bool | `true` | Enable the API |
 | autoscaling.behavior | object | `{}` | behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). |
 | autoscaling.enabled | bool | `false` | Create HorizontalPodAutoscaler object. See EXAMPLES.md for more details. |
 | autoscaling.maxReplicas | string | `nil` | maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -210,6 +210,11 @@
             {{- end }}
            {{- end }}
           {{- end }}
+          {{- if .Values.api.enabled }}
+          - "--api=true"
+          {{- else if .Values.api.dashboard }}
+            {{- fail "ERROR: Cannot enable the dashboard without setting api.enable to true" -}}
+          {{- end }}
           {{- if .Values.api.dashboard }}
           - "--api.dashboard=true"
           {{- else if .Values.ingressRoute.dashboard.enabled }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -247,6 +247,7 @@ tests:
             - --entryPoints.traefik.address=:8080/tcp
             - --entryPoints.web.address=:8000/tcp
             - --entryPoints.websecure.address=:8443/tcp
+            - --api=true
             - --api.dashboard=true
             - --ping=true
             - --metrics.prometheus=true
@@ -313,6 +314,14 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "redirectTo"
+  - it: should fail when api.dashboard is enabled but not api.enabled
+    set:
+      api:
+        enabled: false
+        dashboard: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Cannot enable the dashboard without setting api.enable to true"
   - it: should fail when dashboard has ingressRoute but is disabled
     set:
       api:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -26,6 +26,9 @@
                 },
                 "dashboard": {
                     "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -191,6 +191,8 @@ gatewayClass:  # @schema additionalProperties: false
   labels: {}
 
 api:
+  # -- Enable the API
+  enabled: true
   # -- Enable the dashboard
   dashboard: true
   # -- Configure API basePath


### PR DESCRIPTION
### What does this PR do?

The `api.dashboard` command line argument require api to be enabled.

Adding option to enable the API, enabled by default.

### Motivation

Dashboard is enabled by default but needs `api=true` to be added to additional arguments.

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed
