### PR TITLE
feat(nginx): :sparkles: support modsec option

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -465,6 +465,9 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.httpsEntryPoint | string | `""` | Defines the EntryPoint to use for HTTPS requests |
 | providers.kubernetesIngressNGINX.ingressClass | string | `"nginx"` | Name of the ingress class this controller satisfies |
 | providers.kubernetesIngressNGINX.ingressClassByName | bool | `false` | Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class |
+| providers.kubernetesIngressNGINX.modsec.enabled | bool | `false` | Enable ModSec engine. Requires Traefik Hub >= v3.20.0-ea.8. |
+| providers.kubernetesIngressNGINX.modsec.owaspCoreRules | bool | `false` | Enable OWASP Core Rules. |
+| providers.kubernetesIngressNGINX.modsec.snippet | string | `""` | Custom ModSec rules snippet. |
 | providers.kubernetesIngressNGINX.proxyBodySize | int | `0` | Default maximum size of a client request body in bytes (default: 1048576) |
 | providers.kubernetesIngressNGINX.proxyBufferSize | int | `0` | Default buffer size for reading the response body in bytes (default: 8192) |
 | providers.kubernetesIngressNGINX.proxyBuffering | string | `nil` | Defines whether to enable response buffering (default: false) |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -602,7 +602,11 @@
             {{- if and $.Values.service.enabled .publishService.enabled }}
           - "--providers.kubernetesingressnginx.publishservice={{ template "providers.kubernetesIngressNGINX.publishServicePath" $ }}"
             {{- end }}
-            {{- include "traefik.yaml2CommandLineArgs" (dict "path" "providers.kubernetesingressnginx" "content" (omit . "enabled" "publishService" "watchNamespace")) | nindent 10 }}
+            {{- if .modsec.enabled }}
+          - "--providers.kubernetesingressnginx.modsec=true"
+              {{- include "traefik.yaml2CommandLineArgs" (dict "path" "providers.kubernetesingressnginx.modsec" "content" (omit .modsec "enabled")) | nindent 10 }}
+            {{- end }}
+            {{- include "traefik.yaml2CommandLineArgs" (dict "path" "providers.kubernetesingressnginx" "content" (omit . "enabled" "publishService" "watchNamespace" "modsec")) | nindent 10 }}
            {{- end }}
           {{- end }}
           {{- with .Values.providers.knative }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -30,6 +30,10 @@
   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
 {{- end }}
 
+{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
+  {{- fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub." }}
+{{- end }}
+
 {{- with .Values.providers.kubernetesIngressNGINX }}
   {{- if and (semverCompare "<v3.7.0-0" $version) .enabled (or
     (ne .proxyRequestBuffering nil)
@@ -139,6 +143,10 @@
         {{ fail "ERROR: uplink EntryPoints requires the hub multicluster provider" }}
       {{- end }}
     {{- end }}
+  {{- end }}
+
+  {{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (semverCompare "<v3.20.0-ea.8" $hubVersion) }}
+    {{ fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8." }}
   {{- end }}
 
 {{- end }}

--- a/traefik/tests/provider-kubernetesingressnginx_test.yaml
+++ b/traefik/tests/provider-kubernetesingressnginx_test.yaml
@@ -327,3 +327,32 @@ tests:
         contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingressnginx.httpsEntryPoint=websecure"
+
+  - it: should add modsec flags when enabled
+    set:
+      providers:
+        kubernetesIngressNGINX:
+          modsec:
+            enabled: true
+            owaspCoreRules: true
+            snippet: "SecRuleEngine On"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.modsec=true"
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.modsec.owaspCoreRules=true"
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.modsec.snippet=SecRuleEngine On"
+
+  - it: should not add modsec flags when disabled
+    asserts:
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.modsec=true"

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -375,6 +375,47 @@ tests:
             enabled: true
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using kubernetesIngressNGINX modsec without Traefik Hub
+    set:
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+          modsec:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub."
+  - it: should fail when using kubernetesIngressNGINX modsec on Traefik Hub < v3.20.0-ea.8
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.7
+      hub:
+        token: "xxx"
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+          modsec:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8."
+  - it: should pass when using kubernetesIngressNGINX modsec on Traefik Hub >= v3.20.0-ea.8
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.8
+      hub:
+        token: "xxx"
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+          modsec:
+            enabled: true
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2590,6 +2590,24 @@
                             "description": "Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class",
                             "type": "boolean"
                         },
+                        "modsec": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable ModSec engine. Requires Traefik Hub \u003e= v3.20.0-ea.8.",
+                                    "type": "boolean"
+                                },
+                                "owaspCoreRules": {
+                                    "description": "Enable OWASP Core Rules.",
+                                    "type": "boolean"
+                                },
+                                "snippet": {
+                                    "description": "Custom ModSec rules snippet.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "proxyBodySize": {
                             "description": "Default maximum size of a client request body in bytes (default: 1048576)",
                             "type": "integer"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -455,6 +455,14 @@ providers:
     httpEntryPoint: ""
     # -- Defines the EntryPoint to use for HTTPS requests
     httpsEntryPoint: ""
+    # @schema additionalProperties: false
+    modsec:
+      # -- Enable ModSec engine. Requires Traefik Hub >= v3.20.0-ea.8.
+      enabled: false
+      # -- Enable OWASP Core Rules.
+      owaspCoreRules: false
+      # -- Custom ModSec rules snippet.
+      snippet: ""
 
   # @schema additionalProperties: false
   knative:


### PR DESCRIPTION
### What does this PR do?

Add support for the Kubernetes Ingress NGINX provider ModSecurity options introduced in Traefik Hub v3.20.0:

- `providers.kubernetesIngressNGINX.modsec.enabled`
- `providers.kubernetesIngressNGINX.modsec.owaspCoreRules`
- `providers.kubernetesIngressNGINX.modsec.snippet`

### Motivation

Expose the ModSecurity WAF engine for the ingress-nginx provider.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed