### PR TITLE
feat: add service.nameOverride for adopting existing Services

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -500,6 +500,7 @@ Kubernetes: `>=1.25.0-0`
 | service.annotationsUDP | object | `{}` | Additional annotations for UDP service only |
 | service.enabled | bool | `true` |  |
 | service.labels | object | `{}` | Additional service labels (e.g. for filtering Service by custom labels) |
+| service.nameOverride | string | `""` | Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller). |
 | service.single | bool | `true` |  |
 | service.spec | object | `{"type":"LoadBalancer"}` | Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core). Cannot contain selector or ports entries. |
 | serviceAccount | object | `{"name":""}` | The service account the pods will use to interact with the Kubernetes API |

--- a/traefik/templates/_service.tpl
+++ b/traefik/templates/_service.tpl
@@ -1,7 +1,7 @@
 {{- define "traefik.service-name" -}}
 {{- $fullname := printf "%s-%s" (include "traefik.fullname" .root) .name -}}
 {{- if eq .name "default" -}}
-{{- $fullname = include "traefik.fullname" .root -}}
+{{- $fullname = default (include "traefik.fullname" .root) .root.Values.service.nameOverride -}}
 {{- end -}}
 
 {{- if ge (len $fullname) 60 -}} # 64 - 4 (udp-postfix) = 60

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2780,6 +2780,13 @@
                     "description": "Additional service labels (e.g. for filtering Service by custom labels)",
                     "type": "object"
                 },
+                "nameOverride": {
+                    "description": "Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "single": {
                     "type": "boolean"
                 },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1066,6 +1066,8 @@ tlsStore: {}
 
 service:
   enabled: true
+  # -- Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller).
+  nameOverride: ""  # @schema type:[string, null]
   ## -- Single service is using `MixedProtocolLBService` feature gate.
   ## -- When set to false, it will create two Service, one for TCP and one for UDP.
   single: true


### PR DESCRIPTION
## Summary

- Adds `service.nameOverride` to allow setting the Service name independently of the release name
- Enables the orphan-and-adopt migration pattern where Traefik needs to take ownership of an existing Service (e.g., `ingress-nginx-controller`) without `fullnameOverride` affecting all resources

## Use case

When migrating from NGINX Ingress Controller to Traefik using the [hostname retention approach](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/#loadbalancer-hostname-retention), users orphan the NGINX LoadBalancer Service and need Traefik's Helm release to adopt it. Without `service.nameOverride`, enabling `service.enabled: true` creates a new Service (e.g., `traefik-ingress-nginx`) instead of adopting the existing `ingress-nginx-controller` Service. `fullnameOverride` cannot be used because it renames all resources (deployment, serviceaccount, etc.), not just the Service.

**Example values:**

```yaml
service:
  enabled: true
  nameOverride: ingress-nginx-controller
```

## Test plan

- [ ] `helm template` with `service.nameOverride` set produces a Service with the overridden name
- [ ] `helm template` without `service.nameOverride` produces the default Service name (no behavior change)
- [ ] `additionalServices` are unaffected by `service.nameOverride`