### PR TITLE
feat(podtemplate): allow disabling automatic GOMEMLIMIT

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -50,7 +50,7 @@ Kubernetes: `>=1.25.0-0`
 | deployment.dnsConfig | object | `{}` | Custom pod [DNS config](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#poddnsconfig-v1-core) |
 | deployment.dnsPolicy | string | `""` | Custom pod DNS policy. Apply if `hostNetwork: true` |
 | deployment.enabled | bool | `true` | Enable deployment |
-| deployment.goMemLimitPercentage | float | `0.9` | only takes effect when resources.limits.memory is set |
+| deployment.goMemLimitPercentage | float | `0.9` | Percentage of memory limit to set for GOMEMLIMIT, set as decimal (0.9 = 90%, 0.95 = 95% etc). Only takes effect when resources.limits.memory is set. Set to 0 to disable (e.g. when using VPA or setting it via env) |
 | deployment.healthchecksHost | string | `""` |  |
 | deployment.healthchecksPort | string | `nil` |  |
 | deployment.healthchecksScheme | string | `nil` |  |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -938,7 +938,7 @@
                 resource: limits.cpu
                 divisor: '1'
           {{- end }}
-          {{- if ($.Values.resources.limits).memory }}
+          {{- if and ($.Values.resources.limits).memory $.Values.deployment.goMemLimitPercentage }}
           - name: GOMEMLIMIT
             value: {{ include "traefik.gomemlimit" (dict "memory" .Values.resources.limits.memory "percentage" .Values.deployment.goMemLimitPercentage) | quote }}
           {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -81,6 +81,19 @@ tests:
       - notEqual:
           path: spec.template.spec.containers[0].env[0].name
           value: GOMEMLIMIT
+  - it: should have not set GOMEMLIMIT when goMemLimitPercentage is 0
+    set:
+      resources:
+        limits:
+          memory: "512Mi"
+      deployment:
+        goMemLimitPercentage: 0
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GOMEMLIMIT
+          any: true
   - it: should have expected env + additional env with specified values
     set:
       env:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -151,7 +151,7 @@
                     "type": "boolean"
                 },
                 "goMemLimitPercentage": {
-                    "description": "Percentage of memory limit to set for GOMEMLIMIT",
+                    "description": "Percentage of memory limit to set for GOMEMLIMIT, set as decimal (0.9 = 90%, 0.95 = 95% etc). Only takes effect when resources.limits.memory is set. Set to 0 to disable (e.g. when using VPA or setting it via env)",
                     "type": "number"
                 },
                 "healthchecksHost": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -108,9 +108,7 @@ deployment:
   #     scheme: HTTP
   # -- Set a runtimeClassName on pod
   runtimeClassName: ""
-  # -- Percentage of memory limit to set for GOMEMLIMIT
-  # -- set as decimal (0.9 = 90%, 0.95 = 95% etc)
-  # -- only takes effect when resources.limits.memory is set
+  # -- Percentage of memory limit to set for GOMEMLIMIT, set as decimal (0.9 = 90%, 0.95 = 95% etc). Only takes effect when resources.limits.memory is set. Set to 0 to disable (e.g. when using VPA or setting it via env)
   goMemLimitPercentage: 0.9
 
 # -- [Pod Disruption Budget](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1/)


### PR DESCRIPTION
### What does this PR do?
Allow opting out of the automatic GOMEMLIMIT env var injection by setting deployment.goMemLimitPercentage to 0. When set to 0, the chart skips adding GOMEMLIMIT, letting users provide their own via the env values instead.

### Motivation
When using a Vertical Pod Autoscaler (VPA), the memory limit changes dynamically. The chart's static GOMEMLIMIT (calculated at deploy time of the Helm release) becomes stale after VPA adjusts the limit. Setting GOMEMLIMIT via env with a resourceFieldRef to limits.memory solves this.

The resourceFieldRef solution was implemented before merging #1418 , which calculates it based on the ratio. For people that don't use the VPA this would probably be a great default setting, but for people that do use the VPA it currently makes it difficult. A relatively low GOMEMLIMIT causes the garbage collector to use a lot of CPU. 

Besides the solution above I've also considered not setting the `memory.limit` to prevent the generation of the GOMEMLIMIT env var, but I use the `RequestsAndLimits` [mode](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/#controlledvalues) on the VPA object, since I do want to have a limit set, since GOMEMLIMIT is just a soft limit.  

By introducing this change people are able to use their own solution for the GOMEMLIMIT or provide it manually via resourceFieldRef.

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed

