### PR TITLE
feat: support templated values in service annotations

### DIFF
--- a/traefik/templates/service.yaml
+++ b/traefik/templates/service.yaml
@@ -50,7 +50,7 @@ metadata:
   {{- template "traefik.service-metadata" (dict "root" $ "service" $service) }}
   annotations:
   {{- with (merge dict (default dict $service.annotationsTCP) (default dict $service.annotations)) }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}
@@ -73,7 +73,7 @@ metadata:
   {{- template "traefik.service-metadata" (dict "root" $ "service" $service) }}
   annotations:
   {{- with (merge dict (default dict $service.annotationsUDP) (default dict $service.annotations)) }}
-  {{- toYaml . | nindent 4 }}
+  {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- template "traefik.service-spec" (dict "root" $ "service" $service) }}

--- a/traefik/tests/service-config_test.yaml
+++ b/traefik/tests/service-config_test.yaml
@@ -51,6 +51,17 @@ tests:
       - equal:
           path: metadata.annotations.azure-load-balancer-internal
           value: true
+  - it: should support templated annotations
+    release:
+      name: my-traefik
+    set:
+      service:
+        annotations:
+          custom-annotation: '{{ template "traefik.fullname" . }}.example.com'
+    asserts:
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: my-traefik.example.com
   - it: should have customized labels when specified via values
     set:
       service:


### PR DESCRIPTION
## Summary

Wraps service annotation rendering with `tpl` to allow Helm template expressions in annotation values. This enables dynamic annotations based on release name, chart helpers, or other template functions.

### Example use case

```yaml
service:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: '{{ template "traefik.fullname" . }}.example.com'
```

### Changes
- `templates/service.yaml`: Replace `toYaml` with `tpl (toYaml .)` for both TCP and UDP service annotations
- `tests/service-config_test.yaml`: Add test verifying templated annotation values are correctly rendered

### Notes
- The `tpl` pattern is already used elsewhere in the chart (HPA `scaleTargetRef.name`, ServiceMonitor `metricRelabelings`)
- Static annotation values continue to work exactly as before — `tpl` is a no-op when no template expressions are present
- Both TCP and UDP service annotations are covered