### PR TITLE
ci(release): fix version name

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: v39.0.7
+version: 39.0.7
 appVersion: v3.6.12
 kubeVersion: '>=1.22.0-0'
 keywords:

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: v39.0.7](https://img.shields.io/badge/Version-v39.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.12](https://img.shields.io/badge/AppVersion-v3.6.12-informational?style=flat-square)
+![Version: 39.0.7](https://img.shields.io/badge/Version-39.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.6.12](https://img.shields.io/badge/AppVersion-v3.6.12-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Fix typo on version name. Should be 39.0.7, not v39.0.7
