### PR TITLE
fix(nginx)!: 🐛 align provider settings and provide required rbac

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -418,13 +418,13 @@ Kubernetes: `>=1.22.0-0`
 | providers.kubernetesIngressNginx.endpoint | string | `""` | Kubernetes server endpoint (required for external cluster client) |
 | providers.kubernetesIngressNginx.ingressClass | string | `"nginx"` | Name of the ingress class this controller satisfies |
 | providers.kubernetesIngressNginx.ingressClassByName | bool | `false` | Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class |
-| providers.kubernetesIngressNginx.namespaceSelector | string | `""` | Selector selects namespaces the controller watches for updates to Kubernetes objects |
-| providers.kubernetesIngressNginx.namespaces | list | `[]` | Namespace the controller watches for updates to Kubernetes objects. All namespaces are watched if this parameter is left empty. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesIngressNginx.publishService | object | `{"enabled":false,"pathOverride":""}` | Service fronting the Ingress controller. Takes the form 'namespace/name' |
 | providers.kubernetesIngressNginx.publishStatusAddress | string | `""` | Customized address (or addresses, separated by comma) to set as the load-balancer status of Ingress objects this controller satisfies |
 | providers.kubernetesIngressNginx.throttleDuration | string | `""` | Ingress refresh throttle duration |
 | providers.kubernetesIngressNginx.token | string | `""` | Kubernetes bearer token (not needed for in-cluster client). It accepts either a token value or a file path to the token |
 | providers.kubernetesIngressNginx.watchIngressWithoutClass | bool | `false` | Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified |
+| providers.kubernetesIngressNginx.watchNamespace | string | `""` | Namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector. |
+| providers.kubernetesIngressNginx.watchNamespaceSelector | string | `""` | Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. |
 | rbac | object | `{"aggregateTo":[],"enabled":true,"namespaced":false,"secretResourceNames":[]}` | Whether Role Based Access Control objects like roles and rolebindings should be created |
 | readinessProbe.failureThreshold | int | `1` | The number of consecutive failures allowed before considering the probe as failed. |
 | readinessProbe.initialDelaySeconds | int | `2` | The number of seconds to wait before starting the first probe. |

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -164,7 +164,7 @@ Construct a comma-separated list of whitelisted namespaces
 {{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngress.namespaces) }}
 {{- end -}}
 {{- define "providers.kubernetesIngressNginx.namespaces" -}}
-{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngressNginx.namespaces) }}
+{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngressNginx.watchNamespace) }}
 {{- end -}}
 {{- define "providers.knative.namespaces" -}}
 {{- default (include "traefik.namespace" .) (join "," .Values.providers.knative.namespaces) }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -593,10 +593,10 @@
             {{- if .watchIngressWithoutClass }}
           - "--providers.kubernetesingressnginx.watchingresswithoutclass=true"
             {{- end }}
-            {{- if or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}
+            {{- if or .watchNamespace (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}
           - "--providers.kubernetesingressnginx.watchnamespace={{ template "providers.kubernetesIngressNginx.namespaces" $ }}"
             {{- end }}
-            {{- with .namespaceSelector }}
+            {{- with .watchNamespaceSelector }}
           - "--providers.kubernetesingressnginx.watchnamespaceselector={{ . }}"
             {{- end }}
             {{- if and $.Values.service.enabled .publishService.enabled }}

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -105,6 +105,13 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
   {{- end -}}
   {{- if .Values.providers.kubernetesCRD.enabled }}
    {{- if not .Values.providers.kubernetesIngress.enabled }}

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -1,10 +1,9 @@
 {{- $version := include "traefik.proxyVersion" $ }}
 {{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
-{{- $ingressNginxNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngressNginx.namespaces -}}
 {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
 {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.knative.namespaces -}}
 {{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
-{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $ingressNginxNamespaces $CRDNamespaces $hubNamespaces $knativeNamespaces)) -}}
+{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $hubNamespaces $knativeNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced -}}
 {{- range $allNamespaces }}
@@ -73,7 +72,7 @@ rules:
       - get
       - list
       - watch
-{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) (and (has . $ingressNginxNamespaces) $.Values.providers.kubernetesIngressNginx.enabled)}}
+{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($.Values.providers.kubernetesIngressNginx.enabled) }}
   - apiGroups:
       - extensions
       - networking.k8s.io

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -1,10 +1,9 @@
 {{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
-{{- $ingressNginxNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngressNginx.namespaces -}}
 {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
 {{- $gatewayNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.kubernetesGateway).namespaces) -}}
 {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.knative).namespaces) -}}
 {{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
-{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $ingressNginxNamespaces $CRDNamespaces $gatewayNamespaces $knativeNamespaces $hubNamespaces)) -}}
+{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $gatewayNamespaces $knativeNamespaces $hubNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
 {{- range $allNamespaces }}

--- a/traefik/tests/provider-kubernetesingressnginx_test.yaml
+++ b/traefik/tests/provider-kubernetesingressnginx_test.yaml
@@ -57,15 +57,13 @@ tests:
     set:
       providers:
         kubernetesIngressNginx:
-          namespaces:
-            - "nginx-ingress"
-            - "default"
-          namespaceSelector: "environment=production"
+          watchNamespace: "nginx-ingress"
+          watchNamespaceSelector: "environment=production"
     asserts:
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].args
-          content: "--providers.kubernetesingressnginx.watchnamespace=nginx-ingress,default"
+          content: "--providers.kubernetesingressnginx.watchnamespace=nginx-ingress"
       - template: deployment.yaml
         contains:
           path: spec.template.spec.containers[0].args

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1629,38 +1629,6 @@ tests:
             verbs:
               - list
               - watch
-  - it: should use multiple namespaces if provided to kubernetesIngressNginx
-    set:
-      providers:
-        kubernetesIngressNginx:
-          enabled: true
-          namespaces:
-            - default
-            - nginx-ns
-      rbac:
-        namespaced: true
-    asserts:
-      - hasDocuments:
-          count: 3
-        template: rbac/role.yaml
-      - hasDocuments:
-          count: 3
-        template: rbac/rolebinding.yaml
-      - equal:
-          path: metadata.namespace
-          value: NAMESPACE
-        template: rbac/role.yaml
-        documentIndex: 0
-      - equal:
-          path: metadata.namespace
-          value: default
-        template: rbac/role.yaml
-        documentIndex: 1
-      - equal:
-          path: metadata.namespace
-          value: nginx-ns
-        template: rbac/role.yaml
-        documentIndex: 2
   - it: should add RBAC rules when kubernetesIngressNginx is enabled
     set:
       providers:
@@ -1696,6 +1664,17 @@ tests:
               - ingresses/status
             verbs:
               - update
+      - template: rbac/clusterrole.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - namespaces
+            verbs:
+              - list
+              - watch
   - it: should not duplicate RBAC rules when kubernetesIngress is also enabled
     set:
       providers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1939,12 +1939,6 @@
                         "ingressClassByName": {
                             "type": "boolean"
                         },
-                        "namespaceSelector": {
-                            "type": "string"
-                        },
-                        "namespaces": {
-                            "type": "array"
-                        },
                         "publishService": {
                             "type": "object",
                             "properties": {
@@ -1967,6 +1961,12 @@
                         },
                         "watchIngressWithoutClass": {
                             "type": "boolean"
+                        },
+                        "watchNamespace": {
+                            "type": "string"
+                        },
+                        "watchNamespaceSelector": {
+                            "type": "string"
                         }
                     }
                 }

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -363,10 +363,10 @@ providers:
     ingressClassByName: false
     # -- Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified
     watchIngressWithoutClass: false
-    # -- Namespace the controller watches for updates to Kubernetes objects. All namespaces are watched if this parameter is left empty. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
-    namespaces: []
-    # -- Selector selects namespaces the controller watches for updates to Kubernetes objects
-    namespaceSelector: ""
+    # -- Namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector.
+    watchNamespace: ""
+    # -- Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.
+    watchNamespaceSelector: ""
     # -- Service fronting the Ingress controller. Takes the form 'namespace/name'
     publishService:
       enabled: false


### PR DESCRIPTION
### What does this PR do?

This is a breaking change.

1. Add missing namespace rbac for _kubernetesIngressNginx_ provider
2. Align this chart _kubernetesIngressNginx_ provider setting with [upstream](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx/#configuration-example)

**Before**

```yaml
providers:
  kubernetesIngressNginx:
    # Namespace discovery
    namespaces: 
      - "default"
    # OR 
    namespaceSelector: "environment=production"
```

**After**

```yaml
providers:
  kubernetesIngressNginx:
    # Namespace discovery
    watchNamespace: "default"
    # OR 
    watchNamespaceSelector: "environment=production"
```

### Motivation

1. Fixes #1592
3. Fixes divergence with upstream provider setting:

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

