### PR TITLE
feat(api): support disableDashboardAd option

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -34,6 +34,7 @@ Kubernetes: `>=1.25.0-0`
 | api.dashboard | bool | `true` | Enable the dashboard |
 | api.dashboardName | string | `""` | Custom name for the dashboard (v3.7+). |
 | api.debug | string | `nil` | Enable the debug API |
+| api.disableDashboardAd | string | `nil` | Disable the advertisement from the dashboard. |
 | api.insecure | string | `nil` | Enable the insecure API (HTTP) |
 | autoscaling.behavior | object | `{}` | behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). |
 | autoscaling.enabled | bool | `false` | Create HorizontalPodAutoscaler object. See EXAMPLES.md for more details. |

--- a/traefik/tests/api_test.yaml
+++ b/traefik/tests/api_test.yaml
@@ -58,6 +58,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--api.dashboardName=My Traefik"
+  - it: should disable the dashboard advertisement when configured
+    set:
+      api:
+        disableDashboardAd: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--api.disableDashboardAd=true"
   - it: should fail if ingressRoute.dashboard is enabled but api.dashboard is false
     set:
       api:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -46,6 +46,13 @@
                         "null"
                     ]
                 },
+                "disableDashboardAd": {
+                    "description": "Disable the advertisement from the dashboard.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "insecure": {
                     "description": "Enable the insecure API (HTTP)",
                     "type": [

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -207,6 +207,8 @@ api:  # @schema additionalProperties: false
   dashboard: true
   # -- Custom name for the dashboard (v3.7+).
   dashboardName: ""  # @schema type:[string, null]
+  # -- Disable the advertisement from the dashboard.
+  disableDashboardAd:  # @schema type:[boolean, null]
   # -- Enable the insecure API (HTTP)
   insecure:  # @schema type:[boolean, null]
   # -- Enable the debug API


### PR DESCRIPTION
### What does this PR do?

Adds the `api.disableDashboardAd` Helm value so users can configure Traefik's `api.disableDashboardAd` static option from the chart values.

This also updates the generated values documentation, regenerates the values schema with the Helm schema plugin, and adds a unit test covering the rendered Deployment container argument.

### Motivation

Traefik's API and dashboard configuration options now include `api.disableDashboardAd`, but the Helm chart values did not expose this option yet:
```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
traefik:
- at '/api': additional properties 'disabledashboardad' not allowed
```

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed