### PR TITLE
refactor(chart): clean output on Deployment & Daemonset

### DIFF
--- a/traefik/templates/daemonset.yaml
+++ b/traefik/templates/daemonset.yaml
@@ -55,5 +55,5 @@ spec:
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   {{- end }}
   {{/* This dual conversion is used to remove all spurious newlines */}}
-  template: {{ include "traefik.podTemplate" . | fromYaml | toYamlPretty | nindent 4 }}
+  template: {{ include "traefik.podTemplate" . | fromYaml | toYaml | nindent 4 }}
 {{- end -}}

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -63,5 +63,5 @@ spec:
   {{- end }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   {{/* This dual conversion is used to remove all spurious newlines */}}
-  template: {{ include "traefik.podTemplate" . | fromYaml | toYamlPretty | nindent 4 }}
+  template: {{ include "traefik.podTemplate" . | fromYaml | toYaml | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
### What does this PR do?

Clean YAML output.

**before**

```yaml
        volumeMounts:
          - name: data
            mountPath: /data
          - name: tmp
            mountPath: /tmp

        args:
          - "--entryPoints.metrics.address=:9100/tcp"
          - "--entryPoints.traefik.address=:8080/tcp"
          - "--entryPoints.web.address=:8000/tcp"
          - "--entryPoints.websecure.address=:8443/tcp"
          - "--api.dashboard=true"
          - "--ping=true"
          - "--metrics.prometheus=true"
          - "--metrics.prometheus.entrypoint=metrics"
        
        
          - "--providers.kubernetescrd"
          - "--providers.kubernetescrd.allowEmptyServices=true"
          - "--providers.kubernetesingress"
          - "--providers.kubernetesingress.allowEmptyServices=true"
          - "--providers.kubernetesingress.ingressendpoint.publishedservice=flux-system/traefik"
          
          
          - "--entryPoints.websecure.http.tls=true"
          - "--log.level=INFO"
        
        env:
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: USER
            value: traefik
```

**after**

```yaml
    spec:
      automountServiceAccountToken: true
      containers:
        - args:
            - --entryPoints.metrics.address=:9100/tcp
            - --entryPoints.traefik.address=:8080/tcp
            - --entryPoints.web.address=:8000/tcp
            - --entryPoints.websecure.address=:8443/tcp
            - --api.dashboard=true
            - --ping=true
            - --metrics.prometheus=true
            - --metrics.prometheus.entrypoint=metrics
            - --providers.kubernetescrd
            - --providers.kubernetescrd.allowEmptyServices=true
            - --providers.kubernetesingress
            - --providers.kubernetesingress.allowEmptyServices=true
            - --providers.kubernetesingress.ingressendpoint.publishedservice=flux-system/traefik
            - --entryPoints.websecure.http.tls=true
            - --log.level=INFO
          env:
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: POD_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: USER
              value: traefik
```

### Motivation

Even if it's valid YAML, those empty newlines do not bring anything.


### More

- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

