### PR TITLE
feat(deps): support traefik v3.7.0 & hub v3.20.0

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -13,16 +13,5 @@ if ! helm plugin list 2>/dev/null | awk 'NR>1 && $1=="unittest"{found=1} END{exi
   exit 1
 fi
 
-# Pin version-support annotations so tests stay decoupled from the real
-# supported ranges shipped with releases. Restore on exit.
-cp traefik/Chart.yaml /tmp/traefik-Chart.yaml.bak
-trap 'mv /tmp/traefik-Chart.yaml.bak traefik/Chart.yaml' EXIT
-sed -i \
-  -e 's|traefik.io/proxy-min-version:.*|traefik.io/proxy-min-version: v3.6.0|' \
-  -e 's|traefik.io/proxy-max-version:.*|traefik.io/proxy-max-version: v3.6.12|' \
-  -e 's|traefik.io/hub-min-version:.*|traefik.io/hub-min-version: v3.19.3|' \
-  -e 's|traefik.io/hub-max-version:.*|traefik.io/hub-max-version: v3.20.0-ea.1|' \
-  traefik/Chart.yaml
-
 helm unittest --color ./traefik
 helm unittest --color ./traefik-crds

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -23,9 +23,9 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   traefik.io/proxy-min-version: v3.6.0
-  traefik.io/proxy-max-version: v3.7.0-rc.2
+  traefik.io/proxy-max-version: v3.7.0
   traefik.io/hub-min-version: v3.19.3
-  traefik.io/hub-max-version: v3.20.0-rc.1
+  traefik.io/hub-max-version: v3.20.0
   artifacthub.io/changes: |
     - "fix(CRDs): content item admission webhook name"
     - "feat: add service.nameOverride for adopting existing Services"

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -4,7 +4,7 @@ description: A Traefik based Kubernetes ingress controller
 type: application
 version: 40.0.0-rc.2
 # renovate: image=traefik
-appVersion: v3.7.0-rc.2
+appVersion: v3.7.0
 kubeVersion: ">=1.25.0-0"
 keywords:
   - traefik

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 40.0.0-rc.2](https://img.shields.io/badge/Version-40.0.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.0-rc.2](https://img.shields.io/badge/AppVersion-v3.7.0--rc.2-informational?style=flat-square)
+![Version: 40.0.0-rc.2](https://img.shields.io/badge/Version-40.0.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.0](https://img.shields.io/badge/AppVersion-v3.7.0-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -196,8 +196,8 @@ It requires a dict with "Version" and "Hub".
      {{- if semverCompare "<v3.19.0-0" $version }}
         {{- $hubProxyVersion = "v3.6.3" }}
      {{- else if semverCompare "<v3.20.0-ea.7" $version }}
-        {{- $hubProxyVersion := "v3.6.7" }}
-     {{- else if semverCompare "<v3.20.0" $version }}
+        {{- $hubProxyVersion = "v3.6.7" }}
+     {{- else if semverCompare "<v3.20.0-0" $version }}
         {{- $hubProxyVersion = "v3.7.0-rc.1" }}
      {{- end -}}
    {{- end -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -191,11 +191,13 @@ It requires a dict with "Version" and "Hub".
 {{- define "traefik.proxyVersionFromHub" -}}
  {{- $version := .Version -}}
  {{- if .Hub -}}
-   {{- $hubProxyVersion := "v3.6.7" }}
+   {{- $hubProxyVersion := "v3.7.0" }}
    {{- if regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $version) }}
      {{- if semverCompare "<v3.19.0-0" $version }}
         {{- $hubProxyVersion = "v3.6.3" }}
-     {{- else if semverCompare ">=v3.20.0-ea.7" $version }}
+     {{- else if semverCompare "<v3.20.0-ea.7" $version }}
+        {{- $hubProxyVersion := "v3.6.7" }}
+     {{- else if semverCompare "<v3.20.0" $version }}
         {{- $hubProxyVersion = "v3.7.0-rc.1" }}
      {{- end -}}
    {{- end -}}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -41,26 +41,14 @@ tests:
   - it: should fail when trying to use this Chart with a stable Proxy version above max
     set:
       image:
-        tag: v3.7.0
+        tag: v3.8.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.6.12."
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.0."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:
-        tag: v3.7.0-ea.1
-    asserts:
-      - notFailedTemplate: {}
-  - it: should not fail when trying to use this Chart with a Proxy version within range
-    set:
-      image:
-        tag: v3.6.10
-    asserts:
-      - notFailedTemplate: {}
-  - it: should not fail when trying to use this Chart with an ea Proxy version within range
-    set:
-      image:
-        tag: v3.6.10-ea.1
+        tag: v3.8.0-ea.1
     asserts:
       - notFailedTemplate: {}
   - it: should fail when trying to use this Chart with Traefik Proxy v3 and Hub enabled
@@ -101,7 +89,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.0-ea.1."
+          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.0."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:
@@ -112,17 +100,6 @@ tests:
         token: xxx
     asserts:
       - notFailedTemplate: {}
-  - it: should fail when trying to use this Chart with the stable release above ea max Hub version
-    set:
-      image:
-        registry: ghcr.io
-        repository: traefik/traefik-hub
-        tag: v3.20.0
-      hub:
-        token: xxx
-    asserts:
-      - failedTemplate:
-          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.0-ea.1."
   - it: should not fail when trying to use this Chart with a Hub version within range
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Update traefik docker tag to v3.7.0

### Motivation

Support latest release

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed