### PR TITLE
ci: fix renovate config & deprecation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,8 @@
     ':semanticCommitTypeAll(chore)',
     'helpers:pinGitHubActionDigests',
     // Update appVersion in Chart.yaml
-    'customManagers:helmChartYamlAppVersions'
-    'config:recommended',
+    'customManagers:helmChartYamlAppVersions',
+    'config:recommended'
   ],
   semanticCommits: 'enabled',
   gitAuthor: 'traefiker <30906710+traefiker@users.noreply.github.com>',

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### What does this PR do?

1. Fix renovate config typo in config array
2. Fix deprecation warning that can be seen in [last successfull run](https://github.com/traefik/traefik-helm-chart/actions/runs/25436274145): `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

### Motivation

Fix CI.
