### PR TITLE
fix(traefik): allow any extraValues for templating in extraObjects

### DIFF
--- a/traefik/tests/extra-config_test.yaml
+++ b/traefik/tests/extra-config_test.yaml
@@ -18,3 +18,14 @@ tests:
       - equal:
           path: data.something
           value: "templated"
+  - it: should render extraValues in extra objects
+    values:
+      - ./values/extra.yaml
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: data.myKey
+          value: "myValue"
+      - equal:
+          path: data.nested
+          value: "nestedValue"

--- a/traefik/tests/values/extra.yaml
+++ b/traefik/tests/values/extra.yaml
@@ -12,3 +12,16 @@ extraObjects:
       name: "templated"
     data:
       something: {{ printf "templated" }}
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: "from-extra-values"
+    data:
+      myKey: {{ .Values.extraValues.myKey }}
+      nested: {{ .Values.extraValues.nested.deep }}
+
+extraValues:
+  myKey: myValue
+  nested:
+    deep: nestedValue

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -308,6 +308,11 @@
             "description": "Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example.",
             "type": "array"
         },
+        "extraValues": {
+            "description": "Extra values to pass to the templates in extraObjects.",
+            "type": "object",
+            "additionalProperties": true
+        },
         "fullnameOverride": {
             "description": "Overrides the resource name for templates (i.e deployment, service, etc..)",
             "type": "string"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1209,6 +1209,9 @@ podSecurityContext:
 # See #595 for more details and traefik/tests/values/extra.yaml for example.
 extraObjects: []
 
+# -- Extra values to pass to the templates in extraObjects.
+extraValues: {}
+
 # -- This field overrides the default Release Namespace for Helm.
 # It will not affect optional CRDs such as `ServiceMonitor` and `PrometheusRules`
 namespaceOverride: ""


### PR DESCRIPTION
### What does this PR do?

Added extraValues to the JSON schema as an open object (additionalProperties: true), enabling users to pass any custom key-value pairs that can be referenced inside extraObjects templates via {{ .Values.extraValues.* }}.

### Motivation

Fixes https://github.com/traefik/traefik-helm-chart/issues/1738

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
