### PR TITLE
feat(image): add image.digest for digest-based pinning

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -213,6 +213,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceId | string | `""` | Name of the header that will contain the trace-id copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceParent | string | `""` | Name of the header that will contain the traceparent copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
+| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version. |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
 | image.registry | string | `"docker.io"` | Traefik image host registry |
 | image.repository | string | `"traefik"` | Traefik image repository |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -213,7 +213,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceId | string | `""` | Name of the header that will contain the trace-id copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceParent | string | `""` | Name of the header that will contain the traceparent copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
-| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
+| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`. |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
 | image.registry | string | `"docker.io"` | Traefik image host registry |
 | image.repository | string | `"traefik"` | Traefik image repository |
@@ -578,7 +578,7 @@ Kubernetes: `>=1.25.0-0`
 | updateStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | updateStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | updateStrategy.type | string | `"RollingUpdate"` | Customize updateStrategy of Deployment or DaemonSet |
-| versionOverride | string | `""` | This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest. |
+| versionOverride | string | `""` | This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`). |
 | volumes | list | `[]` | Add volumes to the traefik pod. The volume name will be passed to tpl. This can be used to mount a cert pair or a configmap that holds a config.toml file. After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg: `additionalArguments: - "--providers.file.filename=/config/dynamic.toml" - "--ping" - "--ping.entrypoint=web"` |
 
 ----------------------------------------------

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -217,7 +217,7 @@ Kubernetes: `>=1.25.0-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
 | image.registry | string | `"docker.io"` | Traefik image host registry |
 | image.repository | string | `"traefik"` | Traefik image repository |
-| image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`. |
+| image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
 | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
 | ingressClass.isDefaultClass | bool | `true` |  |
 | ingressClass.name | string | `""` |  |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -213,7 +213,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceId | string | `""` | Name of the header that will contain the trace-id copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceParent | string | `""` | Name of the header that will contain the traceparent copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
-| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`. |
+| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
 | image.registry | string | `"docker.io"` | Traefik image host registry |
 | image.repository | string | `"traefik"` | Traefik image repository |
@@ -578,7 +578,7 @@ Kubernetes: `>=1.25.0-0`
 | updateStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | updateStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | updateStrategy.type | string | `"RollingUpdate"` | Customize updateStrategy of Deployment or DaemonSet |
-| versionOverride | string | `""` | This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`). |
+| versionOverride | string | `""` | This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest. |
 | volumes | list | `[]` | Add volumes to the traefik pod. The volume name will be passed to tpl. This can be used to mount a cert pair or a configmap that holds a config.toml file. After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg: `additionalArguments: - "--providers.file.filename=/config/dynamic.toml" - "--ping" - "--ping.entrypoint=web"` |
 
 ----------------------------------------------

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -213,11 +213,11 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceId | string | `""` | Name of the header that will contain the trace-id copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceParent | string | `""` | Name of the header that will contain the traceparent copy. |
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
-| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version. |
+| image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
 | image.registry | string | `"docker.io"` | Traefik image host registry |
 | image.repository | string | `"traefik"` | Traefik image repository |
-| image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. When a digest is required, `versionOverride` can be used to set the version. |
+| image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`. |
 | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
 | ingressClass.isDefaultClass | bool | `true` |  |
 | ingressClass.name | string | `""` |  |
@@ -578,7 +578,7 @@ Kubernetes: `>=1.25.0-0`
 | updateStrategy.rollingUpdate.maxSurge | int | `1` |  |
 | updateStrategy.rollingUpdate.maxUnavailable | int | `0` |  |
 | updateStrategy.type | string | `"RollingUpdate"` | Customize updateStrategy of Deployment or DaemonSet |
-| versionOverride | string | `""` | This field overrides the default version extracted from image.tag |
+| versionOverride | string | `""` | This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest. |
 | volumes | list | `[]` | Add volumes to the traefik pod. The volume name will be passed to tpl. This can be used to mount a cert pair or a configmap that holds a config.toml file. After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg: `additionalArguments: - "--providers.file.filename=/config/dynamic.toml" - "--ping" - "--ping.entrypoint=web"` |
 
 ----------------------------------------------

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -30,6 +30,8 @@ Create the chart image name.
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.proxy.registry .Values.global.azure.images.proxy.image .Values.global.azure.images.proxy.tag }}
  {{- end -}}
+{{- else if .Values.image.digest -}}
+{{- printf "%s/%s@%s" .Values.image.registry .Values.image.repository .Values.image.digest }}
 {{- else -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end -}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -112,8 +112,11 @@
 {{- if $.Values.hub.token -}}
   {{ $hubVersion := $.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag }}
   {{ $hubVersion = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $hubVersion) }}
+  {{- if and (not $hubVersion) $.Values.versionOverride }}
+    {{- $hubVersion = $.Values.versionOverride }}
+  {{- end }}
   {{ if not $hubVersion }}
-    {{ fail "When using Traefik Hub image tag needs to be specified!" }}
+    {{ fail "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride." }}
   {{- end -}}
 
   {{ $hubVersion = (split "@" (default "v3" $hubVersion))._0 }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -50,6 +50,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: docker.io/traefik@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  - it: should preserve the legacy tag@digest combo in image.tag
+    set:
+      image:
+        tag: v3.7.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik:v3.7.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   - it: should fail validation for invalid image.digest format
     set:
       image:

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -33,6 +33,44 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: example.org/traefik:v3.6.10
+  - it: should use digest when image.digest is specified
+    set:
+      image:
+        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  - it: should let image.digest take precedence over image.tag
+    set:
+      image:
+        tag: v3.7.0
+        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  - it: should fail validation for invalid image.digest format
+    set:
+      image:
+        digest: not-a-valid-digest
+    asserts:
+      - failedTemplate:
+          errorPattern: "image/digest.*does not match pattern"
+  - it: should fail validation when image.digest uses uppercase hex characters
+    set:
+      image:
+        digest: sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789
+    asserts:
+      - failedTemplate:
+          errorPattern: "image/digest.*does not match pattern"
+  - it: should fail validation when image.digest hex is not 64 chars
+    set:
+      image:
+        digest: sha256:abc123
+    asserts:
+      - failedTemplate:
+          errorPattern: "image/digest.*does not match pattern"
 
   - it: should have no resource limit by default
     asserts:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -30,6 +30,13 @@ tests:
         tag: experimental-master
     asserts:
       - notFailedTemplate: {}
+  - it: should pass with image.digest alone — version-aware logic falls back to appVersion (no versionOverride needed)
+    set:
+      image:
+        tag: null
+        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    asserts:
+      - notFailedTemplate: {}
   - it: should not pass when trying to use this Chart with unknown tag
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -91,6 +91,30 @@ tests:
         token: xxx
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using Traefik Hub with image.digest but no versionOverride
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: null
+        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      hub:
+        token: xxx
+    asserts:
+      - failedTemplate:
+          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
+  - it: should succeed when using Traefik Hub with image.digest and versionOverride
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: null
+        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      versionOverride: v3.19.3
+      hub:
+        token: xxx
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when trying to use this Chart with a stable Hub version above max
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -30,13 +30,6 @@ tests:
         tag: experimental-master
     asserts:
       - notFailedTemplate: {}
-  - it: should pass with image.digest alone — version-aware logic falls back to appVersion (no versionOverride needed)
-    set:
-      image:
-        tag: null
-        digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-    asserts:
-      - notFailedTemplate: {}
   - it: should not pass when trying to use this Chart with unknown tag
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -69,7 +69,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "When using Traefik Hub image tag needs to be specified!"
+          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
   - it: should fail when trying to use this Chart with Traefik Hub < v3.19.3
     set:
       image:
@@ -319,7 +319,7 @@ tests:
         token: "xxx"
     asserts:
       - failedTemplate:
-          errorMessage: "When using Traefik Hub image tag needs to be specified!"
+          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
   - it: should not fail when using Traefik Hub with tag set for OCI
     set:
       hub:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1126,7 +1126,7 @@
             "type": "object",
             "properties": {
                 "digest": {
-                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`.",
+                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).",
                     "type": [
                         "string",
                         "null"
@@ -3219,7 +3219,7 @@
             "additionalProperties": false
         },
         "versionOverride": {
-            "description": "This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`).",
+            "description": "This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.",
             "type": "string"
         },
         "volumes": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1126,7 +1126,7 @@
             "type": "object",
             "properties": {
                 "digest": {
-                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).",
+                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`.",
                     "type": [
                         "string",
                         "null"
@@ -3219,7 +3219,7 @@
             "additionalProperties": false
         },
         "versionOverride": {
-            "description": "This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.",
+            "description": "This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`).",
             "type": "string"
         },
         "volumes": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1126,7 +1126,7 @@
             "type": "object",
             "properties": {
                 "digest": {
-                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version.",
+                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).",
                     "type": [
                         "string",
                         "null"
@@ -1146,7 +1146,7 @@
                     "type": "string"
                 },
                 "tag": {
-                    "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. When a digest is required, `versionOverride` can be used to set the version.",
+                    "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.",
                     "type": [
                         "string",
                         "null"
@@ -3219,7 +3219,7 @@
             "additionalProperties": false
         },
         "versionOverride": {
-            "description": "This field overrides the default version extracted from image.tag",
+            "description": "This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.",
             "type": "string"
         },
         "volumes": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1146,7 +1146,7 @@
                     "type": "string"
                 },
                 "tag": {
-                    "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.",
+                    "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `\u003cversion\u003e@\u003cdigest\u003e` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).",
                     "type": [
                         "string",
                         "null"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1125,6 +1125,14 @@
         "image": {
             "type": "object",
             "properties": {
+                "digest": {
+                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "pattern": "^sha256:[a-f0-9]{64}$"
+                },
                 "pullPolicy": {
                     "description": "Traefik image pull policy",
                     "type": "string"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -10,7 +10,7 @@ image:  # @schema additionalProperties: false
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.
   tag:  # @schema type:[string, null]
-  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
+  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`.
   digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
   # -- Traefik image pull policy
   pullPolicy: IfNotPresent
@@ -1248,7 +1248,7 @@ namespaceOverride: ""
 # -- This field overrides the default app.kubernetes.io/instance label for all Objects.
 instanceLabelOverride: ""
 
-# -- This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.
+# -- This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`).
 versionOverride: ""
 
 # -- overrides the app.kubernetes.io/name label

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -10,6 +10,8 @@ image:  # @schema additionalProperties: false
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # When a digest is required, `versionOverride` can be used to set the version.
   tag:  # @schema type:[string, null]
+  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version.
+  digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
   # -- Traefik image pull policy
   pullPolicy: IfNotPresent
 

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -8,7 +8,7 @@ image:  # @schema additionalProperties: false
   # -- Traefik image repository
   repository: traefik
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
-  # To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.
+  # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
   tag:  # @schema type:[string, null]
   # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
   digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -8,9 +8,9 @@ image:  # @schema additionalProperties: false
   # -- Traefik image repository
   repository: traefik
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
-  # When a digest is required, `versionOverride` can be used to set the version.
+  # To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.
   tag:  # @schema type:[string, null]
-  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag` and `versionOverride` should be used to set the version.
+  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
   digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
   # -- Traefik image pull policy
   pullPolicy: IfNotPresent
@@ -1248,7 +1248,7 @@ namespaceOverride: ""
 # -- This field overrides the default app.kubernetes.io/instance label for all Objects.
 instanceLabelOverride: ""
 
-# -- This field overrides the default version extracted from image.tag
+# -- This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.
 versionOverride: ""
 
 # -- overrides the app.kubernetes.io/name label

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -10,7 +10,7 @@ image:  # @schema additionalProperties: false
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # To pin by digest instead of tag, use `image.digest`; it takes precedence over `tag`.
   tag:  # @schema type:[string, null]
-  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. The chart's version-aware logic falls back to `appVersion`; only set `versionOverride` if the digest corresponds to a different Traefik version than `appVersion`.
+  # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
   digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
   # -- Traefik image pull policy
   pullPolicy: IfNotPresent
@@ -1248,7 +1248,7 @@ namespaceOverride: ""
 # -- This field overrides the default app.kubernetes.io/instance label for all Objects.
 instanceLabelOverride: ""
 
-# -- This field overrides the default version extracted from image.tag (or `appVersion` when pinning by `image.digest`).
+# -- This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.
 versionOverride: ""
 
 # -- overrides the app.kubernetes.io/name label


### PR DESCRIPTION
### What does this PR do?

Adds `image.digest` to the `image` section of `values.yaml`. When set, it takes precedence over `image.tag` and the rendered image reference switches to the `registry/repository@sha256:<hex>` form. The field is validated by a strict schema pattern (`^sha256:[a-f0-9]{64}$`) so misconfiguration fails at `helm install/upgrade` time rather than on the cluster. `versionOverride` continues to be how the chart's version-checking logic learns the version when pinning by digest.

### Motivation

Closes (https://github.com/traefik/traefik-helm-chart/issues/1820).

Tags are *mutable* pointers; digests are immutable, content-addressable hashes. Pinning by digest is the baseline supply-chain control recommended by NIST SP 800-204D, the CNCF Software Supply Chain Best Practices, and CIS / NSA Kubernetes hardening guidance. Today, `image.tag` cannot carry a digest because the rendered string uses a `:` separator (`registry/repo:<tag>`), which collides with the `sha256:` prefix. The `image.tag` doc comment already acknowledged this gap ("When a digest is required, `versionOverride` can be used to set the version") without offering a field to express it. This PR closes that gap.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
