### PR TITLE
fix(pvc): allow empty storageClassName

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -314,7 +314,7 @@ Kubernetes: `>=1.22.0-0`
 | persistence.name | string | `"data"` |  |
 | persistence.path | string | `"/data"` |  |
 | persistence.size | string | `"128Mi"` |  |
-| persistence.storageClass | string | `""` |  |
+| persistence.storageClass | string | `nil` |  |
 | persistence.subPath | string | `""` | Only mount a subpath of the Volume into the pod |
 | persistence.volumeName | string | `""` |  |
 | podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | [Pod Disruption Budget](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1/) |

--- a/traefik/templates/pvc.yaml
+++ b/traefik/templates/pvc.yaml
@@ -17,7 +17,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- if .Values.persistence.storageClass }}
+  {{- if ne .Values.persistence.storageClass nil }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
   {{- end }}
   {{- if .Values.persistence.volumeName }}

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1459,7 +1459,10 @@
                     "type": "string"
                 },
                 "storageClass": {
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "subPath": {
                     "type": "string"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1059,7 +1059,7 @@ persistence:
   existingClaim: ""
   accessMode: ReadWriteOnce
   size: 128Mi
-  storageClass: ""
+  storageClass:  # @schema type:[string, null]
   volumeName: ""
   path: /data
   annotations: {}


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix https://github.com/traefik/traefik-helm-chart/issues/1537

In PVC schema, not defining `storageClassName` means it will use _cluster default_.
However setting it to `""` (empty string) means _do not use a storage class_, disabling dynamic provisioning.
Behavior is not the same and the second case is not currently possible with that template condition.

I suggest changing `persistence.storageClass` default to `null` and handling `null` as "cluster default" (ommiting `storageClassName`) - schema updated to reflect that.
This should keep consistent behavior for everyone using the chart and _not_ re-defining `storageClass`.
Those that happen to have re-defined it as `""` in their local values will need to update though.

We can do it differently (`null` or `false` being "no storage class") but I think it would be confusing for those familiar with the PVC object schema: empty would mean ommitting and null mean empty... "why not empty mean empty?" would they ask 😄 

### Motivation

In my setup, I need to NOT usage storage classes 😄 

### More

- [ ] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed
