### PR TITLE
fix(ingressroute): fail fast on uppercase ingressRoute keys (RFC 1123)

### DIFF
--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -34,7 +34,7 @@
 
 {{- range $name, $config := .Values.ingressRoute }}
   {{- if regexMatch "[A-Z]" $name }}
-    {{- fail (printf "ERROR: ingressRoute key %q contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase). If you meant to enable a provider, use providers.%s instead." $name $name) }}
+    {{- fail (printf "ERROR: ingressRoute key %q contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase)." $name) }}
   {{- end }}
 {{- end }}
 

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -32,6 +32,12 @@
   {{- end }}
 {{- end }}
 
+{{- range $name, $config := .Values.ingressRoute }}
+  {{- if regexMatch "[A-Z]" $name }}
+    {{- fail (printf "ERROR: ingressRoute key %q contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase). If you meant to enable a provider, use providers.%s instead." $name $name) }}
+  {{- end }}
+{{- end }}
+
 {{- if and (semverCompare "<v3.6.2-0" $version) (.Values.providers.kubernetesIngressNGINX).enabled}}
   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
 {{- end }}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -689,3 +689,18 @@ tests:
               baseModuleName: "gitlab.company.com"
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when an ingressRoute key contains uppercase characters
+    set:
+      ingressRoute:
+        kubernetesCRD:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'ERROR: ingressRoute key "kubernetesCRD" contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase). If you meant to enable a provider, use providers.kubernetesCRD instead.'
+  - it: should not fail when all ingressRoute keys are lowercase
+    set:
+      ingressRoute:
+        dashboard:
+          enabled: true
+    asserts:
+      - notFailedTemplate: {}

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -696,7 +696,7 @@ tests:
           enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'ERROR: ingressRoute key "kubernetesCRD" contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase). If you meant to enable a provider, use providers.kubernetesCRD instead.'
+          errorMessage: 'ERROR: ingressRoute key "kubernetesCRD" contains uppercase characters and would generate an invalid Kubernetes resource name (RFC 1123 requires lowercase).'
   - it: should not fail when all ingressRoute keys are lowercase
     set:
       ingressRoute:


### PR DESCRIPTION
## What does this PR do?

Adds a pre-flight validation in `requirements.yaml` that fails with a clear, actionable error when any `ingressRoute` map key contains uppercase characters.

## Motivation

`IngressRoute` names are generated as `{release}-{key}`, where `{key}` is the map key from `.Values.ingressRoute`. Uppercase characters produce names like `release-kubernetesCRD` which Kubernetes rejects:

```
metadata.name: Invalid value: "traefik-kubernetesCRD": a lowercase RFC 1123 subdomain
must consist of lower case alphanumeric characters, '-' or '.'...
```

The root cause is often a user confusing `ingressRoute.<name>` with `providers.<name>`. Rather than silently lowercasing the key, this PR follows the chart's existing pattern (see `requirements.yaml`) of failing fast with a message that explains both the problem and the likely fix:

```
ERROR: ingressRoute key "kubernetesCRD" contains uppercase characters and would generate
an invalid Kubernetes resource name (RFC 1123 requires lowercase). If you meant to enable
a provider, use providers.kubernetesCRD instead.
```

## More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed