### PR TITLE
chore(ci): fix release workflow on branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'v*'
 
 env:
   tag_prefix: v


### PR DESCRIPTION
### What does this PR do?

Allow triggering the release workflow on v39.1 branch.

### Motivation

Avoid having to open again PR like https://github.com/traefik/traefik-helm-chart/pull/1655