### PR TITLE
ci(renovate): enable stable updates on v39.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
     // Update appVersion in Chart.yaml
     'customManagers:helmChartYamlAppVersions'
   ],
-  baseBranchPatterns: [ 'master', 'v40.0'],
+  baseBranchPatterns: [ 'master', 'v40.0', 'v39.0'],
   semanticCommits: 'enabled',
   gitAuthor: 'traefiker <30906710+traefiker@users.noreply.github.com>',
   rebaseWhen: 'conflicted',
@@ -27,18 +27,17 @@
     },
   ],
   packageRules: [
+    // Stable update on master & stable branch
     {
       matchPackageNames: ['traefik'],
+      matchBaseBranches: [ 'master', 'v39.0'],
       extends: [':semanticCommitTypeAll(feat)'],
     },
+    // Pre-release update on pre-release branch
     {
       matchPackageNames: ['traefik'],
       matchBaseBranches: [ 'v40.0'],
-      ignoreUnstable: false,
-    },
-    {
-      matchPackageNames: ['traefik'],
-      matchBaseBranches: [ 'v40.0'],
+      extends: [':semanticCommitTypeAll(feat)'],
       ignoreUnstable: false,
     },
     {
@@ -51,7 +50,7 @@
     // No GHA update on previous branches
     {
       matchManagers: ['github-actions'],
-      matchBaseBranches: ['v40.0'],
+      matchBaseBranches: ['v40.0', 'v39.0'],
       enabled: false
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,11 @@
     {
       matchPackageNames: ['traefik'],
       extends: [':semanticCommitTypeAll(feat)'],
-      matchBaseBranches: [ 'master', 'v40.0' ],
+    },
+    {
+      matchPackageNames: ['traefik'],
+      matchBaseBranches: [ 'v40.0'],
+      ignoreUnstable: false,
     },
     {
       matchPackageNames: ['traefik'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,7 @@
     {
       matchPackageNames: ['traefik'],
       extends: [':semanticCommitTypeAll(feat)'],
+      matchBaseBranches: [ 'master', 'v40.0' ],
     },
     {
       matchPackageNames: ['traefik'],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ All commits will appear in traefik helm chart changelog with two exceptions:
 Renovate can be run locally for debugging purpose, like this:
 
 ```bash
-docker run -it -v $(pwd):/usr/src/app  -e RENOVATE_CONFIG_FILE=/usr/src/app/.github/renovate.json5 -e LOG_LEVEL=DEBUG renovate/renovate --dry-run --platform=local
+docker run -it -v $(pwd):/usr/src/app  -e RENOVATE_CONFIG_FILE=/usr/src/app/.github/renovate.json5 -e LOG_LEVEL=DEBUG renovate/renovate --platform=local
 ```
 
 ## About CRDs


### PR DESCRIPTION
### What does this PR do?

1. Enable Renovate on branch v39.0
2. Improve doc following https://github.com/traefik/traefik-helm-chart/pull/1765#discussion_r3001487691


### Motivation

More automation, less manual work.
