### PR TITLE
fix(CRDs): enforce the fact that this Chart does not support Traefik Hub v3.19.0

### DIFF
--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -118,7 +118,11 @@
     {{ $hubVersion = "v3.99" }}
   {{- end }}
 
-  {{- if and (semverCompare "<v3.9.0" $hubVersion) .Values.hub.tracing.additionalTraceHeaders.enabled }}
+  {{- if semverCompare ">v3.19.0-0" $hubVersion }}
+    {{ fail "ERROR: this Chart does not support Traefik Hub v3.19.0+."}}
+  {{- end }}
+
+  {{- if and (semverCompare "<v3.9.0-0" $hubVersion) .Values.hub.tracing.additionalTraceHeaders.enabled }}
     {{ fail "ERROR: additionalTraceHeaders is a feature only available for traefik-hub >= v3.9.0."}}
   {{- end }}
 
@@ -126,15 +130,15 @@
     {{ fail "ERROR: additionalTraceHeaders needs tracing.otlp to be enabled."}}
   {{- end }}
 
-  {{- if and (semverCompare "<v3.6.0" $hubVersion) .Values.hub.providers.consulCatalogEnterprise.enabled }}
+  {{- if and (semverCompare "<v3.6.0-0" $hubVersion) .Values.hub.providers.consulCatalogEnterprise.enabled }}
     {{ fail "ERROR: consulCatalogEnterprise provider is a feature only available for traefik-hub >= v3.6.0."}}
   {{- end }}
 
-  {{- if and (semverCompare "<v3.7.0" $hubVersion) .Values.hub.providers.microcks.enabled }}
+  {{- if and (semverCompare "<v3.7.0-0" $hubVersion) .Values.hub.providers.microcks.enabled }}
     {{ fail "ERROR: microcks provider is a feature only available for traefik-hub >= v3.7.0."}}
   {{- end }}
 
-  {{- if and (and .Values.hub.apimanagement.enabled (and .Values.rbac.enabled .Values.rbac.namespaced)) (semverCompare "<v3.16.0" $hubVersion) }}
+  {{- if and (and .Values.hub.apimanagement.enabled (and .Values.rbac.enabled .Values.rbac.namespaced)) (semverCompare "<v3.16.0-0" $hubVersion) }}
     {{- fail "ERROR: Traefik Hub < v3.16.0 doesn't support namespaced RBACs" -}}
   {{- end }}
 

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -23,12 +23,23 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: traefik-hub image is required when enabling Traefik Hub"
+  - it: should fail when trying to use this Chart with Traefik Hub v3.19.0+
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.0-ea.9
+      hub:
+        token: xxx
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: this Chart does not support Traefik Hub v3.19.0+."
   - it: should pass when trying to use this Chart with Traefik API gateway v3 and Hub enabled and providing a token
     set:
       image:
         registry: ghcr.io
         repository: traefik/traefik-hub
-        tag: latest-v3.0
+        tag: v3.18.3
       hub:
         token: "xxx"
     asserts:
@@ -310,28 +321,12 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: microcks provider is a feature only available for traefik-hub >= v3.7.0."
-  - it: should not fail when using hub.tracing.additionalTraceHeaders on Traefik Hub main builds
+  - it: should not fail when using hub.tracing.additionalTraceHeaders on Traefik Hub v3.10.1+
     set:
       image:
         registry: "ghcr.io"
         repository: "traefik/traefik-hub"
-        tag: main-1af57d3-1737730202
-      tracing:
-        otlp:
-          enabled: true
-      hub:
-        token: "xxx"
-        tracing:
-          additionalTraceHeaders:
-            enabled: true
-    asserts:
-      - notFailedTemplate: {}
-  - it: should not fail when using hub.tracing.additionalTraceHeaders on Traefik Hub latest v3 builds
-    set:
-      image:
-        registry: "ghcr.io"
-        repository: "traefik/traefik-hub"
-        tag: latest-v3
+        tag: v3.10.1
       tracing:
         otlp:
           enabled: true


### PR DESCRIPTION
### What does this PR do?

Fail install when trying to deploy Traefik Hub v3.19.0 with current CRDs of this Chart.

### Motivation

There is a breaking change on CRDs between Traefik Hub v3.18.0 and inferior and the CRDs of Traefik Hub v3.19.0+ preview versions (ea & rc).
With this PR and the [crd revert](https://github.com/traefik/traefik-helm-chart/pull/1615), we fix the issue for all users with stable version.

When Traefik Hub v3.19.0 is GA, we will release a new major version of this Chart, that will only accept Traefik Hub v3.19.0+ versions.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

