### PR TITLE
feat(hub): :bento: map Traefik Hub v3.20.0-ea.7+ to Traefik Proxy v3.7.0-rc.1

### DIFF
--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -193,6 +193,8 @@ It requires a dict with "Version" and "Hub".
    {{- if regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $version) }}
      {{- if semverCompare "<v3.19.0-0" $version }}
         {{- $hubProxyVersion = "v3.6.3" }}
+     {{- else if semverCompare ">=v3.20.0-ea.7" $version }}
+        {{- $hubProxyVersion = "v3.7.0-rc.1" }}
      {{- end -}}
    {{- end -}}
    {{- $hubProxyVersion }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -135,6 +135,33 @@ tests:
           nativeLBByDefault: true
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using providers.precedence on Traefik Hub < v3.20.0-ea.7 (proxy < v3.7.0-rc.1)
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.6
+      hub:
+        token: "xxx"
+      providers:
+        precedence:
+          - kubernetesCRD
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1."
+  - it: should pass when using providers.precedence on Traefik Hub >= v3.20.0-ea.7 (proxy >= v3.7.0-rc.1)
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0-ea.7
+      hub:
+        token: "xxx"
+      providers:
+        precedence:
+          - kubernetesCRD
+    asserts:
+      - notFailedTemplate: {}
   - it: should not fail when using traefik-hub API management with namespaced RBACs after v3.19.3
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Update `traefik.proxyVersionFromHub` to map Traefik Hub `>= v3.20.0-ea.7` to Traefik Proxy `v3.7.0-rc.1`, matching the actual Proxy bundled in these Hub releases.

This unlocks Proxy v3.7 feature checks (e.g. `providers.precedence`) when running Traefik Hub v3.20+.

### Motivation

Prevent false-positive `requires traefik >= v3.7.0-rc.1` failures when using Traefik Hub v3.20+.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed