### PR TITLE
feat(hub): :sparkles: expose multicluster serversTransport TLS and timeout options

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -158,11 +158,20 @@ Kubernetes: `>=1.25.0-0`
 | hub.providers.multicluster.children | object | {} | Child cluster configurations, keyed by a unique name. |
 | hub.providers.multicluster.children.cluster-1.address | string | `""` | URL of the child cluster's uplink entrypoint. |
 | hub.providers.multicluster.children.cluster-1.serversTransport | object | {} | TLS and transport configuration for connecting to this child. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.cipherSuites | list | `[]` | List of supported cipher suites for TLS versions up to 1.2. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.disableHTTP2 | string | false | Disable HTTP/2 for connections to this child. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.dialTimeout | string | 30s | Timeout for establishing connections. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.idleConnTimeout | string | 90s | Timeout for idle connections. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.pingTimeout | string | 15s | Timeout for HTTP/2 server ping frames. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.readIdleTimeout | string | 0s | Timeout for HTTP/2 connection idle reads. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.readTimeout | string | 0s | Timeout for reading the request body. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.responseHeaderTimeout | string | 0s | Timeout for reading response headers. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.forwardingTimeouts.writeTimeout | string | 0s | Timeout for writing the response. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.insecureSkipVerify | string | false | Disable TLS certificate verification. **Not recommended for production.** |
 | hub.providers.multicluster.children.cluster-1.serversTransport.maxIdleConnsPerHost | string | 200 | Maximum idle connections per host. |
+| hub.providers.multicluster.children.cluster-1.serversTransport.maxVersion | string | `""` | Maximum TLS version (e.g. `VersionTLS12`, `VersionTLS13`). |
+| hub.providers.multicluster.children.cluster-1.serversTransport.minVersion | string | `""` | Minimum TLS version (e.g. `VersionTLS12`, `VersionTLS13`). |
+| hub.providers.multicluster.children.cluster-1.serversTransport.peerCertURI | string | `""` | URI used to match against SAN URIs during the server's certificate verification. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.serverName | string | `""` | Server name used for SNI and certificate verification. |
 | hub.providers.multicluster.children.cluster-1.serversTransport.spiffe.trustDomain | string | `""` | SPIFFE trust domain. |
 | hub.providers.multicluster.enabled | bool | `false` | Enable Multi-cluster provider. |

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -149,4 +149,16 @@
     {{ fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8." }}
   {{- end }}
 
+  {{- if and $.Values.hub.providers.multicluster.enabled (semverCompare "<v3.20.0-ea.1" $hubVersion) }}
+    {{ fail "ERROR: hub.providers.multicluster is only available for Traefik Hub >= v3.20.0-ea.1." }}
+  {{- end }}
+
+  {{- if semverCompare "<v3.20.0-ea.7" $hubVersion }}
+    {{- range $childName, $childConfig := $.Values.hub.providers.multicluster.children }}
+      {{- if or (($childConfig.serversTransport).forwardingTimeouts).readTimeout (($childConfig.serversTransport).forwardingTimeouts).writeTimeout }}
+        {{ fail "ERROR: hub.providers.multicluster.children.<name>.serversTransport.forwardingTimeouts.readTimeout and .writeTimeout are only available for Traefik Hub >= v3.20.0-ea.7." }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
 {{- end }}

--- a/traefik/tests/hub-multicluster-config_test.yaml
+++ b/traefik/tests/hub-multicluster-config_test.yaml
@@ -71,6 +71,58 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--hub.providers.multicluster.children.child2.serversTransport.certificates[1].keyFile=/certs/client2.key"
 
+  - it: should be possible to configure Traefik Hub multicluster provider serversTransport TLS and timeouts
+    set:
+      hub:
+        token: "xxx"
+        providers:
+          multicluster:
+            enabled: true
+            children:
+              child1:
+                address: https://foo
+                serversTransport:
+                  disableHTTP2: true
+                  minVersion: "VersionTLS12"
+                  maxVersion: "VersionTLS13"
+                  cipherSuites:
+                    - TLS_AES_128_GCM_SHA256
+                    - TLS_AES_256_GCM_SHA384
+                  peerCertURI: "spiffe://example.org/child1"
+                  forwardingTimeouts:
+                    pingTimeout: 20
+                    readIdleTimeout: 30
+                    readTimeout: 10
+                    writeTimeout: 10
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.disableHTTP2=true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.minVersion=VersionTLS12"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.maxVersion=VersionTLS13"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.cipherSuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.peerCertURI=spiffe://example.org/child1"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.forwardingTimeouts.pingTimeout=20"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.forwardingTimeouts.readIdleTimeout=30"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.forwardingTimeouts.readTimeout=10"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.multicluster.children.child1.serversTransport.forwardingTimeouts.writeTimeout=10"
+
   - it: should be possible to configure Traefik Hub uplinkEntryPoints
     set:
       ports:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -375,17 +375,41 @@ tests:
             enabled: true
     asserts:
       - notFailedTemplate: {}
-  - it: should fail when using kubernetesIngressNGINX modsec without Traefik Hub
+  - it: should fail when using multicluster provider on Traefik Hub < v3.20.0-ea.1
     set:
-      providers:
-        kubernetesIngressNGINX:
-          enabled: true
-          modsec:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.19.3
+      hub:
+        token: "xxx"
+        providers:
+          multicluster:
             enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub."
-  - it: should fail when using kubernetesIngressNGINX modsec on Traefik Hub < v3.20.0-ea.8
+          errorMessage: "ERROR: hub.providers.multicluster is only available for Traefik Hub >= v3.20.0-ea.1."
+  - it: should fail when using multicluster serversTransport readTimeout/writeTimeout on Traefik Hub < v3.20.0-ea.7
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.6
+      hub:
+        token: "xxx"
+        providers:
+          multicluster:
+            enabled: true
+            children:
+              child1:
+                address: https://foo
+                serversTransport:
+                  forwardingTimeouts:
+                    readTimeout: 10
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.multicluster.children.<name>.serversTransport.forwardingTimeouts.readTimeout and .writeTimeout are only available for Traefik Hub >= v3.20.0-ea.7."
+  - it: should pass when using multicluster serversTransport readTimeout/writeTimeout on Traefik Hub >= v3.20.0-ea.7
     set:
       image:
         registry: "ghcr.io"
@@ -393,27 +417,16 @@ tests:
         tag: v3.20.0-ea.7
       hub:
         token: "xxx"
-      providers:
-        kubernetesIngressNGINX:
-          enabled: true
-          modsec:
+        providers:
+          multicluster:
             enabled: true
-    asserts:
-      - failedTemplate:
-          errorMessage: "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8."
-  - it: should pass when using kubernetesIngressNGINX modsec on Traefik Hub >= v3.20.0-ea.8
-    set:
-      image:
-        registry: "ghcr.io"
-        repository: "traefik/traefik-hub"
-        tag: v3.20.0-ea.8
-      hub:
-        token: "xxx"
-      providers:
-        kubernetesIngressNGINX:
-          enabled: true
-          modsec:
-            enabled: true
+            children:
+              child1:
+                address: https://foo
+                serversTransport:
+                  forwardingTimeouts:
+                    readTimeout: 10
+                    writeTimeout: 10
     asserts:
       - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -777,6 +777,17 @@
                                                     "certificates": {
                                                         "type": "array"
                                                     },
+                                                    "cipherSuites": {
+                                                        "description": "List of supported cipher suites for TLS versions up to 1.2.",
+                                                        "type": "array"
+                                                    },
+                                                    "disableHTTP2": {
+                                                        "description": "Disable HTTP/2 for connections to this child.",
+                                                        "type": [
+                                                            "boolean",
+                                                            "null"
+                                                        ]
+                                                    },
                                                     "forwardingTimeouts": {
                                                         "type": "object",
                                                         "properties": {
@@ -796,8 +807,40 @@
                                                                     "null"
                                                                 ]
                                                             },
+                                                            "pingTimeout": {
+                                                                "description": "Timeout for HTTP/2 server ping frames.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "readIdleTimeout": {
+                                                                "description": "Timeout for HTTP/2 connection idle reads.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "readTimeout": {
+                                                                "description": "Timeout for reading the request body.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
                                                             "responseHeaderTimeout": {
                                                                 "description": "Timeout for reading response headers.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "writeTimeout": {
+                                                                "description": "Timeout for writing the response.",
                                                                 "type": [
                                                                     "string",
                                                                     "integer",
@@ -819,6 +862,18 @@
                                                             "integer",
                                                             "null"
                                                         ]
+                                                    },
+                                                    "maxVersion": {
+                                                        "description": "Maximum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).",
+                                                        "type": "string"
+                                                    },
+                                                    "minVersion": {
+                                                        "description": "Minimum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).",
+                                                        "type": "string"
+                                                    },
+                                                    "peerCertURI": {
+                                                        "description": "URI used to match against SAN URIs during the server's certificate verification.",
+                                                        "type": "string"
                                                     },
                                                     "rootCAs": {
                                                         "type": "array"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1398,6 +1398,18 @@ hub:  # @schema additionalProperties: false
             # -- Maximum idle connections per host.
             # @default -- 200
             maxIdleConnsPerHost:
+            # @schema type:[boolean, null]
+            # -- Disable HTTP/2 for connections to this child.
+            # @default -- false
+            disableHTTP2:
+            # -- Minimum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).
+            minVersion: ""
+            # -- Maximum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).
+            maxVersion: ""
+            # -- List of supported cipher suites for TLS versions up to 1.2.
+            cipherSuites: []
+            # -- URI used to match against SAN URIs during the server's certificate verification.
+            peerCertURI: ""
             forwardingTimeouts:
               # @schema type:[string, integer, null]
               # -- Timeout for establishing connections.
@@ -1411,6 +1423,22 @@ hub:  # @schema additionalProperties: false
               # -- Timeout for idle connections.
               # @default -- 90s
               idleConnTimeout:
+              # @schema type:[string, integer, null]
+              # -- Timeout for HTTP/2 server ping frames.
+              # @default -- 15s
+              pingTimeout:
+              # @schema type:[string, integer, null]
+              # -- Timeout for HTTP/2 connection idle reads.
+              # @default -- 0s
+              readIdleTimeout:
+              # @schema type:[string, integer, null]
+              # -- Timeout for reading the request body.
+              # @default -- 0s
+              readTimeout:
+              # @schema type:[string, integer, null]
+              # -- Timeout for writing the response.
+              # @default -- 0s
+              writeTimeout:
             spiffe:
               ids: []
               # @schema type:[string, integer, null]


### PR DESCRIPTION
### What does this PR do?

Expose the `hub.providers.multicluster.children.<name>.serversTransport` options already supported by Traefik Hub but missing from the chart values:

- `disableHTTP2`, `minVersion`, `maxVersion`, `cipherSuites`, `peerCertURI`
- `forwardingTimeouts.pingTimeout`, `.readIdleTimeout`, `.readTimeout`, `.writeTimeout`

### Motivation

Allow tuning TLS and transport timeouts when connecting to child clusters.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed