### PR TITLE
chore(release): 🚀 publish traefik 38.0.1

### DIFF
--- a/traefik-crds/Changelog.md
+++ b/traefik-crds/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.13.0  ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2025-12-17
+**Release date:** 2025-12-18
 
 * feat(CRDs): update Traefik Hub to v1.24.2
 * feat(CRDs): update Traefik Hub to v1.24.1, with required RBACs

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## 38.0.1  ![AppVersion: v3.6.5](https://img.shields.io/static/v1?label=AppVersion&message=v3.6.5&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2025-12-19
+
+* fix(ports): 🐛 add missing `http.maxHeaderBytes` option
+* fix(ports): 🐛 `http.encodedCharacters` on custom entrypoints
+* chore(release): 🚀 publish traefik 38.0.1
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 0ccdbae..f2a9f10 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -908,6 +908,8 @@ ports:
+         allowEncodedPercent: false
+         allowEncodedQuestionMark: false
+         allowEncodedHash: false
++      # -- Maximum size of request headers in bytes. Default: 1048576 (1 MB)
++      maxHeaderBytes:  # @schema type:[integer, null]; minimum:0
+       # -- See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#path-sanitization)
+       sanitizePath:  # @schema type:[boolean, null]
+     http3:
+```
+
 ## 38.0.0  ![AppVersion: v3.6.5](https://img.shields.io/static/v1?label=AppVersion&message=v3.6.5&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2025-12-17

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 38.0.0
+version: 38.0.1
 # renovate: image=traefik
 appVersion: v3.6.5
 kubeVersion: ">=1.22.0-0"
@@ -23,17 +23,6 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - "fix: update error message for maxUnavailable validation"
-    - "fix(pvc): allow empty storageClassName"
-    - "fix(providers): ✨ enforce schema for all providers"
-    - "fix(providers)!: align labelSelector for kubernetesGateway and knative"
-    - "fix(notes): minor typo"
-    - "fix(nginx)!: 🐛 align provider settings and provide required rbac"
-    - "feat(security): ✨ 🔒️ add support for request path options of traefik 3.6.4+"
-    - "feat(providers): ✨ enforce schema"
-    - "feat(ports): enforce schema"
-    - "feat(deps): update traefik docker tag to v3.6.5"
-    - "feat(deps): update traefik docker tag to v3.6.4"
-    - "feat(CRDs): update Traefik Hub to v1.24.2"
-    - "feat(CRDs): update Traefik Hub to v1.24.1, with required RBACs"
-    - "chore(release): 🚀 publish traefik 38.0.0 and crds 1.13.0"
+    - "fix(ports): 🐛 add missing `http.maxHeaderBytes` option"
+    - "fix(ports): 🐛 `http.encodedCharacters` on custom entrypoints"
+    - "chore(release): 🚀 publish traefik 38.0.1"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 38.0.0](https://img.shields.io/badge/Version-38.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.5](https://img.shields.io/badge/AppVersion-v3.6.5-informational?style=flat-square)
+![Version: 38.0.1](https://img.shields.io/badge/Version-38.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.5](https://img.shields.io/badge/AppVersion-v3.6.5-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Release a new version of the Traefik chart

### Motivation

Bug fixes discovered in v38.0.0