### PR TITLE
fix(providers)!: align labelSelector for kubernetesGateway and knative

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -382,7 +382,7 @@ Kubernetes: `>=1.22.0-0`
 | providers.file.enabled | bool | `false` | Create a file provider |
 | providers.file.watch | bool | `true` | Allows Traefik to automatically watch for file changes |
 | providers.knative.enabled | bool | `false` | Enable Knative provider |
-| providers.knative.labelselector | string | `""` | Allow filtering Knative Ingress objects |
+| providers.knative.labelSelector | string | `""` | Allow filtering Knative Ingress objects |
 | providers.knative.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesCRD.allowCrossNamespace | bool | `false` | Allows IngressRoute to reference resources in namespace other than theirs |
 | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
@@ -393,7 +393,7 @@ Kubernetes: `>=1.22.0-0`
 | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
 | providers.kubernetesGateway.enabled | bool | `false` | Enable Traefik Gateway provider for Gateway API |
 | providers.kubernetesGateway.experimentalChannel | bool | `false` | Toggles support for the Experimental Channel resources (Gateway API release channels documentation). This option currently enables support for TCPRoute and TLSRoute. |
-| providers.kubernetesGateway.labelselector | string | `""` | A label selector can be defined to filter on specific GatewayClass objects only. |
+| providers.kubernetesGateway.labelSelector | string | `""` | A label selector can be defined to filter on specific GatewayClass objects only. |
 | providers.kubernetesGateway.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesGateway.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
 | providers.kubernetesGateway.statusAddress.hostname | string | `""` | This Hostname will get copied to the Gateway status.addresses. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -560,8 +560,8 @@
             {{- if .experimentalChannel }}
           - "--providers.kubernetesgateway.experimentalchannel=true"
             {{- end }}
-            {{- with .labelselector }}
-          - "--providers.kubernetesgateway.labelselector={{ . }}"
+            {{- with .labelSelector }}
+          - "--providers.kubernetesgateway.labelSelector={{ . }}"
             {{- end }}
            {{- end }}
           {{- end }}
@@ -631,8 +631,8 @@
             {{- if or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}
           - "--providers.knative.namespaces={{ template "providers.knative.namespaces" $ }}"
             {{- end }}
-            {{- with .labelselector }}
-          - "--providers.knative.labelselector={{ . }}"
+            {{- with .labelSelector }}
+          - "--providers.knative.labelSelector={{ . }}"
             {{- end }}
            {{- end }}
           {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -1036,14 +1036,14 @@ tests:
           enabled: true
           experimentalChannel: true
           nativeLBByDefault: true
-          labelselector: "app=traefik"
+          labelSelector: "app=traefik"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesgateway.experimentalchannel=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--providers.kubernetesgateway.labelselector=app=traefik"
+          content: "--providers.kubernetesgateway.labelSelector=app=traefik"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesgateway.nativeLBByDefault=true"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2072,7 +2072,7 @@
                         "enabled": {
                             "type": "boolean"
                         },
-                        "labelselector": {
+                        "labelSelector": {
                             "type": "string"
                         },
                         "namespaces": {
@@ -2115,7 +2115,7 @@
                         "experimentalChannel": {
                             "type": "boolean"
                         },
-                        "labelselector": {
+                        "labelSelector": {
                             "type": "string"
                         },
                         "namespaces": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -327,7 +327,7 @@ providers:  # @schema additionalProperties: false
     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
     namespaces: []
     # -- A label selector can be defined to filter on specific GatewayClass objects only.
-    labelselector: ""
+    labelSelector: ""
     # -- Defines whether to use Native Kubernetes load-balancing mode by default.
     nativeLBByDefault: false
     statusAddress:
@@ -389,7 +389,7 @@ providers:  # @schema additionalProperties: false
     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
     namespaces: []
     # -- Allow filtering Knative Ingress objects
-    labelselector: ""
+    labelSelector: ""
 
 # -- Add volumes to the traefik pod. The volume name will be passed to tpl.
 # This can be used to mount a cert pair or a configmap that holds a config.toml file.


### PR DESCRIPTION
Fixes #1576

## Summary

This PR corrects the inconsistent `labelselector` field used by the `kubernetesGateway` and `knative` providers in the Traefik Helm chart.

### Motivation

Users setting `labelSelector` (capital S) for kubernetesGateway or knative get empty selectors due to naming mismatch.  
This PR updates both providers to use the canonical camelCase key: `providers.<provider>.labelSelector`


## Changes

- Replace the old `labelselector` values key with the correct `labelSelector`
  - Applies to:
    - `providers.kubernetesGateway`
    - `providers.knative`
- Update `values.schema.json` to contain **only** the camelCase `labelSelector`
- Regenerate chart documentation (`VALUES.md`) using `make docs`
- Update unit tests in `traefik/tests/traefik-config_test.yaml`:
  - kubernetesGateway test now validates `labelSelector`

This is consistent with other providers and resolves the incorrect behavior reported in #1576

### Testing

I have:

- Run generators:
  - `make docs`
  - `make schema`
- Run tests:
  - `make test`
- Verified rendered arguments manually:

```bash
# kubernetesGateway
helm template test ./traefik \
  --kube-version 1.29.0 \
  --set providers.kubernetesGateway.enabled=true \
  --set providers.kubernetesGateway.labelSelector='traefik=dmz' \
  | grep -A2 'providers.kubernetesgateway.labelSelector'

# knative (experimental)
helm template test ./traefik \
  --kube-version 1.29.0 \
  --set experimental.knative=true \
  --set providers.knative.enabled=true \
  --set providers.knative.labelSelector='traefik=dmz' \
  | grep -A2 'providers.knative.labelSelector'
``` 

  Both commands render the expected CLI flags:

```bash
--providers.kubernetesgateway.labelSelector=traefik=dmz

--providers.knative.labelSelector=traefik=dmz
```
### More

- [x] I have read the contributing guide.
- [x] I have read the testing guidelines.
- [x] I ran `make docs`, `make schema`, and `make test`.
- [x] I only changed what is required for this fix.



