### PR TITLE
test(acme): add certificateTimeout option coverage

### DIFF
--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -404,6 +404,7 @@ tests:
           acme:
             email: email@example.com
             emailaddresses: foo@example.com,bar@example.org
+            certificateTimeout: 60s
             clientResponseHeaderTimeout: 1m
             clientTimeout: 1m
             disableCommonName: true
@@ -445,6 +446,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--certificatesresolvers.myAcmeResolver.acme.clientTimeout=1m"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--certificatesresolvers.myAcmeResolver.acme.certificateTimeout=60s"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--certificatesresolvers.myAcmeResolver.acme.disableCommonName=true"


### PR DESCRIPTION
### What does this PR do?

This PR adds test coverage for the ACME `certificateTimeout` option introduced in Traefik v3.7.

### Motivation

Support v3.7.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed