### PR TITLE
chore(deps): update treafik docker tag to v3.7.3

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 40.2.0
-appVersion: v3.7.1
+appVersion: v3.7.3
 kubeVersion: '>=1.25.0-0'
 keywords:
   - traefik
@@ -22,7 +22,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   traefik.io/proxy-min-version: v3.6.0
-  traefik.io/proxy-max-version: v3.7.1
+  traefik.io/proxy-max-version: v3.7.3
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.2
   artifacthub.io/changes: |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.1](https://img.shields.io/badge/AppVersion-v3.7.1-informational?style=flat-square)
+![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.1](https://img.shields.io/badge/AppVersion-v3.7.3-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.1](https://img.shields.io/badge/AppVersion-v3.7.3-informational?style=flat-square)
+![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.3](https://img.shields.io/badge/AppVersion-v3.7.3-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -44,7 +44,7 @@ tests:
         tag: v3.8.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.1."
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.3."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Updates the Traefik Helm chart to use the latest Traefik Docker image (v3.7.3).


### Motivation

The current chart references an outdated Traefik image version.  

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

