### PR TITLE
feat(providers): :sparkles: support precedence option

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -484,6 +484,7 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.watchIngressWithoutClass | bool | `false` | Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified |
 | providers.kubernetesIngressNGINX.watchNamespace | string | `""` | Namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector. |
 | providers.kubernetesIngressNGINX.watchNamespaceSelector | string | `""` | Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. |
+| providers.precedence | list | `[]` | Defines the routing precedence between providers. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/overview/#routing-precedence) for the default order. |
 | rbac.aggregateTo | list | `[]` |  |
 | rbac.enabled | bool | `true` | Whether Role Based Access Control objects like roles and rolebindings should be created |
 | rbac.namespaced | bool | `false` |  |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -471,6 +471,9 @@
           {{- if .Values.experimental.abortOnPluginFailure }}
           - "--experimental.abortonpluginfailure={{ .Values.experimental.abortOnPluginFailure }}"
           {{- end }}
+          {{- with .Values.providers.precedence }}
+          - "--providers.precedence={{ join "," . }}"
+          {{- end }}
           {{- if .Values.providers.kubernetesCRD.enabled }}
           - "--providers.kubernetescrd"
            {{- if .Values.providers.kubernetesCRD.labelSelector }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -59,6 +59,10 @@
   {{- fail "ERROR: Kubernetes Ingress NGINX provider strictValidatePathType option requires traefik >= v3.7.0-ea.2." }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty .Values.providers.precedence)) }}
+  {{- fail "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1." }}
+{{- end }}
+
 {{- if and (not .Values.experimental.otlpLogs) (or (.Values.logs.general.otlp.enabled) (.Values.logs.access.otlp.enabled))}}
   {{- fail "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true." }}
 {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -1131,3 +1131,21 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.otlp.grpc.tls"
+
+  - it: should not add providers.precedence by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.precedence"
+
+  - it: should add providers.precedence when set
+    set:
+      providers:
+        precedence:
+          - kubernetescrd
+          - kubernetesingressnginx
+          - kubernetesgateway
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.precedence=kubernetescrd,kubernetesingressnginx,kubernetesgateway"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2681,6 +2681,10 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "precedence": {
+                    "description": "Defines the routing precedence between providers. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/overview/#routing-precedence) for the default order.",
+                    "type": "array"
                 }
             },
             "additionalProperties": false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -291,6 +291,8 @@ startupProbe: {}
 
 # @schema additionalProperties: false
 providers:
+  # -- Defines the routing precedence between providers. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/overview/#routing-precedence) for the default order.
+  precedence: []
   # @schema additionalProperties: false
   kubernetesCRD:
     # -- Load Kubernetes IngressRoute provider


### PR DESCRIPTION
### What does this PR do?

Adds support for the `providers.precedence` option introduced in Traefik v3.7.0-rc.1 (see [traefik/traefik#12895](https://github.com/traefik/traefik/pull/12895)).

### Motivation

Expose the new upstream flag, which defines the routing precedence between providers.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed