### PR TITLE
fix(gateway): setting port value for `websecure` listener can fail

### DIFF
--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -354,38 +354,6 @@
                                     "type": "integer"
                                 },
                                 "protocol": {
-                                    "description": "Specify expected protocol on this listener. See [ProtocolType](https://gateway-api.sigs.k8s.io/reference/spec/#protocoltype)",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "websecure": {
-                            "type": "object",
-                            "properties": {
-                                "certificateRefs": {
-                                    "description": "Reference to a Secret containing a certificate for `TLS` or `HTTPS` protocols (ignored for `mode:Passthrough`). See [SecretObjectReference](https://gateway-api.sigs.k8s.io/reference/spec/#secretobjectreference)"
-                                },
-                                "hostname": {
-                                    "description": "Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname)",
-                                    "type": "string"
-                                },
-                                "mode": {
-                                    "description": "TLS behavior for the TLS session initiated by the client. See [TLSModeType](https://gateway-api.sigs.k8s.io/reference/spec/#tlsmodetype).",
-                                    "type": "string"
-                                },
-                                "namespacePolicy": {
-                                    "description": "Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces",
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ]
-                                },
-                                "port": {
-                                    "description": "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. The port must match a port declared in ports section.",
-                                    "type": "integer"
-                                },
-                                "protocol": {
-                                    "description": "Specify expected protocol on this listener. See [ProtocolType](https://gateway-api.sigs.k8s.io/reference/spec/#protocoltype)",
                                     "type": "string"
                                 }
                             }


### PR DESCRIPTION
### What does this PR do?

This change fixes an error when trying to use the [pre-set `websecure` listener](https://artifacthub.io/packages/helm/traefik/traefik/39.0.1?modal=values&path=gateway.listeners) in the `traefik` chart values. Apparently, there is a [known issue](https://github.com/helm/helm/issues/11130) issue with `go-yaml` deserializing numbers into `float64` instead of `int64`, and [the usual workaround is to cast it manually to an `int` type](https://github.com/helm/helm/issues/13023).

I've also updated the JSON Schema to actually include support for the `gateway.listeners.websecure` object in addition to `gateway.listeners.web`, as it was previously missing – probably related to the fact that this value is optional and disabled by default, however the schema should include it anyway.

### Motivation

Currently, trying to use the pre-set `websecure` Gateway listener results in this error:

```console
$ helm template --set api.dashboard=false \
  --set providers.kubernetesGateway.enabled=true \
  --set gateway.listeners.web.namespacePolicy.from=All \
  --set gateway.listeners.websecure.namespacePolicy.from=All \
  --set gateway.listeners.websecure.port=8443 \
  --set gateway.listeners.websecure.protocol=TLS \
  --set gateway.listeners.websecure.mode=Passthrough \
  traefik ./traefik-39.0.1 # <- local template obtained via `helm pull traefik/traefik --version 39.0.1`
Error: template: traefik/templates/gateway.yaml:34:15: executing "traefik/templates/gateway.yaml" at <eq $portConfig.port $config.port>: error calling eq: incompatible types for comparison: float64 and int64
```

With this fix, the `Gateway` resource is correctly rendered:

```console
$ helm template --set api.dashboard=false \
  --set providers.kubernetesGateway.enabled=true \
  --set gateway.listeners.web.namespacePolicy.from=All \
  --set gateway.listeners.websecure.namespacePolicy.from=All \
  --set gateway.listeners.websecure.port=8443 \
  --set gateway.listeners.websecure.protocol=TLS \
  --set gateway.listeners.websecure.mode=Passthrough \
  --show-only templates/gateway.yaml \
  traefik ./traefik-helm-chart/traefik # <-- local Git repository fork including fix

---
# Source: traefik/templates/gateway.yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: traefik-gateway
  namespace: default
  labels:
    app.kubernetes.io/name: traefik
    app.kubernetes.io/instance: traefik-default
    helm.sh/chart: traefik-39.0.1
    app.kubernetes.io/managed-by: Helm
spec:
  gatewayClassName: traefik
  listeners:
    - name: web
      port: 8000
      protocol: HTTP
      allowedRoutes:
        namespaces:
          from: All


    - name: websecure
      port: 8443
      protocol: TLS
      allowedRoutes:
        namespaces:
          from: All


      tls:

        mode: Passthrough
```

### More

- [ ] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed