### PR TITLE
docs: add example for binding to privileged ports

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2053,7 +2053,8 @@ ports:
     hostPort: 443
 ```
 
-> **Note:** When using `hostPort`, you typically want to deploy Traefik as a `DaemonSet` (see the DaemonSet example above) so that each node binds the ports.
+> [!NOTE]
+> When using `hostPort`, you typically want to deploy Traefik as a `DaemonSet` (see the DaemonSet example above) so that each node binds the ports.
 
 <details>
 <summary>Running on privileged ports with host network</summary>

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2015,3 +2015,42 @@ For an uplink named `whoami`, the parent exposes:
 
 - `whoami@multicluster` (weighted across all children)
 - `whoami-child1@multicluster` (direct to a specific child)
+
+## Bind to privileged ports (80 and 443)
+
+By default, Traefik listens on high ports (8000/8443) because binding to ports below 1024 requires extra privileges. To bind directly to ports 80 and 443, add the `NET_BIND_SERVICE` capability and configure the port numbers:
+
+```yaml
+ports:
+  web:
+    port: 80
+    containerPort: 80
+  websecure:
+    port: 443
+    containerPort: 443
+
+securityContext:
+  capabilities:
+    drop: [ALL]
+    add: [NET_BIND_SERVICE]
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+```
+
+This keeps the container running as a non-root user while allowing it to bind to privileged ports. No changes to `podSecurityContext` are needed.
+
+If you also want the host to listen on ports 80 and 443 directly (bypassing the Service), combine with `hostPort`:
+
+```yaml
+ports:
+  web:
+    port: 80
+    containerPort: 80
+    hostPort: 80
+  websecure:
+    port: 443
+    containerPort: 443
+    hostPort: 443
+```
+
+> **Note:** When using `hostPort`, you typically want to deploy Traefik as a `DaemonSet` (see the DaemonSet example above) so that each node binds the ports.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2054,3 +2054,60 @@ ports:
 ```
 
 > **Note:** When using `hostPort`, you typically want to deploy Traefik as a `DaemonSet` (see the DaemonSet example above) so that each node binds the ports.
+
+<details>
+<summary>Running on privileged ports with host network</summary>
+
+If you need to run Traefik on host network and on privileged ports you'll need extra capabilities set on the `traefik` binary itself (cf. https://github.com/traefik/traefik/pull/12902#issuecomment-4160942102). Here's an init container approach that helps you achieve this:
+
+```yaml
+podSecurityContext:
+  runAsGroup: 65532
+  runAsNonRoot: false
+  runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  allowPrivilegeEscalation: true
+  capabilities:
+    drop: [ALL]
+    add: [NET_BIND_SERVICE]
+
+hostNetwork: true
+
+service:
+  enabled: false
+
+deployment:
+  initContainers:
+    - name: copy-binary
+      image: traefik:v3.6.12
+      command: ["cp", "/usr/local/bin/traefik", "/shared/traefik"]
+      volumeMounts:
+        - name: traefik-bin
+          mountPath: /shared
+    - name: setcap
+      image: alpine:3.21
+      command:
+        - sh
+        - -c
+        - apk add --no-cache libcap && setcap cap_net_bind_service=+ep /shared/traefik
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+      volumeMounts:
+        - name: traefik-bin
+          mountPath: /shared
+  additionalVolumes:
+    - name: traefik-bin
+      emptyDir: {}
+
+additionalVolumeMounts:
+  - name: traefik-bin
+    mountPath: /usr/local/bin
+```
+
+</details>


### PR DESCRIPTION
## Summary

Added an EXAMPLES.md section documenting how to bind Traefik to ports 80 and 443 using the `NET_BIND_SERVICE` capability.

## Changes

New section in `EXAMPLES.md` covering:
- Adding `NET_BIND_SERVICE` to `securityContext.capabilities.add`
- Configuring `ports.web` and `ports.websecure` to use 80/443
- Combining with `hostPort` for DaemonSet deployments

The examples keep the container running as non-root (no changes to `podSecurityContext`) while allowing privileged port binding, which is the recommended approach.

## Testing

Documentation-only change. The values shown match the schema defined in `values.yaml` for `ports`, `securityContext`, and `hostPort`.

Fixes #1781

This contribution was developed with AI assistance (Claude Code).