### PR TITLE
fix(deps): bump traefik.io CRDs to release v3.6.14

### DIFF
--- a/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_ingressroutes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressroutes.traefik.io
 spec:
   group: traefik.io
@@ -340,6 +340,9 @@ spec:
                                     - none
                                     - lax
                                     - strict
+                                    - None
+                                    - Lax
+                                    - Strict
                                     type: string
                                   secure:
                                     description: Secure defines whether the cookie
@@ -374,6 +377,7 @@ spec:
                       description: |-
                         Syntax defines the router's rule syntax.
                         More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax
+
                         Deprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.
                       type: string
                   required:

--- a/traefik-crds/crds-files/traefik/traefik.io_ingressroutetcps.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_ingressroutetcps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressroutetcps.traefik.io
 spec:
   group: traefik.io
@@ -123,6 +123,7 @@ spec:
                             description: |-
                               ProxyProtocol defines the PROXY protocol configuration.
                               More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/service/#proxy-protocol
+
                               Deprecated: ProxyProtocol will not be supported in future APIVersions, please use ServersTransport to configure ProxyProtocol instead.
                             properties:
                               version:
@@ -145,6 +146,7 @@ spec:
                               hence fully terminating the connection.
                               It is a duration in milliseconds, defaulting to 100.
                               A negative value means an infinite deadline (i.e. the reading capability is never closed).
+
                               Deprecated: TerminationDelay will not be supported in future APIVersions, please use ServersTransport to configure the TerminationDelay instead.
                             type: integer
                           tls:
@@ -165,6 +167,7 @@ spec:
                       description: |-
                         Syntax defines the router's rule syntax.
                         More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/#rulesyntax
+
                         Deprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.
                       enum:
                       - v3

--- a/traefik-crds/crds-files/traefik/traefik.io_ingressrouteudps.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_ingressrouteudps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressrouteudps.traefik.io
 spec:
   group: traefik.io

--- a/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_middlewares.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: middlewares.traefik.io
 spec:
   group: traefik.io
@@ -231,6 +231,7 @@ spec:
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
+
                       Deprecated: AutoDetect option is deprecated, Content-Type middleware is only meant to be used to enable the content-type detection, please remove any usage of this option.
                     type: boolean
                 type: object
@@ -473,6 +474,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -569,6 +573,11 @@ spec:
                       allowed to be forwarded to the authentication server.
                     format: int64
                     type: integer
+                  maxResponseBodySize:
+                    description: MaxResponseBodySize defines the maximum body size
+                      in bytes allowed in the response from the authentication server.
+                    format: int64
+                    type: integer
                   preserveLocationHeader:
                     description: PreserveLocationHeader defines whether to forward
                       the Location header to the client as is or prefix it with the
@@ -603,8 +612,10 @@ spec:
                         type: boolean
                     type: object
                   trustForwardHeader:
-                    description: 'TrustForwardHeader defines whether to trust (ie:
-                      forward) all X-Forwarded-* headers.'
+                    description: |-
+                      TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+
+                      Deprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.
                     type: boolean
                 type: object
               grpcWeb:
@@ -1211,8 +1222,9 @@ spec:
                   More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/redirectscheme/
                 properties:
                   permanent:
-                    description: Permanent defines whether the redirection is permanent
-                      (308).
+                    description: |-
+                      Permanent defines whether the redirection is permanent.
+                      For HTTP GET requests a 301 is returned, otherwise a 308 is returned.
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.

--- a/traefik-crds/crds-files/traefik/traefik.io_middlewaretcps.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_middlewaretcps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: middlewaretcps.traefik.io
 spec:
   group: traefik.io
@@ -69,8 +69,9 @@ spec:
                 description: |-
                   IPWhiteList defines the IPWhiteList middleware configuration.
                   This middleware accepts/refuses connections based on the client IP.
-                  Deprecated: please use IPAllowList instead.
                   More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/ipwhitelist/
+
+                  Deprecated: please use IPAllowList instead.
                 properties:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of

--- a/traefik-crds/crds-files/traefik/traefik.io_serverstransports.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_serverstransports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverstransports.traefik.io
 spec:
   group: traefik.io
@@ -139,6 +139,7 @@ spec:
               rootCAsSecrets:
                 description: |-
                   RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.
+
                   Deprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.
                 items:
                   type: string

--- a/traefik-crds/crds-files/traefik/traefik.io_serverstransporttcps.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_serverstransporttcps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverstransporttcps.traefik.io
 spec:
   group: traefik.io
@@ -124,6 +124,7 @@ spec:
                   rootCAsSecrets:
                     description: |-
                       RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.
+
                       Deprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.
                     items:
                       type: string

--- a/traefik-crds/crds-files/traefik/traefik.io_tlsoptions.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_tlsoptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tlsoptions.traefik.io
 spec:
   group: traefik.io
@@ -103,6 +103,7 @@ spec:
                 description: |-
                   PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
                   It is enabled automatically when minVersion or maxVersion is set.
+
                   Deprecated: https://github.com/golang/go/issues/45430
                 type: boolean
               sniStrict:

--- a/traefik-crds/crds-files/traefik/traefik.io_tlsstores.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_tlsstores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tlsstores.traefik.io
 spec:
   group: traefik.io

--- a/traefik-crds/crds-files/traefik/traefik.io_traefikservices.yaml
+++ b/traefik-crds/crds-files/traefik/traefik.io_traefikservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: traefikservices.traefik.io
 spec:
   group: traefik.io
@@ -251,6 +251,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -580,6 +583,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -729,6 +735,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only
@@ -963,6 +972,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1033,6 +1045,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only

--- a/traefik/crds/traefik.io_ingressroutes.yaml
+++ b/traefik/crds/traefik.io_ingressroutes.yaml
@@ -340,6 +340,9 @@ spec:
                                     - none
                                     - lax
                                     - strict
+                                    - None
+                                    - Lax
+                                    - Strict
                                     type: string
                                   secure:
                                     description: Secure defines whether the cookie

--- a/traefik/crds/traefik.io_middlewares.yaml
+++ b/traefik/crds/traefik.io_middlewares.yaml
@@ -474,6 +474,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -609,8 +612,10 @@ spec:
                         type: boolean
                     type: object
                   trustForwardHeader:
-                    description: 'TrustForwardHeader defines whether to trust (ie:
-                      forward) all X-Forwarded-* headers.'
+                    description: |-
+                      TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+
+                      Deprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.
                     type: boolean
                 type: object
               grpcWeb:

--- a/traefik/crds/traefik.io_traefikservices.yaml
+++ b/traefik/crds/traefik.io_traefikservices.yaml
@@ -251,6 +251,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -580,6 +583,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -729,6 +735,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only
@@ -963,6 +972,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -1033,6 +1045,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only


### PR DESCRIPTION
### What does this PR do?

Updates the CRDs to match with the Traefik v3.6.14

### Motivation

Be up to date


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

