### PR TITLE
chore(ci): avoid pull request target

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -1,10 +1,15 @@
 name: 'Lint PR'
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
+      - reopened
       - edited
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
### What does this PR do?

Switch trigger from pull_request_target to pull_request

### Motivation

This trigger can be used for leak.


<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

