### PR TITLE
feat(logs): add accesslog.dualOutput option

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -205,6 +205,7 @@ Kubernetes: `>=1.25.0-0`
 | livenessProbe.timeoutSeconds | int | `2` | The number of seconds to wait for a probe response before considering it as failed. |
 | logs.access.addInternals | bool | `false` | Enables accessLogs for internal resources. Default: false. |
 | logs.access.bufferingSize | string | `nil` | Set [bufferingSize](https://doc.traefik.io/traefik/observability/access-logs/#bufferingsize) |
+| logs.access.dualOutput | bool | `false` | Enables access log output alongside OTLP (v3.7+). |
 | logs.access.enabled | bool | `false` | To enable access logs |
 | logs.access.fields.general.defaultmode | string | `"keep"` | Set default mode for fields.names |
 | logs.access.fields.general.names | object | `{}` | Names of the fields to limit. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -741,6 +741,9 @@
               {{- if .access.addInternals }}
           - "--accesslog.addinternals"
               {{- end }}
+              {{- if .access.dualOutput }}
+          - "--accesslog.dualOutput=true"
+              {{- end }}
               {{- with .access.bufferingSize }}
           - "--accesslog.bufferingsize={{ . }}"
               {{- end }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -34,6 +34,10 @@
   {{- fail "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true." }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.0-0" $version) .Values.logs.access.dualOutput }}
+  {{- fail "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0." }}
+{{- end }}
+
 {{- if and (semverCompare "<v3.6.4-0" $version) (or
     (eq .Values.ports.websecure.http.sanitizePath false)
     .Values.ports.websecure.http.encodedCharacters.allowEncodedSlash

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -272,6 +272,16 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: request path security options are only available for traefik >= v3.6.4."
+  - it: should fail when using accesslog dualOutput on traefik < 3.7.0
+    set:
+      image:
+        tag: v3.6.10
+      logs:
+        access:
+          dualOutput: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0."
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -950,6 +950,19 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.filters.statuscodes=200,300-302"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--accesslog.dualOutput=true"
+  - it: should be possible to enable access log dualOutput
+    set:
+      logs:
+        access:
+          enabled: true
+          dualOutput: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--accesslog.dualOutput=true"
   - it: should set custom startupProbe
     set:
       startupProbe:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1064,6 +1064,10 @@
                                 "null"
                             ]
                         },
+                        "dualOutput": {
+                            "description": "Enables access log output alongside OTLP (v3.7+).",
+                            "type": "boolean"
+                        },
                         "enabled": {
                             "description": "To enable access logs",
                             "type": "boolean"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -514,6 +514,8 @@ logs:
       minduration: ""
     # -- Enables accessLogs for internal resources. Default: false.
     addInternals: false
+    # -- Enables access log output alongside OTLP (v3.7+).
+    dualOutput: false
     fields:
       general:
         # -- Set default mode for fields.names


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the `accesslog.dualOutput` option introduced in Traefik v3.7, enabling access log output alongside OTLP.

### Motivation

Support v3.7.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed