### PR TITLE
feat(nginx): :sparkles: support globalAuthUrl option

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -460,6 +460,7 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.enabled | bool | `false` | Enable Kubernetes Ingress NGINX provider |
 | providers.kubernetesIngressNGINX.endpoint | string | `""` | Kubernetes server endpoint (required for external cluster client) |
 | providers.kubernetesIngressNGINX.globalAllowedResponseHeaders | list | `[]` | List of allowed response headers inside the custom headers annotations |
+| providers.kubernetesIngressNGINX.globalAuthUrl | string | `""` | URL to the service that provides authentication for all the locations. Per ingress auth-url annotation has precedence over this option. |
 | providers.kubernetesIngressNGINX.httpEntryPoint | string | `""` | Defines the EntryPoint to use for HTTP requests |
 | providers.kubernetesIngressNGINX.httpsEntryPoint | string | `""` | Defines the EntryPoint to use for HTTPS requests |
 | providers.kubernetesIngressNGINX.ingressClass | string | `"nginx"` | Name of the ingress class this controller satisfies |

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -63,6 +63,10 @@
   {{- fail "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1." }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty (.Values.providers.kubernetesIngressNGINX).globalAuthUrl)) }}
+  {{- fail "ERROR: Kubernetes Ingress NGINX provider globalAuthUrl option requires traefik >= v3.7.0-rc.1." }}
+{{- end }}
+
 {{- if and (not .Values.experimental.otlpLogs) (or (.Values.logs.general.otlp.enabled) (.Values.logs.access.otlp.enabled))}}
   {{- fail "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true." }}
 {{- end }}

--- a/traefik/tests/provider-kubernetesingressnginx_test.yaml
+++ b/traefik/tests/provider-kubernetesingressnginx_test.yaml
@@ -301,6 +301,17 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingressnginx.strictValidatePathType=false"
 
+  - it: should add globalAuthUrl
+    set:
+      providers:
+        kubernetesIngressNGINX:
+          globalAuthUrl: "http://auth.default.svc.cluster.local"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.globalAuthUrl=http://auth.default.svc.cluster.local"
+
   - it: should add httpEntryPoint & httpsEntryPoint
     set:
       providers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2570,6 +2570,10 @@
                             "description": "List of allowed response headers inside the custom headers annotations",
                             "type": "array"
                         },
+                        "globalAuthUrl": {
+                            "description": "URL to the service that provides authentication for all the locations. Per ingress auth-url annotation has precedence over this option.",
+                            "type": "string"
+                        },
                         "httpEntryPoint": {
                             "description": "Defines the EntryPoint to use for HTTP requests",
                             "type": "string"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -445,6 +445,8 @@ providers:
     allowCrossNamespaceResources: null  # @schema type:[boolean, null]
     # -- List of allowed response headers inside the custom headers annotations
     globalAllowedResponseHeaders: []
+    # -- URL to the service that provides authentication for all the locations. Per ingress auth-url annotation has precedence over this option.
+    globalAuthUrl: ""
     # -- Enables parsing and adding -snippet annotations/directives (default: false)
     allowSnippetAnnotations: null  # @schema type:[boolean, null]
     # -- Defines whether to reject the entire ingress when any path contains regex characters and pathType is Prefix or Exact (default: true)


### PR DESCRIPTION
### What does this PR do?

Adds support for the `providers.kubernetesingressnginx.globalAuthUrl` option introduced in Traefik v3.7.0-rc.1 (see [traefik/traefik#12893](https://github.com/traefik/traefik/pull/12893)).

### Motivation

Expose the new upstream flag, which defines a URL to the service providing authentication for all the locations. Per-ingress `auth-url` annotation has precedence over this option.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed