### PR TITLE
fix(ports): 🐛 `http.encodedCharacters` on custom entrypoints

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -664,6 +664,34 @@
             {{- if $config.middlewares }}
           - "--entryPoints.{{ $entrypoint }}.http.middlewares={{ join "," $config.middlewares }}"
             {{- end }}
+            {{- with $config.http }}
+             {{- if ne .sanitizePath nil }}
+              {{- with .sanitizePath | toString }}
+          - "--entryPoints.{{ $entrypoint }}.http.sanitizePath={{ . }}"
+              {{- end }}
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedSlash }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedSlash={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedBackSlash }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedBackSlash={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedNullCharacter }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedNullCharacter={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedSemicolon }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedSemicolon={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedPercent }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedPercent={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedQuestionMark }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedQuestionMark={{ . }}"
+             {{- end }}
+             {{- with .encodedCharacters.allowEncodedHash }}
+          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedHash={{ . }}"
+             {{- end }}
+            {{- end }}
             {{- if $config.tls }}
               {{- if $config.tls.enabled }}
           - "--entryPoints.{{ $entrypoint }}.http.tls=true"
@@ -682,34 +710,6 @@
           - "--entryPoints.{{ $entrypoint }}.http.tls.domains[{{ $index }}].sans={{ join "," $domain.sans }}"
                     {{- end }}
                   {{- end }}
-                {{- end }}
-                {{- with $config.http }}
-                 {{- if ne .sanitizePath nil }}
-                  {{- with .sanitizePath | toString }}
-          - "--entryPoints.{{ $entrypoint }}.http.sanitizePath={{ . }}"
-                  {{- end }}
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedSlash }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedSlash={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedBackSlash }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedBackSlash={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedNullCharacter }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedNullCharacter={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedSemicolon }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedSemicolon={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedPercent }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedPercent={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedQuestionMark }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedQuestionMark={{ . }}"
-                 {{- end }}
-                 {{- with .encodedCharacters.allowEncodedHash }}
-          - "--entryPoints.{{ $entrypoint }}.http.encodedCharacters.allowEncodedHash={{ . }}"
-                 {{- end }}
                 {{- end }}
                 {{- if $config.http3 }}
                   {{- if $config.http3.enabled }}

--- a/traefik/tests/security-config_test.yaml
+++ b/traefik/tests/security-config_test.yaml
@@ -28,7 +28,7 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=false"
-  - it: should be possible to customize security arguments
+  - it: should be possible to customize security arguments on websecure
     set:
       ports:
         websecure:
@@ -67,4 +67,43 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=true"
+  - it: should be possible to customize security arguments on custom entrypoint
+    set:
+      ports:
+        foo:
+          http:
+            sanitizePath: false
+            encodedCharacters:
+              allowEncodedSlash: true
+              allowEncodedBackSlash: true
+              allowEncodedNullCharacter: true
+              allowEncodedSemicolon: true
+              allowEncodedPercent: true
+              allowEncodedQuestionMark: true
+              allowEncodedHash: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.sanitizePath=false"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedSlash=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedBackSlash=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedNullCharacter=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedSemicolon=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedPercent=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedQuestionMark=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedHash=true"
 


### PR DESCRIPTION
### What does this PR do?

Ensure it's possible to set those values on other entrypoints than just _websecure_

### Motivation

Fixes #1605


### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

