### PR TITLE
feat(hub): :sparkles: support Nutanix Prism Central provider

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -177,6 +177,20 @@ Kubernetes: `>=1.25.0-0`
 | hub.providers.multicluster.enabled | bool | `false` | Enable Multi-cluster provider. |
 | hub.providers.multicluster.pollInterval | int | `5` | Polling interval for Multi-cluster. |
 | hub.providers.multicluster.pollTimeout | int | `5` | Polling timeout for Multi-cluster. |
+| hub.providers.nutanixPrismCentral.allowedVpcs | list | `[]` | Filter VMs by VPCs. List of `{ uuid: "<vpc-uuid>" }` entries. |
+| hub.providers.nutanixPrismCentral.apiKey | string | `""` | Prism Central API key. |
+| hub.providers.nutanixPrismCentral.enabled | bool | `false` | Enable Nutanix Prism Central provider. |
+| hub.providers.nutanixPrismCentral.endpoint | string | `""` | Prism Central endpoint. |
+| hub.providers.nutanixPrismCentral.filename | string | `""` | Base configuration file path. |
+| hub.providers.nutanixPrismCentral.password | string | `""` | Prism Central password. |
+| hub.providers.nutanixPrismCentral.pollInterval | int | `30` | Polling interval for Nutanix Prism Central API. |
+| hub.providers.nutanixPrismCentral.pollTimeout | int | `5` | Polling timeout for Nutanix Prism Central API. |
+| hub.providers.nutanixPrismCentral.serviceNameCategoryKey | string | `"TraefikServiceName"` | Category key used to derive the service name. |
+| hub.providers.nutanixPrismCentral.tls.ca | string | `""` | TLS CA |
+| hub.providers.nutanixPrismCentral.tls.cert | string | `""` | TLS cert |
+| hub.providers.nutanixPrismCentral.tls.insecureSkipVerify | bool | `false` | TLS insecure skip verify |
+| hub.providers.nutanixPrismCentral.tls.key | string | `""` | TLS key |
+| hub.providers.nutanixPrismCentral.username | string | `""` | Prism Central username. |
 | hub.redis.cluster | string | `nil` | Enable Redis Cluster. Default: true. |
 | hub.redis.database | string | `nil` | Database used to store information. Default: "0". |
 | hub.redis.endpoints | string | `""` | Endpoints of the Redis instances to connect to. Default: "". |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -880,6 +880,13 @@
             {{- if .providers.microcks.enabled }}
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.microcks" "content" (omit $.Values.hub.providers.microcks "enabled")) | nindent 10 }}
             {{- end }}
+            {{- if .providers.nutanixPrismCentral.enabled }}
+              {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.nutanixPrismCentral" "content" (omit $.Values.hub.providers.nutanixPrismCentral "enabled" "allowedVpcs")) | nindent 10 }}
+              {{- range $idx, $val := .providers.nutanixPrismCentral.allowedVpcs }}
+                {{- $vpcPath := printf "hub.providers.nutanixPrismCentral.allowedVpcs[%d]" $idx }}
+                {{- include "traefik.yaml2CommandLineArgs" (dict "path" $vpcPath "content" $val) | nindent 10 }}
+              {{- end }}
+            {{- end }}
             {{- if .providers.multicluster.enabled }}
           - "--hub.providers.multicluster=true"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.multicluster" "content" (omit $.Values.hub.providers.multicluster "enabled" "children")) | nindent 10 }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -161,4 +161,8 @@
     {{- end }}
   {{- end }}
 
+  {{- if and $.Values.hub.providers.nutanixPrismCentral.enabled (semverCompare "<v3.20.0-ea.1" $hubVersion) }}
+    {{ fail "ERROR: hub.providers.nutanixPrismCentral is only available for Traefik Hub >= v3.20.0-ea.1." }}
+  {{- end }}
+
 {{- end }}

--- a/traefik/tests/hub-nutanix-config_test.yaml
+++ b/traefik/tests/hub-nutanix-config_test.yaml
@@ -1,0 +1,93 @@
+suite: Traefik Hub Nutanix Prism Central provider
+templates:
+  - deployment.yaml
+set:
+  image:
+    registry: ghcr.io
+    repository: traefik/traefik-hub
+    tag: v3.20.0-rc.1
+  hub:
+    token: "xxx"
+tests:
+  - it: should not configure nutanixPrismCentral by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.endpoint="
+
+  - it: should configure nutanixPrismCentral when enabled
+    set:
+      hub:
+        providers:
+          nutanixPrismCentral:
+            enabled: true
+            endpoint: "https://prism.example.com"
+            username: "admin"
+            password: "secret"
+            apiKey: "api-xxx"
+            filename: "/etc/nx.yaml"
+            pollInterval: 30
+            pollTimeout: 5
+            serviceNameCategoryKey: "TraefikServiceName"
+            allowedVpcs:
+              - uuid: "vpc-1"
+              - uuid: "vpc-2"
+            tls:
+              ca: "/tls/ca.crt"
+              cert: "/tls/client.crt"
+              key: "/tls/client.key"
+              insecureSkipVerify: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.endpoint=https://prism.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.username=admin"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.password=secret"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.apiKey=api-xxx"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.filename=/etc/nx.yaml"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.pollInterval=30"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.pollTimeout=5"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.serviceNameCategoryKey=TraefikServiceName"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.allowedVpcs[0].uuid=vpc-1"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.allowedVpcs[1].uuid=vpc-2"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.tls.ca=/tls/ca.crt"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.tls.cert=/tls/client.crt"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.tls.key=/tls/client.key"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral.tls.insecureSkipVerify=true"
+
+  - it: should fail on typo when configuring nutanixPrismCentral
+    set:
+      hub:
+        providers:
+          nutanixPrismCentral:
+            enabled: true
+            endpoints: "https://prism.example.com" # <=== typo: endpoints instead of endpoint
+    asserts:
+      - failedTemplate:
+          errorPattern: "values don't meet the specifications of the schema"

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -429,6 +429,33 @@ tests:
                     writeTimeout: 10
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using nutanixPrismCentral provider on Traefik Hub < v3.20.0-ea.1
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.19.3
+      hub:
+        token: "xxx"
+        providers:
+          nutanixPrismCentral:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.nutanixPrismCentral is only available for Traefik Hub >= v3.20.0-ea.1."
+  - it: should pass when using nutanixPrismCentral provider on Traefik Hub >= v3.20.0-ea.1
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.1
+      hub:
+        token: "xxx"
+        providers:
+          nutanixPrismCentral:
+            enabled: true
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -917,6 +917,73 @@
                                     "type": "integer"
                                 }
                             }
