### PR TITLE
fix(ingressroute): :bug: use spec.ingressClassName with Proxy v3.7+

### DIFF
--- a/traefik/templates/ingressroute.yaml
+++ b/traefik/templates/ingressroute.yaml
@@ -1,8 +1,14 @@
 {{ range $name, $config := .Values.ingressRoute }}
 {{ if $config.enabled }}
-{{ $ingressClassAnnotations := dict }}
+{{- $version := include "traefik.proxyVersion" $ }}
+{{ $ingressClassName := "" }}
 {{- if and $.Values.ingressClass.enabled $.Values.providers.kubernetesCRD.enabled $.Values.providers.kubernetesCRD.ingressClass }}
-  {{ $ingressClassAnnotations = dict "kubernetes.io/ingress.class" $.Values.providers.kubernetesCRD.ingressClass }}
+  {{ $ingressClassName = $.Values.providers.kubernetesCRD.ingressClass }}
+{{- end }}
+{{ $useIngressClassNameField := semverCompare ">=v3.7.0-0" $version }}
+{{ $ingressClassAnnotations := dict }}
+{{- if and $ingressClassName (not $useIngressClassNameField) }}
+  {{ $ingressClassAnnotations = dict "kubernetes.io/ingress.class" $ingressClassName }}
 {{- end }}
 {{ $annotations := merge $ingressClassAnnotations (default $config.annotations dict) }}
 ---
@@ -21,6 +27,9 @@ metadata:
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and $ingressClassName $useIngressClassNameField }}
+  ingressClassName: {{ $ingressClassName }}
+  {{- end }}
   entryPoints:
   {{- range $config.entryPoints }}
   - {{ . }}

--- a/traefik/tests/dashboard-ingressroute_test.yaml
+++ b/traefik/tests/dashboard-ingressroute_test.yaml
@@ -101,8 +101,25 @@ tests:
   asserts:
   - isNull:
       path: metadata.annotations
-- it: should use the ingress class name for the annotation
+  - isNull:
+      path: spec.ingressClassName
+- it: should set spec.ingressClassName when an ingressClass is configured on Traefik >= v3.7.0
   set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+    providers:
+      kubernetesCRD:
+        ingressClass: test-class
+  asserts:
+  - isNull:
+      path: metadata.annotations
+  - equal:
+      path: spec.ingressClassName
+      value: test-class
+- it: should fall back to the legacy annotation when an ingressClass is configured on Traefik < v3.7.0
+  set:
+    versionOverride: v3.6.0
     ingressRoute:
       dashboard:
         enabled: true
@@ -114,6 +131,8 @@ tests:
       path: metadata.annotations
       value:
         kubernetes.io/ingress.class: test-class
+  - isNull:
+      path: spec.ingressClassName
 - it: should insert annotations correctly and give precedence to user annotations
   set:
     ingressRoute:


### PR DESCRIPTION
### What does this PR do?

Sets `spec.ingressClassName` on the dashboard and healthcheck `IngressRoute` objects when `providers.kubernetesCRD.ingressClass` is configured and Traefik version used > v3.7.0.

### Motivation

Fixes #1837.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed