### PR TITLE
chore(ci): upgrade helm unittest to 1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMAGE_CHART_TESTING=quay.io/helmpack/chart-testing:v3.14.0
 IMAGE_HELM_CHANGELOG=ghcr.io/traefik/helm-changelog:v0.3.0
 IMAGE_HELM_DOCS=jnorwood/helm-docs:v1.14.2
-IMAGE_HELM_UNITTEST=docker.io/helmunittest/helm-unittest:3.17.2-0.8.0
+IMAGE_HELM_UNITTEST=docker.io/helmunittest/helm-unittest:3.19.0-1.0.1
 
 traefik/tests/__snapshot__:
 	@mkdir traefik/tests/__snapshot__
@@ -24,6 +24,9 @@ lint:
 docs:
 	docker run --rm -v "$(CURDIR):/helm-docs" $(IMAGE_HELM_DOCS) -o VALUES.md
 
+# To launch only one test
+# $ helm plugin install https://github.com/helm-unittest/helm-unittest
+# $ helm unittest -f 'tests/oci-config_test.yaml' traefik
 test-%:
 	docker run ${DOCKER_ARGS} --network=host --env GIT_SAFE_DIR="true" --entrypoint /bin/sh --rm -v $(CURDIR):/charts -v $(HOME)/.kube:/root/.kube -w /charts $(IMAGE_CHART_TESTING) /charts/hack/ct.sh $*
 

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -327,7 +327,7 @@ tests:
         namespaces: null
     asserts:
       - failedTemplate:
-          errorPattern: "namespaces is required"
+          errorPattern: "values don't meet the specifications of the schema"
   - it: should fail when using otlp logs without experimental flag
     set:
       logs:


### PR DESCRIPTION
### What does this PR do?

Update helm-unittest to 1.0.1 with helm v3.19

### Motivation

Last update was in April 2025.
Cannot update to latest version (1.0.3) because we would face this issue:
https://github.com/helm-unittest/helm-unittest/issues/761

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

