### PR TITLE
feat(provider/kubernetesIngressNGINX): set default values on httpentrypoint & httpsentrypoint

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -493,8 +493,8 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.endpoint | string | `""` | Kubernetes server endpoint (required for external cluster client) |
 | providers.kubernetesIngressNGINX.globalAllowedResponseHeaders | list | `[]` | List of allowed response headers inside the custom headers annotations |
 | providers.kubernetesIngressNGINX.globalAuthUrl | string | `""` | URL to the service that provides authentication for all the locations. Per ingress auth-url annotation has precedence over this option. |
-| providers.kubernetesIngressNGINX.httpEntryPoint | string | `""` | Defines the EntryPoint to use for HTTP requests |
-| providers.kubernetesIngressNGINX.httpsEntryPoint | string | `""` | Defines the EntryPoint to use for HTTPS requests |
+| providers.kubernetesIngressNGINX.httpEntryPoint | string | `"web"` | Defines the EntryPoint to use for HTTP requests |
+| providers.kubernetesIngressNGINX.httpsEntryPoint | string | `"websecure"` | Defines the EntryPoint to use for HTTPS requests |
 | providers.kubernetesIngressNGINX.ingressClass | string | `"nginx"` | Name of the ingress class this controller satisfies |
 | providers.kubernetesIngressNGINX.ingressClassByName | bool | `false` | Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class |
 | providers.kubernetesIngressNGINX.ipAllowListStrategy | object | See below | When set, the strategy is applied to every generated IPAllowList middleware. |

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -58,8 +58,9 @@
     (ne .allowCrossNamespaceResources nil)
     (not (empty .globalAllowedResponseHeaders))
     (ne .allowSnippetAnnotations nil)
-    (not (empty .httpEntryPoint))
-    (not (empty .httpsEntryPoint)) )}}
+    (ne .httpEntryPoint "web")
+    (ne .httpsEntryPoint "websecure")
+    )}}
     {{- fail "ERROR: some Kubernetes Ingress NGINX provider options require traefik >= v3.7.0." }}
   {{- end }}
 {{- end }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -188,7 +188,7 @@ tests:
       providers:
         kubernetesIngressNGINX:
           enabled: true
-          httpEntryPoint: "web"
+          httpEntryPoint: "metrics"
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: some Kubernetes Ingress NGINX provider options require traefik >= v3.7.0."

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -467,9 +467,9 @@ providers:
     # -- Defines whether to reject the entire ingress when any path contains regex characters and pathType is Prefix or Exact (default: true)
     strictValidatePathType: null  # @schema type:[boolean, null]
     # -- Defines the EntryPoint to use for HTTP requests
-    httpEntryPoint: ""
+    httpEntryPoint: "web"
     # -- Defines the EntryPoint to use for HTTPS requests
-    httpsEntryPoint: ""
+    httpsEntryPoint: "websecure"
     # @schema additionalProperties: false
     modsec:
       # -- Enable ModSec engine. Requires Traefik Hub >= v3.20.0-ea.8.


### PR DESCRIPTION
### What does this PR do?

1. Set httpentrypoint to `web` by default
2. Set httpsentrypoint to `websecure` by default

### Motivation

Consistency: this chart provides those entrypoints by default.

