### PR TITLE
tests: update certificatesResolvers with Proxy v3.6 options

### DIFF
--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -411,13 +411,15 @@ tests:
             emailaddresses: foo@example.com,bar@example.org
             clientResponseHeaderTimeout: 1m
             clientTimeout: 1m
+            disableCommonName: true
             dnsChallenge:
               provider: myProvider
               resolvers:
                 - 1.1.1.1
                 - 8.8.8.8
             profile: tlsserver
-            tlsChallenge: true
+            tlsChallenge:
+              delay: 42
             httpChallenge:
               delay: 12
     asserts:
@@ -432,7 +434,7 @@ tests:
           content: "--certificatesresolvers.myAcmeResolver.acme.dnsChallenge.resolvers=1.1.1.1,8.8.8.8"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.tlsChallenge=true"
+          content: "--certificatesresolvers.myAcmeResolver.acme.tlsChallenge.delay=42"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--certificatesresolvers.myAcmeResolver.acme.emailaddresses=foo@example.com,bar@example.org"
@@ -448,6 +450,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--certificatesresolvers.myAcmeResolver.acme.clientTimeout=1m"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.myAcmeResolver.acme.disableCommonName=true"
 
 
   - it: should have the distributed acme resolver options applied


### PR DESCRIPTION
### What does this PR do?

Small changes for Traefik v3.6

Cf. https://github.com/traefik/traefik/pull/11977


### Motivation

Initial support for Traefik v3.6

Part of #1550 


### More

- [x] Yes, I updated the tests accordingly
- [ ] <s>Yes, I updated the schema accordingly</s>
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

