### PR TITLE
feat(ingress): add native ingressEndpoint hostname and ip support

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -422,6 +422,8 @@ Kubernetes: `>=1.22.0-0`
 | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
 | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
 | providers.kubernetesIngress.ingressClass | string | `nil` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |
+| providers.kubernetesIngress.ingressEndpoint.hostname | string | `""` | Hostname used for Kubernetes Ingress endpoints |
+| providers.kubernetesIngress.ingressEndpoint.ip | string | `""` | IP used for Kubernetes Ingress endpoints |
 | providers.kubernetesIngress.labelSelector | string | `nil` |  |
 | providers.kubernetesIngress.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesIngress.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -506,6 +506,12 @@
            {{- if or (and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled) (and .Values.providers.kubernetesIngress.publishedService.enabled .Values.providers.kubernetesIngress.publishedService.pathOverride)}}
           - "--providers.kubernetesingress.ingressendpoint.publishedservice={{ template "providers.kubernetesIngress.publishedServicePath" . }}"
            {{- end }}
+           {{- with .Values.providers.kubernetesIngress.ingressEndpoint.hostname }}
+          - "--providers.kubernetesingress.ingressendpoint.hostname={{ . }}"
+           {{- end }}
+           {{- with .Values.providers.kubernetesIngress.ingressEndpoint.ip }}
+          - "--providers.kubernetesingress.ingressendpoint.ip={{ . }}"
+           {{- end }}
            {{- if .Values.providers.kubernetesIngress.labelSelector }}
           - "--providers.kubernetesingress.labelSelector={{ .Values.providers.kubernetesIngress.labelSelector }}"
            {{- end }}

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -135,6 +135,36 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingress.ingressendpoint.publishedservice=traefik/custom-service"
+  - it: should not have ingressEndpoint hostname when default configuration
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.ingressendpoint.hostname"
+  - it: should have ingressEndpoint hostname when specified in configuration
+    set:
+      providers:
+        kubernetesIngress:
+          ingressEndpoint:
+            hostname: example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.ingressendpoint.hostname=example.com"
+  - it: should not have ingressEndpoint ip when default configuration
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.ingressendpoint.ip"
+  - it: should have ingressEndpoint ip when specified in configuration
+    set:
+      providers:
+        kubernetesIngress:
+          ingressEndpoint:
+            ip: 1.2.3.4
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.ingressendpoint.ip=1.2.3.4"
   - it: should not set default statusAddress when service is disabled
     set:
       service:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2335,6 +2335,26 @@
                                 "null"
                             ]
                         },
+                        "ingressEndpoint": {
+                            "type": "object",
+                            "properties": {
+                                "hostname": {
+                                    "description": "Hostname used for Kubernetes Ingress endpoints",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "ip": {
+                                    "description": "IP used for Kubernetes Ingress endpoints",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "labelSelector": {
                             "type": [
                                 "string",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -331,6 +331,12 @@ providers:
       # -- Override path of Kubernetes Service used to copy status from. Format: namespace/servicename.
       # Default to Service deployed with this Chart.
       pathOverride: ""
+    # @schema additionalProperties: false
+    ingressEndpoint:
+      # -- Hostname used for Kubernetes Ingress endpoints
+      hostname: ""  # @schema type:[string, null]
+      # -- IP used for Kubernetes Ingress endpoints
+      ip: ""  # @schema type:[string, null]
     # -- Defines whether to use Native Kubernetes load-balancing mode by default.
     nativeLBByDefault: false
     # -- Defines whether to make prefix matching strictly comply with the Kubernetes Ingress specification.


### PR DESCRIPTION
## What

Adds first-class `values.yaml` support for `providers.kubernetesIngress.ingressEndpoint.hostname` and `providers.kubernetesIngress.ingressEndpoint.ip`.

## Why

Currently, setting the Kubernetes Ingress endpoint hostname or IP requires raw CLI flags via `additionalArguments`:

```yaml
additionalArguments:
  - "--providers.kubernetesingress.ingressendpoint.hostname=example.com"
```

This is inconsistent with how `publishedService` is already exposed as a native value. The `ingressEndpoint.hostname` and `ingressEndpoint.ip` options are part of Traefik's [static configuration](https://doc.traefik.io/traefik/providers/kubernetes-ingress/#ingressendpoint) but have no corresponding Helm values.

## Changes

- **values.yaml**: Added `providers.kubernetesIngress.ingressEndpoint.hostname` and `providers.kubernetesIngress.ingressEndpoint.ip` (both default to empty string / disabled)
- **_podtemplate.tpl**: Conditionally renders `--providers.kubernetesingress.ingressendpoint.hostname` and `--providers.kubernetesingress.ingressendpoint.ip` when set
- **tests**: Added 4 test cases covering default (not set) and explicit values for both hostname and ip

## Usage

```yaml
providers:
  kubernetesIngress:
    publishedService:
      enabled: false
    ingressEndpoint:
      hostname: "ingress.example.com"
```

This is useful when using an internal load balancer that assigns an IP rather than a hostname, and you need to explicitly set the hostname that appears in Ingress resource status.