### PR TITLE
chore(release): publish v39.0.4

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 39.0.4  ![AppVersion: v3.6.9](https://img.shields.io/static/v1?label=AppVersion&message=v3.6.9&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2026-03-05
+
+* fix(deps): bump traefik.io CRDs to release v3.6.9
+* chore(release): publish v39.0.4
+
 ## 39.0.3  ![AppVersion: v3.6.9](https://img.shields.io/static/v1?label=AppVersion&message=v3.6.9&color=success&logo=) ![Kubernetes: >=1.22.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.22.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2026-03-05

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 39.0.3
+version: 39.0.4
 # renovate: image=traefik
 appVersion: v3.6.9
 kubeVersion: ">=1.22.0-0"
@@ -23,7 +23,5 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   artifacthub.io/changes: |
-    - "fix: remove `rbac.secretResourceNames`"
-    - "feat(deps): update traefik docker tag to v3.6.9"
-    - "docs(example): anchors on trustedIPs with schema enforced"
-    - "chore(release): :rocket: publish v39.0.3"
+    - "fix(deps): bump traefik.io CRDs to release v3.6.9"
+    - "chore(release): publish v39.0.4"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 39.0.3](https://img.shields.io/badge/Version-39.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.9](https://img.shields.io/badge/AppVersion-v3.6.9-informational?style=flat-square)
+![Version: 39.0.4](https://img.shields.io/badge/Version-39.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.9](https://img.shields.io/badge/AppVersion-v3.6.9-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Release a new version.

### Motivation

There is CRD update in v3.6.9 that was missed in v39.0.3.
