### PR TITLE
feat(chart): :memo: version support with annotations

### DIFF
--- a/.github/fixtures/changelog-traefik-crds.md
+++ b/.github/fixtures/changelog-traefik-crds.md
@@ -1,4 +1,5 @@
-## [crds_v1.1.0](https://github.com/traefik/traefik-helm-chart/compare/crds_v1.0.0...crds_v1.1.0) (2025-01-13)
+# [crds_v1.1.0](https://github.com/traefik/traefik-helm-chart/compare/crds_v1.0.0...crds_v1.1.0) (2025-01-13)
+
 ## :rocket: Features
 
 - feat(CRDs): update CRDs for Traefik Proxy v3.3.x #1303 by @mloiseleur

--- a/.github/fixtures/changelog-traefik.md
+++ b/.github/fixtures/changelog-traefik.md
@@ -13,8 +13,6 @@
 - docs: 📚️ fix typo in Guidelines.md #1320 by @lbarnkow
 - chore(release): publish v34.2.0 #1323 by @darkweaver87
 
-
-
 ## 👌 Traefik version support
 
 * Traefik Proxy: v3.6.0 -> v3.6.12 (default)

--- a/.github/fixtures/changelog-traefik.md
+++ b/.github/fixtures/changelog-traefik.md
@@ -1,4 +1,5 @@
-## [v34.2.0](https://github.com/traefik/traefik-helm-chart/compare/v34.1.0...v34.2.0) (2025-01-28)
+# [v34.2.0](https://github.com/traefik/traefik-helm-chart/compare/v34.1.0...v34.2.0) (2025-01-28)
+
 ## :rocket: Features
 
 - feat: :sparkles: add hub tracing capabilities #1322 by @darkweaver87

--- a/.github/fixtures/changelog-traefik.md
+++ b/.github/fixtures/changelog-traefik.md
@@ -14,3 +14,8 @@
 - chore(release): publish v34.2.0 #1323 by @darkweaver87
 
 
+
+## 👌 Traefik version support
+
+* Traefik Proxy: v3.6.0 -> v3.6.12 (default)
+* Traefik Hub: v3.19.0 -> v3.20.0-ea.1

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,10 @@
       matchPackageNames: ['bpsoraggi/helm-gh-pages'],
       enabled: false,
     },
+    {
+      matchPackageNames: ['helm-unittest/helm-unittest'],
+      extractVersion: '^v(?<version>.+)$',
+    },
   ],
   customManagers: [
     {
@@ -65,6 +69,14 @@
         '!\\[AppVersion:\\s*(?<currentValue>[\\w+\\.\\-]*)\\]',
         '\\(https:\\/\\/img\\.shields\\.io\\/badge\\/AppVersion-(?<currentValue>[\\w+\\.\\-]*)-informational.+\\)',
       ],
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['\\.github/workflows/.+\\.yaml$'],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+?))?\\s+.*(VERSION|version|rev): ["\']?(?<currentValue>[^"\'\\s]+)',
+      ],
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
     },
   ],
 }

--- a/.github/workflows/changelog.json
+++ b/.github/workflows/changelog.json
@@ -1,5 +1,5 @@
 {
-  "template": "## [#{{TO_TAG}}](#{{RELEASE_DIFF}}) (${DATE})\n#{{CHANGELOG}}${VERSION_SUPPORT}",
+  "template": "# [#{{TO_TAG}}](#{{RELEASE_DIFF}}) (${DATE})\n\n#{{CHANGELOG}}${VERSION_SUPPORT}",
   "categories": [
     {
       "title": "## :boom: BREAKING CHANGES",

--- a/.github/workflows/changelog.json
+++ b/.github/workflows/changelog.json
@@ -43,7 +43,7 @@
     }
   ],
   "pr_template": "- ${{TITLE}} ##{{NUMBER}} by @#{{AUTHOR}}",
-  "max_pull_requests": 300,
+  "max_pull_requests": 500,
   "empty_template": "- no changes",
   "transformers": [
     {

--- a/.github/workflows/changelog.json
+++ b/.github/workflows/changelog.json
@@ -43,7 +43,7 @@
     }
   ],
   "pr_template": "- ${{TITLE}} ##{{NUMBER}} by @#{{AUTHOR}}",
-  "max_pull_requests": 500,
+  "max_pull_requests": 300,
   "empty_template": "- no changes",
   "transformers": [
     {

--- a/.github/workflows/changelog.json
+++ b/.github/workflows/changelog.json
@@ -1,5 +1,5 @@
 {
-  "template": "## [#{{TO_TAG}}](#{{RELEASE_DIFF}}) (${DATE})\n#{{CHANGELOG}}",
+  "template": "## [#{{TO_TAG}}](#{{RELEASE_DIFF}}) (${DATE})\n#{{CHANGELOG}}${VERSION_SUPPORT}",
   "categories": [
     {
       "title": "## :boom: BREAKING CHANGES",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,15 +71,7 @@ jobs:
       - name: Render changelog configuration
         env:
           REGEXP: '(\\(.+\\)|(?!\\(CRDs-.+\\)))'
-        run: |
-          export DATE=$(date +%F)
-          PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' traefik/Chart.yaml)
-          PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
-          HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
-          HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
-          export VERSION_SUPPORT="## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
-          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
-          cat /tmp/changelog.json
+        run: ./hack/render-changelog-config.sh traefik
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Build Changelog
@@ -215,11 +207,7 @@ jobs:
       - name: Render changelog configuration
         env:
           REGEXP: '\\((CRDs|CRDs-.+)\\)'
-        run: |
-          export DATE=$(date +%F)
-          export VERSION_SUPPORT=""
-          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
-          cat /tmp/changelog.json
+        run: ./hack/render-changelog-config.sh traefik-crds
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Build Changelog

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,14 @@ jobs:
         env:
           REGEXP: '(\\(.+\\)|(?!\\(CRDs-.+\\)))'
         run: |
-          export DATE=$(date +%F); cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json; cat /tmp/changelog.json
+          export DATE=$(date +%F)
+          PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' traefik/Chart.yaml)
+          PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
+          HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
+          HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
+          export VERSION_SUPPORT="\n\n## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
+          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
+          cat /tmp/changelog.json
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Build Changelog
@@ -209,7 +216,10 @@ jobs:
         env:
           REGEXP: '\\((CRDs|CRDs-.+)\\)'
         run: |
-          export DATE=$(date +%F); cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json; cat /tmp/changelog.json
+          export DATE=$(date +%F)
+          export VERSION_SUPPORT=""
+          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
+          cat /tmp/changelog.json
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'
 
       - name: Build Changelog

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
           PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
           HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
           HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
-          export VERSION_SUPPORT="\n\n## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
+          export VERSION_SUPPORT="## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
           cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
           cat /tmp/changelog.json
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -37,6 +37,7 @@ jobs:
           fromTag: v34.1.0
           toTag: v34.2.0
           configuration: "/tmp/changelog.json"
+          fetchViaCommits: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,6 +74,7 @@ jobs:
           fromTag: crds_v1.0.0
           toTag: crds_v1.1.0
           configuration: "/tmp/changelog.json"
+          fetchViaCommits: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -20,7 +20,14 @@ jobs:
         env:
           REGEXP: '(\\(.+\\)|(?!\\(CRDs-.+\\)))'
         run: |
-          export DATE=2025-01-28; cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json; cat /tmp/changelog.json
+          export DATE=2025-01-28
+          PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' traefik/Chart.yaml)
+          PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
+          HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
+          HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
+          export VERSION_SUPPORT="\n\n## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
+          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
+          cat /tmp/changelog.json
 
       - name: Build Changelog
         id: changelog
@@ -56,7 +63,10 @@ jobs:
         env:
           REGEXP: '\\((CRDs|CRDs-.+)\\)'
         run: |
-          export DATE=2025-01-13; cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json; cat /tmp/changelog.json
+          export DATE=2025-01-13
+          export VERSION_SUPPORT=""
+          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
+          cat /tmp/changelog.json
 
       - name: Build Changelog
         id: changelog

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -20,6 +20,13 @@ jobs:
         env:
           REGEXP: '(\\(.+\\)|(?!\\(CRDs-.+\\)))'
         run: |
+          # Pin version-support annotations so the fixture stays stable across releases.
+          sed -i \
+            -e 's|traefik.io/proxy-min-version:.*|traefik.io/proxy-min-version: v3.6.0|' \
+            -e 's|traefik.io/proxy-max-version:.*|traefik.io/proxy-max-version: v3.6.12|' \
+            -e 's|traefik.io/hub-min-version:.*|traefik.io/hub-min-version: v3.19.0|' \
+            -e 's|traefik.io/hub-max-version:.*|traefik.io/hub-max-version: v3.20.0-ea.1|' \
+            traefik/Chart.yaml
           export DATE=2025-01-28
           PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' traefik/Chart.yaml)
           PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Render traefik changelog configuration
         env:
           REGEXP: '(\\(.+\\)|(?!\\(CRDs-.+\\)))'
+          DATE: '2025-01-28'
         run: |
           # Pin version-support annotations so the fixture stays stable across releases.
           sed -i \
@@ -27,14 +28,7 @@ jobs:
             -e 's|traefik.io/hub-min-version:.*|traefik.io/hub-min-version: v3.19.0|' \
             -e 's|traefik.io/hub-max-version:.*|traefik.io/hub-max-version: v3.20.0-ea.1|' \
             traefik/Chart.yaml
-          export DATE=2025-01-28
-          PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' traefik/Chart.yaml)
-          PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
-          HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
-          HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
-          export VERSION_SUPPORT="## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
-          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
-          cat /tmp/changelog.json
+          ./hack/render-changelog-config.sh traefik
 
       - name: Build Changelog
         id: changelog
@@ -69,11 +63,8 @@ jobs:
       - name: Render traefik changelog configuration
         env:
           REGEXP: '\\((CRDs|CRDs-.+)\\)'
-        run: |
-          export DATE=2025-01-13
-          export VERSION_SUPPORT=""
-          cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
-          cat /tmp/changelog.json
+          DATE: '2025-01-13'
+        run: ./hack/render-changelog-config.sh traefik-crds
 
       - name: Build Changelog
         id: changelog

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -32,7 +32,7 @@ jobs:
           PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' traefik/Chart.yaml)
           HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' traefik/Chart.yaml)
           HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' traefik/Chart.yaml)
-          export VERSION_SUPPORT="\n\n## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
+          export VERSION_SUPPORT="## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
           cat .github/workflows/changelog.json | envsubst > /tmp/changelog.json
           cat /tmp/changelog.json
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,18 @@ jobs:
       - name: Lint Chart
         run: make lint
 
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v3.19.0
+
+      - name: Install helm-unittest plugin
+        env:
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          HELM_UNITTEST_VERSION: 1.0.1
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version "$HELM_UNITTEST_VERSION"
+
       - name: Test Chart
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,13 @@
 IMAGE_CHART_TESTING=quay.io/helmpack/chart-testing:v3.14.0
 IMAGE_HELM_CHANGELOG=ghcr.io/traefik/helm-changelog:v1.0.0
 IMAGE_HELM_DOCS=jnorwood/helm-docs:v1.14.2
-IMAGE_HELM_UNITTEST=docker.io/helmunittest/helm-unittest:3.19.0-1.0.1
 
 traefik/tests/__snapshot__:
 	@mkdir traefik/tests/__snapshot__
 	@mkdir traefik-crds/tests/__snapshot__
 
 test: traefik/tests/__snapshot__
-	docker run ${DOCKER_ARGS} --entrypoint /bin/sh --rm -v $(CURDIR):/charts -w /charts $(IMAGE_HELM_UNITTEST) /charts/hack/test.sh
+	./hack/test.sh
 
 test-ns:
 	./hack/check-ns.sh
@@ -25,7 +24,6 @@ docs:
 	docker run --rm -v "$(CURDIR):/helm-docs" $(IMAGE_HELM_DOCS) -o VALUES.md
 
 # To launch only one test
-# $ helm plugin install https://github.com/helm-unittest/helm-unittest
 # $ helm unittest -f 'tests/oci-config_test.yaml' traefik
 test-%:
 	docker run ${DOCKER_ARGS} --network=host --env GIT_SAFE_DIR="true" --entrypoint /bin/sh --rm -v $(CURDIR):/charts -v $(HOME)/.kube:/root/.kube -w /charts $(IMAGE_CHART_TESTING) /charts/hack/ct.sh $*

--- a/hack/render-changelog-config.sh
+++ b/hack/render-changelog-config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Render the changelog-builder configuration for a given chart.
+#
+# Usage: hack/render-changelog-config.sh <chart_dir>
+# Env:
+#   REGEXP    required — category matcher injected into the JSON template
+#   DATE      optional — defaults to today (YYYY-MM-DD)
+#   OUTPUT    optional — defaults to /tmp/changelog.json
+#
+# If <chart_dir>/Chart.yaml declares traefik.io/{proxy,hub}-{min,max}-version
+# annotations, a "Traefik version support" block is appended to the release
+# notes; otherwise VERSION_SUPPORT is left empty (used by the CRDs chart).
+
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <chart_dir>" >&2
+  exit 1
+fi
+if [ -z "${REGEXP:-}" ]; then
+  echo "REGEXP must be set" >&2
+  exit 1
+fi
+
+CHART_DIR="$1"
+CHART_YAML="${CHART_DIR}/Chart.yaml"
+OUTPUT="${OUTPUT:-/tmp/changelog.json}"
+DATE="${DATE:-$(date +%F)}"
+export DATE REGEXP
+
+PROXY_MIN=$(awk '/traefik.io\/proxy-min-version:/{print $2}' "${CHART_YAML}")
+PROXY_MAX=$(awk '/traefik.io\/proxy-max-version:/{print $2}' "${CHART_YAML}")
+HUB_MIN=$(awk '/traefik.io\/hub-min-version:/{print $2}' "${CHART_YAML}")
+HUB_MAX=$(awk '/traefik.io\/hub-max-version:/{print $2}' "${CHART_YAML}")
+
+if [ -n "${PROXY_MIN}" ] && [ -n "${PROXY_MAX}" ] && [ -n "${HUB_MIN}" ] && [ -n "${HUB_MAX}" ]; then
+  VERSION_SUPPORT="## 👌 Traefik version support\n\n* Traefik Proxy: ${PROXY_MIN} -> ${PROXY_MAX} (default)\n* Traefik Hub: ${HUB_MIN} -> ${HUB_MAX}"
+else
+  VERSION_SUPPORT=""
+fi
+export VERSION_SUPPORT
+
+envsubst <.github/workflows/changelog.json >"${OUTPUT}"
+cat "${OUTPUT}"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -2,5 +2,19 @@
 
 set -e
 
-/usr/bin/helm unittest --color ./traefik
+# Test against a copy of the traefik chart with pinned version-support
+# annotations, so tests stay decoupled from the real supported ranges shipped
+# with releases without ever touching the committed Chart.yaml. Copying to
+# /tmp also avoids permission errors when the helm-unittest container user
+# cannot write to the mounted workspace (e.g. in GitHub Actions).
+rm -rf /tmp/traefik-test
+cp -r traefik /tmp/traefik-test
+sed -i \
+  -e 's|traefik.io/proxy-min-version:.*|traefik.io/proxy-min-version: v3.6.0|' \
+  -e 's|traefik.io/proxy-max-version:.*|traefik.io/proxy-max-version: v3.6.12|' \
+  -e 's|traefik.io/hub-min-version:.*|traefik.io/hub-min-version: v3.19.3|' \
+  -e 's|traefik.io/hub-max-version:.*|traefik.io/hub-max-version: v3.20.0-ea.1|' \
+  /tmp/traefik-test/Chart.yaml
+
+/usr/bin/helm unittest --color /tmp/traefik-test
 /usr/bin/helm unittest --color ./traefik-crds

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -2,19 +2,27 @@
 
 set -e
 
-# Test against a copy of the traefik chart with pinned version-support
-# annotations, so tests stay decoupled from the real supported ranges shipped
-# with releases without ever touching the committed Chart.yaml. Copying to
-# /tmp also avoids permission errors when the helm-unittest container user
-# cannot write to the mounted workspace (e.g. in GitHub Actions).
-rm -rf /tmp/traefik-test
-cp -r traefik /tmp/traefik-test
+if ! command -v helm >/dev/null 2>&1; then
+  echo "Error: helm is not installed. See https://helm.sh/docs/intro/install/" >&2
+  exit 1
+fi
+
+if ! helm plugin list 2>/dev/null | awk 'NR>1 && $1=="unittest"{found=1} END{exit !found}'; then
+  echo "Error: helm-unittest plugin is not installed." >&2
+  echo "Install: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.1" >&2
+  exit 1
+fi
+
+# Pin version-support annotations so tests stay decoupled from the real
+# supported ranges shipped with releases. Restore on exit.
+cp traefik/Chart.yaml /tmp/traefik-Chart.yaml.bak
+trap 'mv /tmp/traefik-Chart.yaml.bak traefik/Chart.yaml' EXIT
 sed -i \
   -e 's|traefik.io/proxy-min-version:.*|traefik.io/proxy-min-version: v3.6.0|' \
   -e 's|traefik.io/proxy-max-version:.*|traefik.io/proxy-max-version: v3.6.12|' \
   -e 's|traefik.io/hub-min-version:.*|traefik.io/hub-min-version: v3.19.3|' \
   -e 's|traefik.io/hub-max-version:.*|traefik.io/hub-max-version: v3.20.0-ea.1|' \
-  /tmp/traefik-test/Chart.yaml
+  traefik/Chart.yaml
 
-/usr/bin/helm unittest --color /tmp/traefik-test
-/usr/bin/helm unittest --color ./traefik-crds
+helm unittest --color ./traefik
+helm unittest --color ./traefik-crds

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -22,6 +22,10 @@ maintainers:
   - name: jnoordsij
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
+  traefik.io/proxy-min-version: v3.6.0
+  traefik.io/proxy-max-version: v3.7.0-rc.1
+  traefik.io/hub-min-version: v3.19.3
+  traefik.io/hub-max-version: v3.20.0-rc.1
   artifacthub.io/changes: |
     - "feat: 🚀 upgrade traefik to v3.7.0-ea.3"
     - "chore(release): 🚀 publish v40.0.0-ea.3"

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -4,13 +4,15 @@
 {{- printf "\n" -}}
 
 
-{{/* Warn about experimental versions */}}
+{{/* Warn about non-standard versions (experimental, or pre-release outside supported range) */}}
 {{- $imageTag := (.Values.image.tag | default .Chart.AppVersion) -}}
-{{- if hasPrefix "experimental-" $imageTag -}}
+{{- $version := include "traefik.proxyVersion" $ -}}
+{{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" -}}
+{{- if or (hasPrefix "experimental-" $imageTag) (and (eq (include "traefik.isStableVersion" $version) "false") (semverCompare (printf ">%s-0" $proxyMaxVersion) $version)) -}}
 {{- printf "\n" -}}
-⚠️ WARNING: You are using an experimental image tag ({{ $imageTag }}). Experimental versions can
+⚠️ WARNING: You are using a non-standard image tag ({{ $imageTag }}). Non-standard versions can
 be unstable, may contain breaking changes, and are NOT recommended for production use.
-This version is not supported by this chart. Use at your own risk. ⚠️
+This version is not officially supported by this chart. Use at your own risk. ⚠️
 {{- printf "\n" -}}
 {{- end -}}
 

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -205,6 +205,18 @@ It requires a dict with "Version" and "Hub".
 
 
 {{/*
+Returns "true" if the given version is a stable release (vX.Y.Z or X.Y.Z), "false" otherwise.
+Non-standard versions include experimental, ea, rc, alpha, beta builds.
+*/}}
+{{- define "traefik.isStableVersion" -}}
+  {{- if regexMatch "^v?[0-9]+\\.[0-9]+\\.[0-9]+$" . -}}
+    true
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}
+
+{{/*
 The version can comes many sources: appVersion, image.tag, override, marketplace.
 */}}
 {{- define "traefik.proxyVersion" -}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -1,7 +1,12 @@
 {{- $version := include "traefik.proxyVersion" $ }}
+{{- $proxyMinVersion := index .Chart.Annotations "traefik.io/proxy-min-version" }}
+{{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" }}
 {{- if (ne $version "experimental-v3.0") }}
-  {{- if (semverCompare "<v3.6.0-0" $version) }}
-    {{- fail "ERROR: This version of the Chart only supports Traefik Proxy v3.6+" -}}
+  {{- if (semverCompare (printf "<%s-0" $proxyMinVersion) $version) }}
+    {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy %s+" $proxyMinVersion) -}}
+  {{- end }}
+  {{- if and (eq (include "traefik.isStableVersion" $version) "true") (semverCompare (printf ">%s" $proxyMaxVersion) $version) }}
+    {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy up to %s." $proxyMaxVersion) -}}
   {{- end }}
 {{- end }}
 
@@ -118,8 +123,13 @@
     {{ $hubVersion = "v3.99" }}
   {{- end }}
 
-  {{- if semverCompare "<v3.19.3-0" $hubVersion }}
-    {{ fail "ERROR: this Chart supports *only* Traefik Hub >= v3.19.3."}}
+  {{- $hubMinVersion := index $.Chart.Annotations "traefik.io/hub-min-version" }}
+  {{- $hubMaxVersion := index $.Chart.Annotations "traefik.io/hub-max-version" }}
+  {{- if semverCompare (printf "<%s-0" $hubMinVersion) $hubVersion }}
+    {{ fail (printf "ERROR: this Chart supports *only* Traefik Hub >= %s." $hubMinVersion) }}
+  {{- end }}
+  {{- if and (eq (include "traefik.isStableVersion" $hubVersion) "true") (semverCompare (printf ">%s" $hubMaxVersion) $hubVersion) }}
+    {{ fail (printf "ERROR: this Chart only supports Traefik Hub up to %s." $hubMaxVersion) }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -44,11 +44,26 @@ tests:
 
             RELEASE-NAME with docker.io/traefik:experimental-v3.6 has been deployed successfully on NAMESPACE namespace!
 
-            ⚠️ WARNING: You are using an experimental image tag (experimental-v3.6). Experimental versions can
+            ⚠️ WARNING: You are using a non-standard image tag (experimental-v3.6). Non-standard versions can
             be unstable, may contain breaking changes, and are NOT recommended for production use.
-            This version is not supported by this chart. Use at your own risk. ⚠️
+            This version is not officially supported by this chart. Use at your own risk. ⚠️
 
-  - it: should not display experimental warning when using a stable image tag
+  - it: should display warning when using an ea version just above max
+    set:
+      image:
+        tag: v3.8.0-ea.1
+    asserts:
+      - equalRaw:
+          value: |
+
+
+            RELEASE-NAME with docker.io/traefik:v3.8.0-ea.1 has been deployed successfully on NAMESPACE namespace!
+
+            ⚠️ WARNING: You are using a non-standard image tag (v3.8.0-ea.1). Non-standard versions can
+            be unstable, may contain breaking changes, and are NOT recommended for production use.
+            This version is not officially supported by this chart. Use at your own risk. ⚠️
+
+  - it: should not display warning when using a stable Proxy version within range
     set:
       image:
         tag: v3.6.8
@@ -58,6 +73,44 @@ tests:
 
 
             RELEASE-NAME with docker.io/traefik:v3.6.8 has been deployed successfully on NAMESPACE namespace!
+  - it: should not display warning when using an ea Proxy version within range
+    set:
+      image:
+        tag: v3.6.10-ea.1
+    asserts:
+      - equalRaw:
+          value: |
+
+
+            RELEASE-NAME with docker.io/traefik:v3.6.10-ea.1 has been deployed successfully on NAMESPACE namespace!
+  - it: should not display warning when using a stable Hub version within range
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.5
+      hub:
+        token: xxx
+    asserts:
+      - equalRaw:
+          value: |
+
+
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.19.5 has been deployed successfully on NAMESPACE namespace!
+  - it: should not display warning when using an ea Hub version within range
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.5-ea.1
+      hub:
+        token: xxx
+    asserts:
+      - equalRaw:
+          value: |
+
+
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.19.5-ea.1 has been deployed successfully on NAMESPACE namespace!
   - it: should not display a warning when persistence and initContainer are enabled
     set:
       persistence:

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -73,44 +73,6 @@ tests:
 
 
             RELEASE-NAME with docker.io/traefik:v3.6.8 has been deployed successfully on NAMESPACE namespace!
-  - it: should not display warning when using an ea Proxy version within range
-    set:
-      image:
-        tag: v3.6.10-ea.1
-    asserts:
-      - equalRaw:
-          value: |
-
-
-            RELEASE-NAME with docker.io/traefik:v3.6.10-ea.1 has been deployed successfully on NAMESPACE namespace!
-  - it: should not display warning when using a stable Hub version within range
-    set:
-      image:
-        registry: ghcr.io
-        repository: traefik/traefik-hub
-        tag: v3.19.5
-      hub:
-        token: xxx
-    asserts:
-      - equalRaw:
-          value: |
-
-
-            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.19.5 has been deployed successfully on NAMESPACE namespace!
-  - it: should not display warning when using an ea Hub version within range
-    set:
-      image:
-        registry: ghcr.io
-        repository: traefik/traefik-hub
-        tag: v3.19.5-ea.1
-      hub:
-        token: xxx
-    asserts:
-      - equalRaw:
-          value: |
-
-
-            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.19.5-ea.1 has been deployed successfully on NAMESPACE namespace!
   - it: should not display a warning when persistence and initContainer are enabled
     set:
       persistence:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -8,14 +8,14 @@ tests:
         tag: v2.11.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy v3.6+"
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy v3.6.0+"
   - it: should fail when trying to use this Chart with Traefik Proxy v3.5
     set:
       image:
         tag: v3.5.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy v3.6+"
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy v3.6.0+"
   - it: should pass when trying to use this Chart with Traefik Proxy v3.6 experimental
     set:
       image:
@@ -38,6 +38,31 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: version \"unknown\" is not supported"
+  - it: should fail when trying to use this Chart with a stable Proxy version above max
+    set:
+      image:
+        tag: v3.7.0
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.6.12."
+  - it: should not fail when trying to use this Chart with an ea Proxy version above max
+    set:
+      image:
+        tag: v3.7.0-ea.1
+    asserts:
+      - notFailedTemplate: {}
+  - it: should not fail when trying to use this Chart with a Proxy version within range
+    set:
+      image:
+        tag: v3.6.10
+    asserts:
+      - notFailedTemplate: {}
+  - it: should not fail when trying to use this Chart with an ea Proxy version within range
+    set:
+      image:
+        tag: v3.6.10-ea.1
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when trying to use this Chart with Traefik Proxy v3 and Hub enabled
     set:
       hub:
@@ -62,6 +87,58 @@ tests:
         registry: ghcr.io
         repository: traefik/traefik-hub
         tag: v3.19.3
+      hub:
+        token: xxx
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when trying to use this Chart with a stable Hub version above max
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.21.0
+      hub:
+        token: xxx
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.0-ea.1."
+  - it: should not fail when trying to use this Chart with an ea Hub version above max
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.21.0-ea.1
+      hub:
+        token: xxx
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when trying to use this Chart with the stable release above ea max Hub version
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.20.0
+      hub:
+        token: xxx
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.0-ea.1."
+  - it: should not fail when trying to use this Chart with a Hub version within range
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.5
+      hub:
+        token: xxx
+    asserts:
+      - notFailedTemplate: {}
+  - it: should not fail when trying to use this Chart with an ea Hub version within range
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.5-ea.1
       hub:
         token: xxx
     asserts:


### PR DESCRIPTION
### What does this PR do?

Declares supported Traefik Proxy and Hub version ranges as Chart.yaml annotations
(`traefik.io/proxy-min-version`, `proxy-max-version`, `hub-min-version`, `hub-max-version`),
replacing hardcoded values in templates.

### Motivation

Fixes https://github.com/traefik/traefik-helm-chart/issues/1758

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed