### PR TITLE
feat(deps): ✨ update traefik docker tag to v3.6.0

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -4,7 +4,7 @@ description: A Traefik based Kubernetes ingress controller
 type: application
 version: 37.2.0
 # renovate: image=traefik
-appVersion: v3.5.4
+appVersion: v3.6.0
 kubeVersion: ">=1.22.0-0"
 keywords:
   - traefik

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 37.2.0](https://img.shields.io/badge/Version-37.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.5.4](https://img.shields.io/badge/AppVersion-v3.5.4-informational?style=flat-square)
+![Version: 37.2.0](https://img.shields.io/badge/Version-37.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.0](https://img.shields.io/badge/AppVersion-v3.6.0-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Updates Traefik Proxy default image tag to v3.6.0

### Motivation

Renovate is not able to open it, there are errors with GitHub API & Renovate code.

### More

- [x] Yes, I updated the docs accordingly