### PR TITLE
feat(helm/traefik): add controllerName to GatewayClass configuration

### DIFF
--- a/traefik/templates/gatewayclass.yaml
+++ b/traefik/templates/gatewayclass.yaml
@@ -10,5 +10,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  controllerName: traefik.io/gateway-controller
+  controllerName: {{ .Values.gatewayClass.controllerName }}
 {{- end }}

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -192,6 +192,8 @@ gatewayClass:  # @schema additionalProperties: false
   enabled: true
   # -- Set a custom name to GatewayClass
   name: ""
+  # -- Set a specific controllerName
+  controllerName: traefik.io/gateway-controller
   # -- Additional gatewayClass labels (e.g. for filtering gateway objects by custom labels)
   labels: {}
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the controllerName field of the GatewayClass configurable via Helm values.
It allows users to define a custom controllerName instead of relying on a fixed default, increasing flexibility when deploying Traefik with the Kubernetes Gateway API.

### Motivation

In clusters running more than one Traefik instance, each controller must be uniquely identified by its controllerName.
Without this flexibility, it is not possible to safely run multiple Gateway API controllers in the same cluster.

By exposing controllerName as a configurable value, this change enables:
Multiple Traefik instances in the same Kubernetes cluster
Clear separation of GatewayClasses per controller
Better support for advanced and multi-ingress architectures

### More

- [ ] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed