### PR TITLE
feat: Improve user facing roles with dedicated roles

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -469,7 +469,8 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.watchIngressWithoutClass | bool | `false` | Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified |
 | providers.kubernetesIngressNGINX.watchNamespace | string | `""` | Namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector. |
 | providers.kubernetesIngressNGINX.watchNamespaceSelector | string | `""` | Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. |
-| rbac.aggregateTo | list | `[]` |  |
+| rbac.aggregateAdminTo | list | `[]` | Aggregate Traefik admin role to specified user roles |
+| rbac.aggregateViewTo | list | `[]` | Aggregate Traefik view role to specified user roles |
 | rbac.enabled | bool | `true` | Whether Role Based Access Control objects like roles and rolebindings should be created |
 | rbac.namespaced | bool | `false` |  |
 | readinessProbe.failureThreshold | int | `1` | The number of consecutive failures allowed before considering the probe as failed. |

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -7,9 +7,6 @@ metadata:
   name: {{ template "traefik.clusterRoleName" . }}
   labels:
     {{- include "traefik.labels" . | nindent 4 }}
-    {{- range .Values.rbac.aggregateTo }}
-    rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
-    {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/traefik/templates/rbac/user-facing-roles.yaml
+++ b/traefik/templates/rbac/user-facing-roles.yaml
@@ -1,0 +1,281 @@
+{{- $version := include "traefik.proxyVersion" $ }}
+{{- if and .Values.rbac.enabled .Values.rbac.aggregateAdminTo }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if (not .Values.rbac.namespaced) }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+metadata:
+  name: {{ template "traefik.clusterRoleName" . }}-admin
+  labels:
+    {{- include "traefik.labels" . | nindent 4 }}
+    {{- range .Values.rbac.aggregateAdminTo }}
+    rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
+    {{- end }}
+rules:
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+      - ingressroutetcps
+      - ingressrouteudps
+      - middlewares
+      - middlewaretcps
+      - serverstransports
+      - serverstransporttcps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  {{- if or .Values.providers.kubernetesIngress.enabled .Values.providers.kubernetesIngressNGINX.enabled }}
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if (.Values.providers.kubernetesGateway).enabled }}
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - backendtlspolicies
+      - grpcroutes
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - referencegrants
+      - tcproutes
+      - tlsroutes
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - backendtlspolicies/status
+      - grpcroutes/status
+      - gatewayclasses/status
+      - gateways/status
+      - httproutes/status
+      - tcproutes/status
+      - tlsroutes/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if (.Values.providers.knative).enabled }}
+  - apiGroups:
+      - networking.internal.knative.dev
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.internal.knative.dev
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if .Values.hub.token }}
+    {{- if .Values.hub.apimanagement.enabled }}
+  - apiGroups:
+      - hub.traefik.io
+    resources:
+      - accesscontrolpolicies
+      - apiauths
+      - apiportals
+      - apiportalauths
+      - apiratelimits
+      - apis
+      - apiversions
+      - apibundles
+      - apiplans
+      - apicatalogitems
+      - managedsubscriptions
+      - managedapplications
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - hub.traefik.io
+    resources:
+      - apiauths/status
+      - apiportals/status
+      - apiportalauths/status
+      - apis/status
+      - apiversions/status
+      - apibundles/status
+      - apiplans/status
+      - apicatalogitems/status
+      - managedsubscriptions/status
+      - managedapplications/status
+    verbs:
+      - get
+      - list
+      - watch
+    {{- end -}}
+  {{- end }}
+{{- end }}
+{{- if and .Values.rbac.enabled .Values.rbac.aggregateViewTo }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if (not .Values.rbac.namespaced) }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
+metadata:
+  name: {{ template "traefik.clusterRoleName" . }}-view
+  labels:
+    {{- include "traefik.labels" . | nindent 4 }}
+    {{- range .Values.rbac.aggregateViewTo }}
+    rbac.authorization.k8s.io/aggregate-to-{{ . }}: "true"
+    {{- end }}
+rules:
+  - apiGroups:
+      - traefik.io
+    resources:
+      - ingressroutes
+      - ingressroutetcps
+      - ingressrouteudps
+      - middlewares
+      - middlewaretcps
+      - serverstransports
+      - serverstransporttcps
+      - tlsoptions
+      - tlsstores
+      - traefikservices
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if or .Values.providers.kubernetesIngress.enabled .Values.providers.kubernetesIngressNGINX.enabled }}
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingresses/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if (.Values.providers.kubernetesGateway).enabled }}
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - backendtlspolicies
+      - backendtlspolicies/status
+      - grpcroutes
+      - grpcroutes/status
+      - gatewayclasses
+      - gatewayclasses/status
+      - gateways
+      - gateways/status
+      - httproutes
+      - httproutes/status
+      - referencegrants
+      - tcproutes
+      - tcproutes/status
+      - tlsroutes
+      - tlsroutes/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if (.Values.providers.knative).enabled }}
+  - apiGroups:
+      - networking.internal.knative.dev
+    resources:
+      - ingresses
+      - ingresses/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if and .Values.hub.token .Values.hub.apimanagement.enabled }}
+  - apiGroups:
+      - hub.traefik.io
+    resources:
+      - accesscontrolpolicies
+      - apiauths
+      - apiauths/status
+      - apibundles
+      - apibundles/status
+      - apicatalogitems
+      - apicatalogitems/status
+      - apiplans
+      - apiplans/status
+      - apiportalauths
+      - apiportalauths/status
+      - apiportals
+      - apiportals/status
+      - apiratelimits
+      - apis
+      - apis/status
+      - apiversions
+      - apiversions/status
+      - managedapplications
+      - managedapplications/status
+      - managedsubscriptions
+      - managedsubscriptions/status
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+{{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -5,6 +5,7 @@ templates:
   - rbac/role.yaml
   - rbac/rolebinding.yaml
   - rbac/serviceaccount.yaml
+  - rbac/user-facing-roles.yaml
   - deployment.yaml
 tests:
   - it: should create default RBAC related objects
@@ -21,6 +22,9 @@ tests:
       - hasDocuments:
           count: 0
         template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/user-facing-roles.yaml
       - isKind:
           of: ServiceAccount
         template: rbac/serviceaccount.yaml
@@ -51,6 +55,11 @@ tests:
   - it: should set expected name when ns is overriden
     set:
       namespaceOverride: foo
+      rbac:
+        aggregateAdminTo:
+          - admin
+        aggregateViewTo:
+          - view
     asserts:
       - equal:
           path: metadata.name
@@ -60,6 +69,16 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-traefik-foo
         template: rbac/clusterrolebinding.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-traefik-foo-admin
+        documentIndex: 0
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-traefik-foo-view
+        documentIndex: 1
+        template: rbac/user-facing-roles.yaml
   - it: should not create RBAC related objects when disabled
     set:
       rbac:
@@ -77,10 +96,17 @@ tests:
       - hasDocuments:
           count: 0
         template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/user-facing-roles.yaml
   - it: should create RBAC related objects at namespace scope
     set:
       rbac:
         namespaced: true
+        aggregateAdminTo:
+          - admin
+        aggregateViewTo:
+          - view
     asserts:
       - isKind:
           of: Role
@@ -94,6 +120,12 @@ tests:
       - hasDocuments:
           count: 0
         template: rbac/clusterrolebinding.yaml
+      - isKind:
+          of: Role
+        template: rbac/user-facing-roles.yaml
+      - hasDocuments:
+          count: 2
+        template: rbac/user-facing-roles.yaml
 
   - it: should use existing ServiceAccount
     set:
@@ -174,23 +206,6 @@ tests:
                 - list
                 - watch
         template: rbac/clusterrole.yaml
-  - it: "ClusterRole should not have aggregate-to-admin label by default"
-    template: rbac/clusterrole.yaml
-    asserts:
-      - isNull:
-          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-admin"]
-  - it: "ClusterRole should be configurable with multiples aggregate-to- label"
-    set:
-      rbac:
-        aggregateTo: [ "admin", "edit" ]
-    template: rbac/clusterrole.yaml
-    asserts:
-      - equal:
-          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-admin"]
-          value: "true"
-      - equal:
-          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
-          value: "true"
   - it: should use helm managed namespace as default behavior
     set:
       rbac:
@@ -1068,6 +1083,325 @@ tests:
               - networking.k8s.io
             resources:
               - ingresses
+            verbs:
+              - get
+              - list
+              - watch
+  - it: should create user facing user cluster role when enabled
+    set:
+      rbac:
+        aggregateAdminTo: [ "admin", "edit" ]
+        aggregateViewTo: [ "view" ]
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-admin"]
+          value: "true"
+        documentIndex: 0
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
+          value: "true"
+        documentIndex: 0
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-view"]
+          value: "true"
+        documentIndex: 1
+        template: rbac/user-facing-roles.yaml
+
+  - it: should not create user facing admin cluster role when only view role is enabled
+    set:
+      rbac:
+        aggregateViewTo: [ "view" ]
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-view"]
+          value: "true"
+        template: rbac/user-facing-roles.yaml
+
+  - it: should not create user facing view cluster role when only admin role is enabled
+    set:
+      rbac:
+        aggregateAdminTo: [ "edit" ]
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: rbac/user-facing-roles.yaml
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
+          value: "true"
+        template: rbac/user-facing-roles.yaml
+
+  - it: should contain networking.k8s.io resources when kubernetes ingress provider is enabled
+    set:
+      rbac:
+        aggregateAdminTo: [ "admin" ]
+        aggregateViewTo: [ "view" ]
+      providers:
+        kubernetesIngress:
+          enabled: true
+    asserts:
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: should contain networking.k8s.io resources when kubernetes ingress nginx provider is enabled
+    set:
+      rbac:
+        aggregateAdminTo: [ "admin" ]
+        aggregateViewTo: [ "view" ]
+      providers:
+        kubernetesIngress:
+          enabled: false
+        kubernetesIngressNGINX:
+          enabled: true
+    asserts:
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: should contain networking.internal.knative.dev resources when kubernetes knavite provider is enabled
+    set:
+      rbac:
+        aggregateAdminTo: [ "admin" ]
+        aggregateViewTo: [ "view" ]
+      providers:
+        knative:
+          enabled: true
+    asserts:
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.internal.knative.dev
+            resources:
+              - ingresses
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.internal.knative.dev
+            resources:
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - networking.internal.knative.dev
+            resources:
+              - ingresses
+              - ingresses/status
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: should contain additional user facing RBACS for hub API management
+    set:
+      rbac:
+        aggregateAdminTo: [ "admin" ]
+        aggregateViewTo: [ "view" ]
+      hub:
+        token: xxx
+        apimanagement:
+          enabled: true
+    asserts:
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - hub.traefik.io
+            resources:
+              - accesscontrolpolicies
+              - apiauths
+              - apiportals
+              - apiportalauths
+              - apiratelimits
+              - apis
+              - apiversions
+              - apibundles
+              - apiplans
+              - apicatalogitems
+              - managedsubscriptions
+              - managedapplications
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 0
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - hub.traefik.io
+            resources:
+              - apiauths/status
+              - apiportals/status
+              - apiportalauths/status
+              - apis/status
+              - apiversions/status
+              - apibundles/status
+              - apiplans/status
+              - apicatalogitems/status
+              - managedsubscriptions/status
+              - managedapplications/status
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/user-facing-roles.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - hub.traefik.io
+            resources:
+              - accesscontrolpolicies
+              - apiauths
+              - apiauths/status
+              - apibundles
+              - apibundles/status
+              - apicatalogitems
+              - apicatalogitems/status
+              - apiplans
+              - apiplans/status
+              - apiportalauths
+              - apiportalauths/status
+              - apiportals
+              - apiportals/status
+              - apiratelimits
+              - apis
+              - apis/status
+              - apiversions
+              - apiversions/status
+              - managedapplications
+              - managedapplications/status
+              - managedsubscriptions
+              - managedsubscriptions/status
             verbs:
               - get
               - list

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2567,7 +2567,12 @@
         "rbac": {
             "type": "object",
             "properties": {
-                "aggregateTo": {
+                "aggregateAdminTo": {
+                    "description": "Aggregate Traefik admin role to specified user roles",
+                    "type": "array"
+                },
+                "aggregateViewTo": {
+                    "description": "Aggregate Traefik view role to specified user roles",
                     "type": "array"
                 },
                 "enabled": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1137,7 +1137,10 @@ rbac:  # @schema additionalProperties: false
   namespaced: false
   # Enable user-facing roles
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
-  aggregateTo: []
+  # -- Aggregate Traefik admin role to specified user roles
+  aggregateAdminTo: []
+  # -- Aggregate Traefik view role to specified user roles
+  aggregateViewTo: []
 
 # -- The service account the pods will use to interact with the Kubernetes API
 serviceAccount:  # @schema additionalProperties: false


### PR DESCRIPTION
### What does this PR do?

Creating two dedicated cluster roles (view and admin) for user facing aggregated roles.

### Motivation

User facing aggregated roles were supported since #664 but only aggregating Traefik cluster role to aggregated role.
In my opinion, this is not the right way to implement it as the Traefik cluster role only have view permission to traefik CRDs while admin aggregated role should "[allow read/write access to most resources in a namespace](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)".

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

