### PR TITLE
fix(traefik): normalize ingressroute names

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -134,6 +134,20 @@ See also the traefik.portname helper.
 {{- end -}}
 
 {{/*
+Change input to a valid RFC 1123 resource name fragment.
+*/}}
+{{- define "traefik.rfc1123name" -}}
+{{- $name := . | toString | lower -}}
+{{- $name = regexReplaceAll "[^a-z0-9.-]+" $name "-" -}}
+{{- $name = regexReplaceAll "-+" $name "-" -}}
+{{- $name = trimAll "-." $name -}}
+{{- if eq $name "" -}}
+{{- fail "ERROR: ingressRoute name must contain at least one lowercase alphanumeric character" -}}
+{{- end -}}
+{{- print $name -}}
+{{- end -}}
+
+{{/*
 Construct the path for the providers.kubernetesingress.ingressendpoint.publishedservice.
 By convention this will simply use the <namespace>/<service-name> to match the name of the
 service generated.

--- a/traefik/templates/ingressroute.yaml
+++ b/traefik/templates/ingressroute.yaml
@@ -9,7 +9,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: {{ $.Release.Name }}-{{ $name }}
+  name: {{ include "traefik.rfc1123name" (printf "%s-%s" $.Release.Name $name) }}
   namespace: {{ template "traefik.namespace" $ }}
   {{- with $annotations }}
   annotations:

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -21,7 +21,7 @@ tests:
       value: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
   - equal:
       path: metadata.name
-      value: RELEASE-NAME-dashboard
+      value: release-name-dashboard
 - it: should support overwriting the route match rule
   set:
     ingressRoute:

--- a/traefik/tests/unsupported-ingressroute_test.yaml
+++ b/traefik/tests/unsupported-ingressroute_test.yaml
@@ -12,4 +12,18 @@ tests:
       count: 1
   - equal:
       path: metadata.name
-      value: RELEASE-NAME-api
+      value: release-name-api
+
+- it: should lowercase unsupported ingressroute names to RFC 1123
+  release:
+    name: release-name
+  set:
+    ingressRoute:
+      kubernetesCRD:
+        enabled: true
+        matchRule: PathPrefix(`/crd`)
+        entryPoints: ["web"]
+  asserts:
+  - equal:
+      path: metadata.name
+      value: release-name-kubernetescrd


### PR DESCRIPTION
## What this changes
- normalize generated `IngressRoute` resource names to valid RFC 1123 lowercase names
- cover the existing dashboard expectation with the normalized output
- add a regression test for unsupported/custom ingress route keys like `kubernetesCRD`

## Why
`ingressRoute` entries such as `kubernetesCRD` and `kubernetesIngress` currently render names with uppercase characters, which makes Kubernetes reject the generated resources as invalid RFC 1123 names.

## Reproduction evidence
Before:
```text
FAIL unsupported IngressRoute configuration traefik/tests/unsupported-ingressroute_test.yaml
- should not fail when enabling an unsupported IngressRoute
  Expected metadata.name: RELEASE-NAME-api
  Actual: release-name-api
```
This exposed that the suite still expected uppercase release-name output, while the reported bug requires lowercase RFC 1123 names.

Targeted failing regression before the fix:
```text
FAIL Dashboard/unsupported ingressroute name expectations
Expected: release-name-dash_board / release-name-kubernetescrd
Actual:   release-name-Dash_Board / release-name-kubernetesCRD
```

After:
```text
PASS Dashboard IngressRoute configuration traefik/tests/dashboard-ingressroute_test.yaml
PASS unsupported IngressRoute configuration traefik/tests/unsupported-ingressroute_test.yaml
```

## Testing
- `/tmp/clawoss-bin-1732/linux-amd64/helm unittest ./traefik -f tests/dashboard-ingressroute_test.yaml`
- `/tmp/clawoss-bin-1732/linux-amd64/helm unittest ./traefik -f tests/unsupported-ingressroute_test.yaml`

Closes #1732.