+                        },
+                        "nutanixPrismCentral": {
+                            "type": "object",
+                            "properties": {
+                                "allowedVpcs": {
+                                    "description": "Filter VMs by VPCs. List of `{ uuid: \"\u003cvpc-uuid\u003e\" }` entries.",
+                                    "type": "array"
+                                },
+                                "apiKey": {
+                                    "description": "Prism Central API key.",
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "description": "Enable Nutanix Prism Central provider.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Prism Central endpoint.",
+                                    "type": "string"
+                                },
+                                "filename": {
+                                    "description": "Base configuration file path.",
+                                    "type": "string"
+                                },
+                                "password": {
+                                    "description": "Prism Central password.",
+                                    "type": "string"
+                                },
+                                "pollInterval": {
+                                    "description": "Polling interval for Nutanix Prism Central API.",
+                                    "type": "integer"
+                                },
+                                "pollTimeout": {
+                                    "description": "Polling timeout for Nutanix Prism Central API.",
+                                    "type": "integer"
+                                },
+                                "serviceNameCategoryKey": {
+                                    "description": "Category key used to derive the service name.",
+                                    "type": "string"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "TLS CA",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "TLS cert",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "TLS insecure skip verify",
+                                            "type": "boolean"
+                                        },
+                                        "key": {
+                                            "description": "TLS key",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "username": {
+                                    "description": "Prism Central username.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
                         }
                     }
                 },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1444,6 +1444,37 @@ hub:  # @schema additionalProperties: false
               # @schema type:[string, integer, null]
               # -- SPIFFE trust domain.
               trustDomain: ""
+    # @schema additionalProperties: false
+    nutanixPrismCentral:
+      # -- Enable Nutanix Prism Central provider.
+      enabled: false
+      # -- Prism Central endpoint.
+      endpoint: ""
+      # -- Prism Central username.
+      username: ""
+      # -- Prism Central password.
+      password: ""
+      # -- Prism Central API key.
+      apiKey: ""
+      # -- Base configuration file path.
+      filename: ""
+      # -- Polling interval for Nutanix Prism Central API.
+      pollInterval: 30
+      # -- Polling timeout for Nutanix Prism Central API.
+      pollTimeout: 5
+      # -- Category key used to derive the service name.
+      serviceNameCategoryKey: "TraefikServiceName"
+      # -- Filter VMs by VPCs. List of `{ uuid: "<vpc-uuid>" }` entries.
+      allowedVpcs: []
+      tls:
+        # -- TLS CA
+        ca: ""
+        # -- TLS cert
+        cert: ""
+        # -- TLS key
+        key: ""
+        # -- TLS insecure skip verify
+        insecureSkipVerify: false
 
   redis:
     # -- Enable Redis Cluster. Default: true.


### PR DESCRIPTION
### What does this PR do?

Expose the `hub.providers.nutanixPrismCentral` configuration introduced in Traefik Hub v3.20.0-ea.1.

### Motivation

Allow using the Nutanix Prism Central provider to discover services from Nutanix VMs.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed