### PR TITLE
ci(security): declare contents:write on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,13 @@ on:
 env:
   tag_prefix: v
 
+permissions: {}
+
 jobs:
   traefik:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - name: Checkout

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,9 +10,13 @@ env:
   CACHE_DIR: /tmp/renovate/cache/renovate/repository
   CACHE_KEY: renovate-cache
 
+permissions: {}
+
 jobs:
   renovate:
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
     steps:
       - name: Get token
         id: get_token

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -9,9 +9,13 @@ on:
       - .github/workflows/release.yml
       - .github/workflows/test-changelog.yaml
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Declares `permissions: contents: write` at the workflow level on `.github/workflows/release.yaml`. The job uses `GITHUB_TOKEN` in two places: `mathieudutour/github-tag-action` creates a new git tag (write on contents) and the `mikepenz/release-changelog-builder` step reads commit history. Write covers both. The actual chart push to the Helm registry uses a separately-stored `CHARTS_TOKEN` PAT and the artifact signing uses a GPG key from secrets, so neither participates in the `GITHUB_TOKEN` scope calculation.

The motivation for being explicit even on release-style workflows where `contents: write` is already needed is the supply-chain threat surfaced by CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise). When the inherited default is `read-all`, any tampered third-party action in the chain runs with `id-token`, `packages: write`, `pages: write` and everything else - capping the workflow to the actual minimum (`contents: write` here) drops the rest. OpenSSF Scorecard's Token-Permissions check also credits the explicit declaration.

YAML validated locally with `yaml.safe_load`.
