### PR TITLE
feat(deployment): add hostUsers support

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -55,6 +55,7 @@ Kubernetes: `>=1.25.0-0`
 | deployment.healthchecksPort | string | `nil` |  |
 | deployment.healthchecksScheme | string | `nil` |  |
 | deployment.hostAliases | list | `[]` | Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) |
+| deployment.hostUsers | string | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | deployment.imagePullSecrets | list | `[]` | Pull secret for fetching traefik container image |
 | deployment.initContainers | list | `[]` | Additional initContainers (e.g. for setting file permission as shown below) |
 | deployment.kind | string | `"Deployment"` | Deployment or DaemonSet |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -33,6 +33,9 @@
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: {{ default 60 .Values.deployment.terminationGracePeriodSeconds }}
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- if not (kindIs "invalid" .Values.deployment.hostUsers) }}
+      hostUsers: {{ .Values.deployment.hostUsers }}
+      {{- end }}
       {{- with .Values.deployment.dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -271,6 +271,26 @@ tests:
       - equal:
           path: spec.template.spec.shareProcessNamespace
           value: true
+  - it: should set hostUsers to false when configured
+    set:
+      deployment:
+        hostUsers: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false
+  - it: should set hostUsers to true when configured
+    set:
+      deployment:
+        hostUsers: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+  - it: should not set hostUsers when unset
+    asserts:
+      - isNull:
+          path: spec.template.spec.hostUsers
   - it: should have customized labels when specified via values
     set:
       deployment:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -180,6 +180,13 @@
                     "description": "Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)",
                     "type": "array"
                 },
+                "hostUsers": {
+                    "description": "Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "imagePullSecrets": {
                     "description": "Pull secret for fetching traefik container image",
                     "type": "array"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -81,6 +81,12 @@ deployment:
   #       mountPath: /data
   # -- Use process namespace sharing
   shareProcessNamespace: false
+  # @schema type: [boolean, null]
+  # -- Whether to use the host user namespace. Setting this to false enables user namespaces,
+  # which can improve security by isolating the pod's users from the host.
+  # See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+  # @default -- unset (inherits cluster default)
+  hostUsers:
   # -- Custom pod DNS policy. Apply if `hostNetwork: true`
   dnsPolicy: ""
   # -- Custom pod [DNS config](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#poddnsconfig-v1-core)


### PR DESCRIPTION
## Summary

- Add `deployment.hostUsers` value to allow setting [`hostUsers`](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) on the Traefik pod spec
- Setting `hostUsers: false` enables Kubernetes user namespace isolation, reducing the blast radius of a pod compromise
- Left **unset by default** to avoid breaking installations using storage types without idmap support or `hostNetwork` mode
- Schema allows `boolean | null` so the field is truly optional
- Added unit test coverage: set to `true`, set to `false`, and unset

Closes #1597

## Example

```yaml
deployment:
  hostUsers: false  # enables user namespace isolation
```

## Test plan

- [x] `helm unittest traefik -f tests/pod-config_test.yaml` passes (82/82 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)