### PR TITLE
docs: Update EXAMPLES.md with REGIONAL load balancer note for Digital Ocean

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -562,6 +562,8 @@ service:
   type: LoadBalancer
   annotations:
     # This will tell DigitalOcean to enable the proxy protocol.
+    # Note that only REGIONAL type loadbalancers are supported.
+    # service.beta.kubernetes.io/do-loadbalancer-type: "REGIONAL"
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
   spec:
     # This is the default and should stay as cluster to keep the DO health checks working.


### PR DESCRIPTION
Added note about REGIONAL type load balancers. This is communication from an official ticket. It is undocumented on DO docs.

### What does this PR do?

Other types of DO LoadBalancers don't support proxy protocol. This clarifies it.




