### PR TITLE
fix(ports): check in Gateway template wasn't updated to new syntax

### DIFF
--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end -}}
       {{ $found := false }}
       {{- range $portName, $portConfig := $.Values.ports -}}
-        {{- if eq $portConfig.port $config.port -}}
+        {{- if eq ($portConfig.http).port $config.port -}}
           {{ $found = true }}
         {{- end -}}
       {{- end -}}


### PR DESCRIPTION

### What does this PR do?

https://github.com/traefik/traefik-helm-chart/pull/1603 introduced a new syntax in the ports section. This wasn't reflected in the test included in the Gateway template, making it fail. This change updates the test to the new syntax.

### Motivation

Fix for https://github.com/traefik/traefik-helm-chart/issues/1636


### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed


