### PR TITLE
feat(providers.file)!: switch content to an object

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1980,7 +1980,7 @@ hub:
 providers:
   file:
     enabled: true
-    content: |
+    content:
       http:
         uplinks:
           whoami:

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -445,7 +445,7 @@ Kubernetes: `>=1.25.0-0`
 | ports.websecure.transport.respondingTimeouts.readTimeout | string | `nil` |  |
 | ports.websecure.transport.respondingTimeouts.writeTimeout | string | `nil` |  |
 | priorityClassName | string | `""` | [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) |
-| providers.file.content | string | `""` | File content (YAML format, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/) |
+| providers.file.content | object | `{}` | File content as an object (will be YAML-formatted, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/) |
 | providers.file.enabled | bool | `false` | Create a file provider |
 | providers.file.watch | bool | `true` | Allows Traefik to automatically watch for file changes |
 | providers.knative.enabled | bool | `false` | Enable Knative provider |

--- a/traefik/templates/provider-file-cm.yaml
+++ b/traefik/templates/provider-file-cm.yaml
@@ -8,5 +8,5 @@ metadata:
   {{- include "traefik.labels" . | nindent 4 }}
 data:
   config.yml:
-    {{ toYaml .Values.providers.file.content | nindent 4 }}
+    {{ toYaml .Values.providers.file.content | quote | nindent 4 }}
 {{- end -}}

--- a/traefik/templates/provider-file-cm.yaml
+++ b/traefik/templates/provider-file-cm.yaml
@@ -8,5 +8,9 @@ metadata:
   {{- include "traefik.labels" . | nindent 4 }}
 data:
   config.yml:
+  {{- if kindIs "string" .Values.providers.file.content }}
+    {{ .Values.providers.file.content | quote | nindent 4 }}
+  {{- else }}
     {{ toYaml .Values.providers.file.content | quote | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/traefik/templates/provider-file-cm.yaml
+++ b/traefik/templates/provider-file-cm.yaml
@@ -8,9 +8,5 @@ metadata:
   {{- include "traefik.labels" . | nindent 4 }}
 data:
   config.yml:
-  {{- if kindIs "string" .Values.providers.file.content }}
-    {{ .Values.providers.file.content | quote | nindent 4 }}
-  {{- else }}
     {{ toYaml .Values.providers.file.content | quote | nindent 4 }}
-  {{- end }}
 {{- end -}}

--- a/traefik/tests/provider-file_test.yaml
+++ b/traefik/tests/provider-file_test.yaml
@@ -75,7 +75,7 @@ tests:
         file:
           enabled: true
           watch: false
-          content: &x-providers-file-content |-
+          content:
             middlewares:
               Middleware00:
                 addPrefix:
@@ -84,7 +84,11 @@ tests:
       - template: provider-file-cm.yaml
         equal:
           path: data["config.yml"]
-          value: *x-providers-file-content
+          value: |-
+            middlewares:
+              Middleware00:
+                addPrefix:
+                  prefix: foobar
       - template: deployment.yaml
         isNotEmpty:
           path: metadata.annotations["checksum/traefik-dynamic-conf"]

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2461,7 +2461,10 @@
                     "properties": {
                         "content": {
                             "description": "File content as an object (will be YAML-formatted, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)",
-                            "type": "object"
+                            "oneOf": [
+                              {"type": "object"},
+                              {"type": "string"}
+                            ]
                         },
                         "enabled": {
                             "description": "Create a file provider",

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2460,8 +2460,8 @@
                     "type": "object",
                     "properties": {
                         "content": {
-                            "description": "File content (YAML format, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)",
-                            "type": "string"
+                            "description": "File content as an object (will be YAML-formatted, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)",
+                            "type": "object"
                         },
                         "enabled": {
                             "description": "Create a file provider",

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2461,10 +2461,7 @@
                     "properties": {
                         "content": {
                             "description": "File content as an object (will be YAML-formatted, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)",
-                            "oneOf": [
-                              {"type": "object"},
-                              {"type": "string"}
-                            ]
+                            "type": "object"
                         },
                         "enabled": {
                             "description": "Create a file provider",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -390,8 +390,8 @@ providers:
     enabled: false
     # -- Allows Traefik to automatically watch for file changes
     watch: true
-    # -- File content (YAML format, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)
-    content: ""
+    # -- File content as an object (will be YAML-formatted, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)
+    content: {}
 
   # @schema additionalProperties: false
   kubernetesIngressNGINX:


### PR DESCRIPTION
### What does this PR do?

allows structured file content in values.yaml rather than requiring yaml-as-string-in-yaml.

Before:

```yaml
providers:
  file:
    enabled: true
    content: |
      http:
        middlewares: ...
```

After:

```yaml
providers:
  file:
    enabled: true
    content:
      http:
        middlewares: ...
```

This is a backward-incompatible change because it changes the type of `providers.file.content` from string to object, but updating (at least for standard values.yaml deployments) is a matter of removing `|` after `content:`.

If there's a good reason to support both strings and objects, I can do that, too. I don't know if there's a situation where a string is easy and yaml/json is hard.

closes #1860

### Motivation

yaml strings of yaml files in yaml values are harder to read/write/validate than regular yaml structures, where authors get syntax highlighting, autoindent, schema validation, etc.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed


### Future

Importing a json schema for the yaml config file itself would allow validation of the full content of this file, as [suggested here](https://github.com/traefik/traefik-helm-chart/issues/1860#issuecomment-4505287563), but that is not done in this PR.

