### PR TITLE
fix(traefik): lowercase ingressroute names

### DIFF
--- a/traefik/templates/ingressroute.yaml
+++ b/traefik/templates/ingressroute.yaml
@@ -9,7 +9,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: {{ $.Release.Name }}-{{ $name }}
+  name: {{ $.Release.Name }}-{{ $name | lower }}
   namespace: {{ template "traefik.namespace" $ }}
   {{- with $annotations }}
   annotations:

--- a/traefik/tests/ingressroute-name_test.yaml
+++ b/traefik/tests/ingressroute-name_test.yaml
@@ -1,0 +1,19 @@
+suite: ingressroute naming
+templates:
+  - ingressroute.yaml
+tests:
+  - it: lowercases custom ingressroute keys to RFC 1123-compatible output
+    set:
+      ingressRoute:
+        MyRoute:
+          enabled: true
+          entryPoints:
+            - traefik
+          matchRule: PathPrefix(`/demo`)
+          services:
+            - name: api@internal
+              kind: TraefikService
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-myroute


### PR DESCRIPTION
## Why
The chart currently uses the raw `ingressRoute` map key in `metadata.name`. If a user provides a mixed-case key, the rendered `IngressRoute` name violates RFC 1123 naming requirements for Kubernetes resources.

A maintainer also pointed to the existing chart-name sanitization helper as the expected direction for this issue.

## What changed
- lowercase the `IngressRoute` name suffix derived from the values key
- add a unit test that reproduces the mixed-case input and verifies RFC 1123-compatible output

## Verification
Passing targeted checks:
```text
helm unittest ./traefik -f tests/ingressroute-name_test.yaml
helm template demo ./traefik --set ingressRoute.MyRoute.enabled=true --set ingressRoute.MyRoute.matchRule='PathPrefix(`/demo`)' --set ingressRoute.MyRoute.entryPoints[0]=traefik --set ingressRoute.MyRoute.services[0].name=api@internal --set ingressRoute.MyRoute.services[0].kind=TraefikService
```

Notes:
- `helm unittest ./traefik` still reports pre-existing failures in `traefik/tests/notes_test.yaml` in this checkout; this PR does not touch `NOTES.txt`.

Closes #1732
