### PR TITLE
feat(provider): :sparkles: support crossProviderNamespaces on kubernetes providers

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -454,11 +454,13 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesCRD.allowCrossNamespace | bool | `false` | Allows IngressRoute to reference resources in namespace other than theirs |
 | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
 | providers.kubernetesCRD.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in IngressRoute |
+| providers.kubernetesCRD.crossProviderNamespaces | list | `[]` | List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+). |
 | providers.kubernetesCRD.enabled | bool | `true` | Load Kubernetes IngressRoute provider |
 | providers.kubernetesCRD.ingressClass | string | `""` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
 | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
 | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
+| providers.kubernetesGateway.crossProviderNamespaces | list | `[]` | List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+). |
 | providers.kubernetesGateway.enabled | bool | `false` | Enable Traefik Gateway provider for Gateway API |
 | providers.kubernetesGateway.experimentalChannel | bool | `false` | Toggles support for the Experimental Channel resources (Gateway API release channels documentation). This option currently enables support for TCPRoute and TLSRoute. |
 | providers.kubernetesGateway.labelSelector | string | `""` | A label selector can be defined to filter on specific GatewayClass objects only. |
@@ -471,6 +473,7 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesGateway.statusAddress.service.namespace | string | `""` |  |
 | providers.kubernetesIngress.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
 | providers.kubernetesIngress.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in Ingress |
+| providers.kubernetesIngress.crossProviderNamespaces | list | `[]` | List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+). |
 | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
 | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
 | providers.kubernetesIngress.ingressClass | string | `nil` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -454,13 +454,13 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesCRD.allowCrossNamespace | bool | `false` | Allows IngressRoute to reference resources in namespace other than theirs |
 | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
 | providers.kubernetesCRD.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in IngressRoute |
-| providers.kubernetesCRD.crossProviderNamespaces | list | `[]` | List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+). |
+| providers.kubernetesCRD.crossProviderNamespaces | list | `[]` | List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+. |
 | providers.kubernetesCRD.enabled | bool | `true` | Load Kubernetes IngressRoute provider |
 | providers.kubernetesCRD.ingressClass | string | `""` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
 | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
 | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
-| providers.kubernetesGateway.crossProviderNamespaces | list | `[]` | List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+). |
+| providers.kubernetesGateway.crossProviderNamespaces | list | `[]` | List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+. |
 | providers.kubernetesGateway.enabled | bool | `false` | Enable Traefik Gateway provider for Gateway API |
 | providers.kubernetesGateway.experimentalChannel | bool | `false` | Toggles support for the Experimental Channel resources (Gateway API release channels documentation). This option currently enables support for TCPRoute and TLSRoute. |
 | providers.kubernetesGateway.labelSelector | string | `""` | A label selector can be defined to filter on specific GatewayClass objects only. |
@@ -473,7 +473,7 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesGateway.statusAddress.service.namespace | string | `""` |  |
 | providers.kubernetesIngress.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
 | providers.kubernetesIngress.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in Ingress |
-| providers.kubernetesIngress.crossProviderNamespaces | list | `[]` | List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+). |
+| providers.kubernetesIngress.crossProviderNamespaces | list | `[]` | List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+. |
 | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
 | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
 | providers.kubernetesIngress.ingressClass | string | `nil` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -493,6 +493,9 @@
            {{- if .Values.providers.kubernetesCRD.allowCrossNamespace }}
           - "--providers.kubernetescrd.allowCrossNamespace=true"
            {{- end }}
+           {{- with .Values.providers.kubernetesCRD.crossProviderNamespaces }}
+          - "--providers.kubernetescrd.crossProviderNamespaces={{ join "," . }}"
+           {{- end }}
            {{- if .Values.providers.kubernetesCRD.allowExternalNameServices }}
           - "--providers.kubernetescrd.allowExternalNameServices=true"
            {{- end }}
@@ -512,6 +515,9 @@
           - "--providers.kubernetesingress"
            {{- if .Values.providers.kubernetesIngress.allowExternalNameServices }}
           - "--providers.kubernetesingress.allowExternalNameServices=true"
+           {{- end }}
+           {{- with .Values.providers.kubernetesIngress.crossProviderNamespaces }}
+          - "--providers.kubernetesingress.crossProviderNamespaces={{ join "," . }}"
            {{- end }}
            {{- if ne .Values.providers.kubernetesIngress.allowEmptyServices nil }}
             {{- with .Values.providers.kubernetesIngress.allowEmptyServices | toString }}
@@ -571,6 +577,9 @@
             {{- end }}
             {{- if .nativeLBByDefault }}
           - "--providers.kubernetesgateway.nativeLBByDefault=true"
+            {{- end }}
+            {{- with .crossProviderNamespaces }}
+          - "--providers.kubernetesgateway.crossProviderNamespaces={{ join "," . }}"
             {{- end }}
             {{- if or .namespaces (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}
           - "--providers.kubernetesgateway.namespaces={{ template "providers.kubernetesGateway.namespaces" $ }}"

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -89,6 +89,14 @@
   {{- fail "ERROR: global.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.1-0" $version) (or
+    (not (empty .Values.providers.kubernetesCRD.crossProviderNamespaces))
+    (not (empty .Values.providers.kubernetesIngress.crossProviderNamespaces))
+    (not (empty .Values.providers.kubernetesGateway.crossProviderNamespaces))
+    ) }}
+  {{- fail "ERROR: providers.kubernetes{CRD,Ingress,Gateway}.crossProviderNamespaces is only available for traefik >= v3.7.1" }}
+{{- end }}
+
 {{- range $name, $config := .Values.ports }}
   {{- if and $config (($config.forwardedHeaders).notAppendXForwardedFor) (semverCompare "<v3.7.0-0" $version) }}
   {{- fail "ERROR: forwardedHeaders.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -240,6 +240,17 @@ tests:
           - kubernetesCRD
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using crossProviderNamespaces on Traefik Proxy < v3.7.1
+    set:
+      image:
+        tag: v3.7.0
+      providers:
+        kubernetesCRD:
+          crossProviderNamespaces:
+            - ns1
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: providers.kubernetes{CRD,Ingress,Gateway}.crossProviderNamespaces is only available for traefik >= v3.7.1"
   - it: should not fail when using traefik-hub API management with namespaced RBACs after v3.19.3
     set:
       image:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -227,6 +227,44 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetescrd.allowCrossNamespace=true"
+  - it: should set crossProviderNamespaces for kubernetes providers when specified
+    set:
+      image:
+        tag: v3.7.1
+      providers:
+        kubernetesCRD:
+          crossProviderNamespaces:
+            - ns1
+            - ns2
+        kubernetesIngress:
+          crossProviderNamespaces:
+            - ns3
+        kubernetesGateway:
+          enabled: true
+          crossProviderNamespaces:
+            - ns4
+            - ns5
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.crossProviderNamespaces=ns1,ns2"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.crossProviderNamespaces=ns3"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesgateway.crossProviderNamespaces=ns4,ns5"
+  - it: should not set crossProviderNamespaces by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetescrd.crossProviderNamespaces"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingress.crossProviderNamespaces"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesgateway.crossProviderNamespaces"
   - it: should allow external name services when specified in configuration
     set:
       providers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2508,7 +2508,7 @@
                             "type": "boolean"
                         },
                         "crossProviderNamespaces": {
-                            "description": "List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "description": "List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+.",
                             "type": "array"
                         },
                         "enabled": {
@@ -2538,7 +2538,7 @@
                     "type": "object",
                     "properties": {
                         "crossProviderNamespaces": {
-                            "description": "List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "description": "List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+.",
                             "type": "array"
                         },
                         "enabled": {
@@ -2604,7 +2604,7 @@
                             "type": "boolean"
                         },
                         "crossProviderNamespaces": {
-                            "description": "List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "description": "List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+.",
                             "type": "array"
                         },
                         "disableIngressClassLookup": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2507,6 +2507,10 @@
                             "description": "Allows to reference ExternalName services in IngressRoute",
                             "type": "boolean"
                         },
+                        "crossProviderNamespaces": {
+                            "description": "List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "type": "array"
+                        },
                         "enabled": {
                             "description": "Load Kubernetes IngressRoute provider",
                             "type": "boolean"
@@ -2533,6 +2537,10 @@
                 "kubernetesGateway": {
                     "type": "object",
                     "properties": {
+                        "crossProviderNamespaces": {
+                            "description": "List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "type": "array"
+                        },
                         "enabled": {
                             "description": "Enable Traefik Gateway provider for Gateway API",
                             "type": "boolean"
@@ -2594,6 +2602,10 @@
                         "allowExternalNameServices": {
                             "description": "Allows to reference ExternalName services in Ingress",
                             "type": "boolean"
+                        },
+                        "crossProviderNamespaces": {
+                            "description": "List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+).",
+                            "type": "array"
                         },
                         "disableIngressClassLookup": {
                             "description": "Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup)",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -311,7 +311,7 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there are no endpoints available
     allowEmptyServices: true
-    # -- List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    # -- List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+.
     crossProviderNamespaces: []
     # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
     ingressClass: ""
@@ -330,7 +330,7 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there are no endpoints available
     allowEmptyServices: true
-    # -- List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    # -- List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+.
     crossProviderNamespaces: []
     # -- Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup)
     disableIngressClassLookup: false
@@ -362,7 +362,7 @@ providers:
   kubernetesGateway:
     # -- Enable Traefik Gateway provider for Gateway API
     enabled: false
-    # -- List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    # -- List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+.
     crossProviderNamespaces: []
     # -- Toggles support for the Experimental Channel resources (Gateway API release channels documentation).
     # This option currently enables support for TCPRoute and TLSRoute.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -311,6 +311,8 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there are no endpoints available
     allowEmptyServices: true
+    # -- List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    crossProviderNamespaces: []
     # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
     ingressClass: ""
     # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector)
@@ -328,6 +330,8 @@ providers:
     allowExternalNameServices: false
     # -- Allows to return 503 when there are no endpoints available
     allowEmptyServices: true
+    # -- List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    crossProviderNamespaces: []
     # -- Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup)
     disableIngressClassLookup: false
     # -- When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed.
@@ -358,6 +362,8 @@ providers:
   kubernetesGateway:
     # -- Enable Traefik Gateway provider for Gateway API
     enabled: false
+    # -- List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+ (hub v3.20.2+).
+    crossProviderNamespaces: []
     # -- Toggles support for the Experimental Channel resources (Gateway API release channels documentation).
     # This option currently enables support for TCPRoute and TLSRoute.
     experimentalChannel: false


### PR DESCRIPTION
### What does this PR do?

Exposes the new `crossProviderNamespaces` option on `providers.kubernetesCRD`, `providers.kubernetesIngress`, and `providers.kubernetesGateway`. This option was introduced in Traefik Proxy v3.7.1 to declare which namespaces are allowed to make cross-provider references in dynamic configuration.

### Motivation

New option introduced with v3.7.1

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed