### PR TITLE
fix: :art: align chart and traefik case on CLI for yaml2CommandLineArgs

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -247,14 +247,14 @@ Hash: {{ sha1sum ($cert.Cert | b64enc) }}
 {{- end -}}
 
 {{- define "traefik.yaml2CommandLineArgsRec" -}}
-    {{- $path := .path -}}
+    {{- $path := lower .path -}}
     {{- range $key, $value := .content -}}
         {{- if kindIs "map" $value }}
-          {{- include "traefik.yaml2CommandLineArgsRec" (dict "path" (printf "%s.%s" $path $key) "content" $value) -}}
+          {{- include "traefik.yaml2CommandLineArgsRec" (dict "path" (printf "%s.%s" $path (lower $key)) "content" $value) -}}
         {{- else if and (kindIs "bool" $value) (ne $value nil) }}
---{{ join "." (list $path $key)}}={{ $value }}
+--{{ join "." (list $path (lower $key))}}={{ $value }}
         {{- else if not (empty $value) }}
---{{ join "." (list $path $key)}}={{ if kindIs "slice" $value }}{{ join "," $value }}{{ else }}{{ $value }}{{ end }}
+--{{ join "." (list $path (lower $key))}}={{ if kindIs "slice" $value }}{{ join "," $value }}{{ else }}{{ $value }}{{ end }}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/traefik/tests/api_test.yaml
+++ b/traefik/tests/api_test.yaml
@@ -12,7 +12,7 @@ tests:
           content: "--ping=true"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--api.basePath=/"
+          content: "--api.basepath=/"
 
   - it: should generate generic api arguments
     set:
@@ -34,7 +34,7 @@ tests:
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--api.basePath="
+          content: "--api.basepath="
 
   - it: should generate basePath flag when set to a value
     set:
@@ -43,7 +43,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--api.basePath=/foo"
+          content: "--api.basepath=/foo"
 
   - it: should fail if ingressRoute.dashboard is enabled but api.dashboard is false
     set:

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -296,7 +296,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--api.basePath=/proxy"
+          content: "--api.basepath=/proxy"
   - it: should be possible to send anonymous usage data
     set:
       global:

--- a/traefik/tests/hub-apigateway-config_test.yaml
+++ b/traefik/tests/hub-apigateway-config_test.yaml
@@ -294,16 +294,16 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.tracing.additionalTraceHeaders.traceContext.parentId=parentId"
+          content: "--hub.tracing.additionaltraceheaders.tracecontext.parentid=parentId"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.tracing.additionalTraceHeaders.traceContext.traceId=traceId"
+          content: "--hub.tracing.additionaltraceheaders.tracecontext.traceid=traceId"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.tracing.additionalTraceHeaders.traceContext.traceParent=traceParent"
+          content: "--hub.tracing.additionaltraceheaders.tracecontext.traceparent=traceParent"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.tracing.additionalTraceHeaders.traceContext.traceState=traceState"
+          content: "--hub.tracing.additionaltraceheaders.tracecontext.tracestate=traceState"
   - it: should be possible to configure Traefik Hub microcks provider
     set:
       hub:
@@ -315,7 +315,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.providers.microcks.endpoint=http://microcks.svc"
-  - it: should be possible to configure Traefik Hub consulCatalogEnterprise provider
+  - it: should be possible to configure Traefik Hub consulcatalogenterprise" provider
     set:
       hub:
         providers:
@@ -353,79 +353,79 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.cache=true"
+          content: "--hub.providers.consulcatalogenterprise.cache=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.connectAware=true"
+          content: "--hub.providers.consulcatalogenterprise.connectaware=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.connectByDefault=true"
+          content: "--hub.providers.consulcatalogenterprise.connectbydefault=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.constraints=constraints"
+          content: "--hub.providers.consulcatalogenterprise.constraints=constraints"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.defaultRule=defaultRule"
+          content: "--hub.providers.consulcatalogenterprise.defaultrule=defaultRule"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.address=address"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.address=address"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.datacenter=datacenter"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.datacenter=datacenter"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.endpointWaitTime=1"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.endpointwaittime=1"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.httpauth.password=password"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.httpauth.password=password"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.httpauth.username=username"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.httpauth.username=username"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.scheme=scheme"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.scheme=scheme"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.tls.ca=ca"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.tls.ca=ca"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.tls.cert=cert"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.tls.cert=cert"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.tls.insecureSkipVerify=true"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.tls.key=key"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.tls.key=key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.endpoint.token=token"
+          content: "--hub.providers.consulcatalogenterprise.endpoint.token=token"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.namespaces=namespaces"
+          content: "--hub.providers.consulcatalogenterprise.namespaces=namespaces"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.partition=partition"
+          content: "--hub.providers.consulcatalogenterprise.partition=partition"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.prefix=prefix"
+          content: "--hub.providers.consulcatalogenterprise.prefix=prefix"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.refreshInterval=2"
+          content: "--hub.providers.consulcatalogenterprise.refreshinterval=2"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.requireConsistent=true"
+          content: "--hub.providers.consulcatalogenterprise.requireconsistent=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.serviceName=serviceName"
+          content: "--hub.providers.consulcatalogenterprise.servicename=serviceName"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.stale=true"
+          content: "--hub.providers.consulcatalogenterprise.stale=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.strictChecks=strictChecks"
+          content: "--hub.providers.consulcatalogenterprise.strictchecks=strictChecks"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--hub.providers.consulCatalogEnterprise.watch=true"
+          content: "--hub.providers.consulcatalogenterprise.watch=true"
   - it: should be possible to configure Traefik Hub plugin sources
     set:
       hub:

--- a/traefik/tests/metrics-config_test.yaml
+++ b/traefik/tests/metrics-config_test.yaml
@@ -374,7 +374,7 @@ tests:
           content: "--metrics.otlp.http.tls.key=path/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--metrics.otlp.http.tls.insecureSkipVerify=true"
+          content: "--metrics.otlp.http.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.grpc=true"
@@ -401,7 +401,7 @@ tests:
           content: "--metrics.otlp.grpc.tls.key=gpath/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--metrics.otlp.grpc.tls.insecureSkipVerify=true"
+          content: "--metrics.otlp.grpc.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--metrics.otlp.resourceAttributes.foo=bar"

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -434,34 +434,34 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.email=email@example.com"
+          content: "--certificatesresolvers.myacmeresolver.acme.email=email@example.com"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.dnsChallenge.provider=myProvider"
+          content: "--certificatesresolvers.myacmeresolver.acme.dnschallenge.provider=myProvider"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.dnsChallenge.resolvers=1.1.1.1,8.8.8.8"
+          content: "--certificatesresolvers.myacmeresolver.acme.dnschallenge.resolvers=1.1.1.1,8.8.8.8"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.tlsChallenge.delay=42"
+          content: "--certificatesresolvers.myacmeresolver.acme.tlschallenge.delay=42"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.emailaddresses=foo@example.com,bar@example.org"
+          content: "--certificatesresolvers.myacmeresolver.acme.emailaddresses=foo@example.com,bar@example.org"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.profile=tlsserver"
+          content: "--certificatesresolvers.myacmeresolver.acme.profile=tlsserver"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.httpChallenge.delay=12"
+          content: "--certificatesresolvers.myacmeresolver.acme.httpchallenge.delay=12"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.clientResponseHeaderTimeout=1m"
+          content: "--certificatesresolvers.myacmeresolver.acme.clientresponseheadertimeout=1m"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.clientTimeout=1m"
+          content: "--certificatesresolvers.myacmeresolver.acme.clienttimeout=1m"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.myAcmeResolver.acme.disableCommonName=true"
+          content: "--certificatesresolvers.myacmeresolver.acme.disablecommonname=true"
 
 
   - it: should have the distributed acme resolver options applied
@@ -477,13 +477,13 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.my-resolver.distributedAcme.email=email@example.com"
+          content: "--certificatesresolvers.my-resolver.distributedacme.email=email@example.com"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.my-resolver.distributedAcme.storage.kubernetes=true"
+          content: "--certificatesresolvers.my-resolver.distributedacme.storage.kubernetes=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--certificatesresolvers.my-resolver.distributedAcme.httpChallenge.entrypoint=web"
+          content: "--certificatesresolvers.my-resolver.distributedacme.httpchallenge.entrypoint=web"
 
   - it: should have the tailscale resolver options applied
     set:
@@ -522,7 +522,7 @@ tests:
           content: "--ocsp=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--ocsp.responderOverrides.foo=bar"
+          content: "--ocsp.responderoverrides.foo=bar"
 
   - it: should have prometheus annotations with specified values
     set:
@@ -909,7 +909,7 @@ tests:
           content: "--log.otlp.http.tls.key=path/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--log.otlp.http.tls.insecureSkipVerify=true"
+          content: "--log.otlp.http.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--log.otlp.grpc=true"
@@ -936,7 +936,7 @@ tests:
           content: "--log.otlp.grpc.tls.key=gpath/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--log.otlp.grpc.tls.insecureSkipVerify=true"
+          content: "--log.otlp.grpc.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--log.otlp.resourceAttributes.foo=bar"
@@ -1087,7 +1087,7 @@ tests:
           content: "--accesslog.otlp.http.tls.key=path/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--accesslog.otlp.http.tls.insecureSkipVerify=true"
+          content: "--accesslog.otlp.http.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.otlp.grpc=true"
@@ -1114,7 +1114,7 @@ tests:
           content: "--accesslog.otlp.grpc.tls.key=gpath/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--accesslog.otlp.grpc.tls.insecureSkipVerify=true"
+          content: "--accesslog.otlp.grpc.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.otlp.resourceAttributes.foo=bar"

--- a/traefik/tests/security-config_test.yaml
+++ b/traefik/tests/security-config_test.yaml
@@ -28,25 +28,25 @@ tests:
           content: "--entryPoints.websecure.http.sanitizePath=true"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedSlash=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedslash=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedBackSlash=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedbackslash=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedNullCharacter=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodednullcharacter=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedSemicolon=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedsemicolon=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedPercent=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedpercent=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedQuestionMark=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedquestionmark=false"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=false"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedhash=false"
   - it: should be possible to customize security arguments on websecure
     set:
       ports:
@@ -67,25 +67,25 @@ tests:
           content: "--entryPoints.websecure.http.sanitizePath=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedSlash=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedslash=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedBackSlash=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedbackslash=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedNullCharacter=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodednullcharacter=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedSemicolon=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedsemicolon=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedPercent=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedpercent=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedQuestionMark=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedquestionmark=true"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.websecure.http.encodedCharacters.allowEncodedHash=true"
+          content: "--entrypoints.websecure.http.encodedcharacters.allowencodedhash=true"
   - it: should be possible to customize security arguments on custom entrypoint
     set:
       ports:
@@ -106,22 +106,22 @@ tests:
           content: "--entryPoints.foo.http.sanitizePath=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedSlash=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedslash=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedBackSlash=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedbackslash=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedNullCharacter=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodednullcharacter=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedSemicolon=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedsemicolon=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedPercent=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedpercent=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedQuestionMark=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedquestionmark=false"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--entryPoints.foo.http.encodedCharacters.allowEncodedHash=false"
+          content: "--entrypoints.foo.http.encodedcharacters.allowencodedhash=false"

--- a/traefik/tests/tracing-config_test.yaml
+++ b/traefik/tests/tracing-config_test.yaml
@@ -96,7 +96,7 @@ tests:
           content: "--tracing.otlp.http.tls.key=path/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--tracing.otlp.http.tls.insecureSkipVerify=true"
+          content: "--tracing.otlp.http.tls.insecureskipverify=true"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--tracing.otlp.grpc=true"
@@ -123,7 +123,7 @@ tests:
           content: "--tracing.otlp.grpc.tls.key=gpath/to/foo.key"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--tracing.otlp.grpc.tls.insecureSkipVerify=true"
+          content: "--tracing.otlp.grpc.tls.insecureskipverify=true"
   - it: should render --tracing.sampleRate=0 when tracing.sampleRate is 0
     set:
       tracing:


### PR DESCRIPTION
### What does this PR do?

This PR updates the helper `yaml2CommandLineArgs` to generate CLI args which matches traefik ones (even if traefik handles case conversion).
<!-- A brief description of the change being made with this pull request. -->


### Motivation

Align chart and traefik CLI.
<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

