### PR TITLE
fix(security): set the seccomp profile to RuntimeDefault

### DIFF
--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1508,6 +1508,14 @@
                 },
                 "runAsUser": {
                     "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1163,6 +1163,8 @@ podSecurityContext:
   runAsGroup: 65532
   runAsNonRoot: true
   runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
 #
 # -- Extra objects to deploy (value evaluated as a template)


### PR DESCRIPTION
### What does this PR do?

It sets the seccomp profile to be `RuntimeDefault` rather than not being set.

### Motivation

A tool I've used to check for the security standards "Restricted" (https://kubernetes.io/docs/concepts/security/pod-security-standards/) triggered this, it was the only security change that needed attention.

### More

- [ ] ~~Yes, I updated the tests accordingly~~ I did not see any kind of tests for other security context settings other than the merging one.
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed