### PR TITLE
add loadBalancerIP support for traefik service

### DIFF
--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -31,6 +31,9 @@
   selector:
     {{- include "traefik.labelselector" .root | nindent 4 }}
   {{- if eq $type "LoadBalancer" }}
+  {{- if .service.loadBalancerIP }}
+  loadBalancerIP: {{ .service.loadBalancerIP }}
+  {{- end }}
   {{- with .service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
### What does this PR do?

add loadBalancerIP support for traefik service

### Motivation

Currently traefik service is not able to stablize the the LoadBalancer external IP as the template does not render `loadBalancerIP` defination.

It should be treated as a bug. Test cases seems not working correctly here, the `make test` always succeed.

#### Process to make stablelize the LB IP (Tested on CKS over CloudStack)

1. Create a public IP on the destination VPC (just create IP, no other configuration required)
2. Configure `service.loadBalancerIP` in values file
3. Apply the helm chart. The IP will be picked and LB configuration will be applied. 

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

