### PR TITLE
docs: clarify DaemonSet updateStrategy to prevent rollout deadlock

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -9,6 +9,20 @@ deployment:
   kind: DaemonSet
 ```
 
+The update strategy default value in `traefik/values.yaml` needs to be changed, in order to accommodate for a `DaemonSet`.
+
+Whenever the `DaemonSet` gets updated with a new configuration using `maxUnavailable: 0`, this prevents any pod owned by the DaemonSet from being terminated, and a `DaemonSet` cannot schedule more than one pod per node, which results in a rollout deadlock.
+
+Instead, this minimal working update-strategy configuration can be used.
+
+```yaml
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+```
+
 ## Configure Traefik Pod parameters
 
 ### Extending /etc/hosts records

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,20 +7,11 @@ Default install is using a `Deployment` but it's possible to use `DaemonSet`
 ```yaml
 deployment:
   kind: DaemonSet
-```
-
-The update strategy default value in `traefik/values.yaml` needs to be changed, in order to accommodate for a `DaemonSet`.
-
-Whenever the `DaemonSet` gets updated with a new configuration using `maxUnavailable: 0`, this prevents any pod owned by the DaemonSet from being terminated, and a `DaemonSet` cannot schedule more than one pod per node, which results in a rollout deadlock.
-
-Instead, this minimal working update-strategy configuration can be used.
-
-```yaml
+# The update strategy needs to be changed accordingly
+# See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ for details
 updateStrategy:
-  type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 1
-    maxSurge: 0
 ```
 
 ## Configure Traefik Pod parameters

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,6 +7,7 @@ Default install is using a `Deployment` but it's possible to use `DaemonSet`
 ```yaml
 deployment:
   kind: DaemonSet
+
 # The update strategy needs to be changed accordingly
 # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ for details
 updateStrategy:


### PR DESCRIPTION
This merge request is part of the open issue #1753.

### What does this PR do?

Adds a clarification in the DaemonSet installation example regarding the required update strategy.

It explains why the default `updateStrategy` is not suitable for a `DaemonSet` and provides a minimal working configuration to prevent rollout deadlocks.

### Motivation

When using Traefik as a `DaemonSet`, the default update strategy (`maxUnavailable: 0`) can lead to a deadlock during updates. Since a `DaemonSet` cannot schedule more than one pod per node, no pods can be terminated and the rollout cannot proceed.

This change helps users avoid this issue by documenting a working configuration.