### PR TITLE
fix: multicluster config parsing

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -907,10 +907,12 @@
                 {{- $childPath := printf "hub.providers.multicluster.children.%s" $childName }}
                 {{- include "traefik.yaml2CommandLineArgs" (dict "path" $childPath "content" (omit $childCfg "serversTransport")) | nindent 10 }}
                 {{- with get $childCfg "serversTransport" }}
-                  {{- include "traefik.yaml2CommandLineArgs" (dict "path" $childPath "content" (omit . "certificates")) | nindent 10 }}
-                  {{- range $idx, $val := get . "certificates" }}
-                    {{- $certPath := printf "hub.providers.multicluster.children.%s.serversTransport.certificates[%d]" $childName $idx }}
-                    {{- include "traefik.yaml2CommandLineArgs" (dict "path" $certPath "content" $val) | nindent 10 }}
+                  {{- include "traefik.yaml2CommandLineArgs" (dict "path" (printf "%s.serversTransport" $childPath) "content" (omit . "certificates")) | nindent 10 }}
+                  {{- with get . "certificates" }}
+                    {{- range $idx, $val := . }}
+                      {{- $certPath := printf "hub.providers.multicluster.children.%s.serversTransport.certificates[%d]" $childName $idx }}
+                      {{- include "traefik.yaml2CommandLineArgs" (dict "path" $certPath "content" $val) | nindent 10 }}
+                    {{- end }}
                   {{- end }}
                 {{- end }}
               {{- end }}

--- a/traefik/tests/hub-multicluster-config_test.yaml
+++ b/traefik/tests/hub-multicluster-config_test.yaml
@@ -15,15 +15,7 @@ tests:
               child2:
                 address: http://bar
                 serversTransport:
-                  rootCAs:
-                    - /certs/ca.crt
-                    - /certs/ca2.crt
-                  certificates:
-                    - certFile: /certs/client.crt
-                      keyFile: /certs/client.key
-                    - certFile: /certs/client2.crt
-                      keyFile: /certs/client2.key
-
+                  insecureSkipVerify: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -33,7 +25,39 @@ tests:
           content: "--hub.providers.multicluster.children.child1.address=http://foo"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.multicluster.children.child2.rootCAs=/certs/ca.crt,/certs/ca2.crt"
+          content: "--hub.providers.multicluster.children.child2.serversTransport.insecureSkipVerify=true"
+
+  - it: should be possible to configure Traefik Hub multicluster provider serversTransport certificates
+    set:
+      hub:
+        token: "xxx"
+        providers:
+          multicluster:
+            enabled: true
+            children:
+              child1:
+                address: http://foo
+              child2:
+                address: http://bar
+                serversTransport:
+                  rootCAs:
+                    - /certs/ca.crt
+                    - /certs/ca2.crt
+                  certificates:
+                    - certFile: /certs/client.crt
+                      keyFile: /certs/client.key
+                    - certFile: /certs/client2.crt
+                      keyFile: /certs/client2.key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.address=http://foo"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child2.serversTransport.rootCAs=/certs/ca.crt,/certs/ca2.crt"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.providers.multicluster.children.child2.serversTransport.certificates[0].certFile=/certs/client.crt"


### PR DESCRIPTION
### What does this PR do?

Fixes parsing of the multi-cluster provider configuration


### Motivation

Fix errors

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

