### PR TITLE
docs(CRDs): improve note on deprecation

### DIFF
--- a/traefik-crds/templates/NOTES.txt
+++ b/traefik-crds/templates/NOTES.txt
@@ -4,5 +4,5 @@ See https://github.com/traefik/traefik-helm-chart/issues/1561#issuecomment-37142
 
 In order to keep CRDs and uninstall this Traefik CRDs Chart, you can follow current upstream procedure:
 https://github.com/helm/helm/issues/8127#issuecomment-2196610968
-Setting the value `deleteOnUninstall` to `true` will automatically add the `helm.sh/resource-policy="keep"` annotation to all CRDs,
+Leaving the default value of `deleteOnUninstall` to `false` will automatically add the `helm.sh/resource-policy="keep"` annotation to all CRDs,
 which may help you in this process.


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
To allow 'safe' uninstalling of the now deprecated CRDs chart, this MR adds some additional context for uninstalling by pointing users towards the `deleteOnUninstall` flag we already provide.

### Motivation

<!-- What inspired you to submit this pull request? -->
See  https://github.com/traefik/traefik-helm-chart/pull/1617#discussion_r2683159229 (and me then finding out we already have this 😄)

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

