### PR TITLE
feat(ports): enforce schema

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -338,6 +338,7 @@ Kubernetes: `>=1.22.0-0`
 | ports.traefik.observability.tracing | string | `nil` | Defines whether a router attached to this EntryPoint produces traces by default. |
 | ports.traefik.port | int | `8080` |  |
 | ports.traefik.protocol | string | `"TCP"` | The port protocol (TCP/UDP) |
+| ports.web.asDefault | string | `nil` |  |
 | ports.web.expose.default | bool | `true` |  |
 | ports.web.exposedPort | int | `80` |  |
 | ports.web.forwardedHeaders.insecure | bool | `false` |  |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -638,9 +638,6 @@
           {{- end }}
           {{- range $entrypoint, $config := $.Values.ports }}
           {{- if $config }}
-            {{- if $config.redirectTo }}
-              {{- fail "ERROR: redirectTo syntax has been removed in v34 of this Chart. See Release notes or EXAMPLES.md for new syntax." -}}
-            {{- end }}
             {{- if $config.redirections }}
              {{- with $config.redirections.entryPoint }}
               {{- if not (hasKey $.Values.ports .to) }}

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -333,7 +333,7 @@ tests:
           exposedPort: 443
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: redirectTo syntax has been removed in v34 of this Chart. See Release notes or EXAMPLES.md for new syntax."
+          errorPattern: "values don't meet the specifications of the schema"
   - it: should fail when redirect on websecure with tls enabled and non-https scheme
     set:
       ports:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1518,532 +1518,249 @@
         },
         "ports": {
             "type": "object",
-            "properties": {
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "expose": {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "type": "boolean"
-                                }
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "allowACMEByPass": {
+                        "type": "boolean"
+                    },
+                    "appProtocol": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "asDefault": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "containerPort": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "expose": {
+                        "type": "object",
+                        "properties": {
+                            "default": {
+                                "type": "boolean"
                             }
-                        },
-                        "exposedPort": {
-                            "type": "integer"
-                        },
-                        "observability": {
-                            "type": "object",
-                            "properties": {
-                                "accessLogs": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "metrics": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "traceVerbosity": {
-                                    "default": "minimal",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "enum": [
-                                        "minimal",
-                                        "detailed",
-                                        null
-                                    ]
-                                },
-                                "tracing": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "protocol": {
-                            "type": "string"
                         }
-                    }
-                },
-                "traefik": {
-                    "type": "object",
-                    "properties": {
-                        "expose": {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "exposedPort": {
-                            "type": "integer"
-                        },
-                        "hostIP": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        },
-                        "hostPort": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "observability": {
-                            "type": "object",
-                            "properties": {
-                                "accessLogs": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "metrics": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "traceVerbosity": {
-                                    "default": "minimal",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "enum": [
-                                        "minimal",
-                                        "detailed",
-                                        null
-                                    ]
-                                },
-                                "tracing": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                }
+                    },
+                    "exposedPort": {
+                        "type": "integer"
+                    },
+                    "forwardedHeaders": {
+                        "type": "object",
+                        "properties": {
+                            "insecure": {
+                                "type": "boolean"
                             },
-                            "additionalProperties": false
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "protocol": {
-                            "type": "string"
+                            "trustedIPs": {
+                                "type": "array"
+                            }
                         }
-                    }
-                },
-                "web": {
-                    "type": "object",
-                    "properties": {
-                        "expose": {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "exposedPort": {
-                            "type": "integer"
-                        },
-                        "forwardedHeaders": {
-                            "type": "object",
-                            "properties": {
-                                "insecure": {
-                                    "type": "boolean"
-                                },
-                                "trustedIPs": {
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "nodePort": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "observability": {
-                            "type": "object",
-                            "properties": {
-                                "accessLogs": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "metrics": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "traceVerbosity": {
-                                    "default": "minimal",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "enum": [
-                                        "minimal",
-                                        "detailed",
-                                        null
-                                    ]
-                                },
-                                "tracing": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                }
+                    },
+                    "hostIP": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "hostPort": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "http3": {
+                        "type": "object",
+                        "properties": {
+                            "advertisedPort": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "minimum": 0
                             },
-                            "additionalProperties": false
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "protocol": {
-                            "type": "string"
-                        },
-                        "proxyProtocol": {
-                            "type": "object",
-                            "properties": {
-                                "insecure": {
-                                    "type": "boolean"
-                                },
-                                "trustedIPs": {
-                                    "type": "array"
-                                }
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "middlewares": {
+                        "type": [
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "nodePort": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "observability": {
+                        "type": "object",
+                        "properties": {
+                            "accessLogs": {
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
+                            "metrics": {
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
+                            "traceVerbosity": {
+                                "default": "minimal",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "minimal",
+                                    "detailed",
+                                    null
+                                ]
+                            },
+                            "tracing": {
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
                             }
                         },
-                        "redirections": {
-                            "type": "object",
-                            "properties": {
-                                "entryPoint": {
-                                    "type": "object"
-                                }
+                        "additionalProperties": false
+                    },
+                    "port": {
+                        "type": "integer"
+                    },
+                    "protocol": {
+                        "type": "string"
+                    },
+                    "proxyProtocol": {
+                        "type": "object",
+                        "properties": {
+                            "insecure": {
+                                "type": "boolean"
+                            },
+                            "trustedIPs": {
+                                "type": "array"
                             }
-                        },
-                        "targetPort": {
-                            "type": [
-                                "string",
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "transport": {
-                            "type": "object",
-                            "properties": {
-                                "keepAliveMaxRequests": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ],
-                                    "minimum": 0
-                                },
-                                "keepAliveMaxTime": {
-                                    "type": [
-                                        "string",
-                                        "integer",
-                                        "null"
-                                    ]
-                                },
-                                "lifeCycle": {
-                                    "type": "object",
-                                    "properties": {
-                                        "graceTimeOut": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "requestAcceptGraceTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
+                        }
+                    },
+                    "redirections": {
+                        "type": "object",
+                        "properties": {
+                            "entryPoint": {
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "targetPort": {
+                        "type": [
+                            "string",
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "tls": {
+                        "type": "object",
+                        "properties": {
+                            "certResolver": {
+                                "type": "string"
+                            },
+                            "domains": {
+                                "type": "array"
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            },
+                            "options": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "transport": {
+                        "type": "object",
+                        "properties": {
+                            "keepAliveMaxRequests": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "minimum": 0
+                            },
+                            "keepAliveMaxTime": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "lifeCycle": {
+                                "type": "object",
+                                "properties": {
+                                    "graceTimeOut": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "requestAcceptGraceTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
                                     }
-                                },
-                                "respondingTimeouts": {
-                                    "type": "object",
-                                    "properties": {
-                                        "idleTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "readTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "writeTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
+                                }
+                            },
+                            "respondingTimeouts": {
+                                "type": "object",
+                                "properties": {
+                                    "idleTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "readTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "writeTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
                                     }
                                 }
                             }
                         }
                     }
                 },
-                "websecure": {
-                    "type": "object",
-                    "properties": {
-                        "allowACMEByPass": {
-                            "type": "boolean"
-                        },
-                        "appProtocol": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        },
-                        "containerPort": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "expose": {
-                            "type": "object",
-                            "properties": {
-                                "default": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "exposedPort": {
-                            "type": "integer"
-                        },
-                        "forwardedHeaders": {
-                            "type": "object",
-                            "properties": {
-                                "insecure": {
-                                    "type": "boolean"
-                                },
-                                "trustedIPs": {
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "hostPort": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "http3": {
-                            "type": "object",
-                            "properties": {
-                                "advertisedPort": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ],
-                                    "minimum": 0
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "middlewares": {
-                            "type": "array"
-                        },
-                        "nodePort": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "observability": {
-                            "type": "object",
-                            "properties": {
-                                "accessLogs": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "metrics": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                },
-                                "traceVerbosity": {
-                                    "default": "minimal",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "enum": [
-                                        "minimal",
-                                        "detailed",
-                                        null
-                                    ]
-                                },
-                                "tracing": {
-                                    "default": true,
-                                    "type": [
-                                        "boolean",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "protocol": {
-                            "type": "string"
-                        },
-                        "proxyProtocol": {
-                            "type": "object",
-                            "properties": {
-                                "insecure": {
-                                    "type": "boolean"
-                                },
-                                "trustedIPs": {
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "targetPort": {
-                            "type": [
-                                "string",
-                                "integer",
-                                "null"
-                            ],
-                            "minimum": 0
-                        },
-                        "tls": {
-                            "type": "object",
-                            "properties": {
-                                "certResolver": {
-                                    "type": "string"
-                                },
-                                "domains": {
-                                    "type": "array"
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "options": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "transport": {
-                            "type": "object",
-                            "properties": {
-                                "keepAliveMaxRequests": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ],
-                                    "minimum": 0
-                                },
-                                "keepAliveMaxTime": {
-                                    "type": [
-                                        "string",
-                                        "integer",
-                                        "null"
-                                    ]
-                                },
-                                "lifeCycle": {
-                                    "type": "object",
-                                    "properties": {
-                                        "graceTimeOut": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "requestAcceptGraceTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "respondingTimeouts": {
-                                    "type": "object",
-                                    "properties": {
-                                        "idleTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "readTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "writeTimeout": {
-                                            "type": [
-                                                "string",
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                "additionalProperties": false
             }
         },
         "priorityClassName": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -785,7 +785,9 @@ env: []
 # -- Environment variables to be passed to Traefik's binary from configMaps or secrets
 envFrom: []
 
+# @schema mergeProperties: true
 ports:
+  # @schema additionalProperties: false
   traefik:
     port: 8080
     # -- Use hostPort if set.
@@ -819,7 +821,7 @@ ports:
       traceVerbosity:  # @schema enum:[minimal, detailed, null]; type:[string, null]; default: minimal
   web:
     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
-    # asDefault: true
+    asDefault:  # @schema type: [boolean, null]; default: null
     port: 8000
     # hostPort: 8000
     # containerPort: 8000
@@ -927,7 +929,7 @@ ports:
     # It follows the provider naming convention: https://doc.traefik.io/traefik/providers/overview/#provider-namespace
     #   - namespace-name1@kubernetescrd
     #   - namespace-name2@kubernetescrd
-    middlewares: []
+    middlewares: []  # @schema type: [array, null]
     observability:  # @schema additionalProperties: false
       # -- Enables metrics for this entryPoint.
       metrics:  # @schema type:[boolean, null]; default: true


### PR DESCRIPTION
### What does this PR do?

Merging all ports schema to be able to validate custom ports with schema

### Motivation

Custom ports are not validated by schema and we issued an incident caused by a typo error in custom ports.

### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed