### PR TITLE
feat(logs): :sparkles: support accesslog query parameters defaultmode

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -253,6 +253,7 @@ Kubernetes: `>=1.25.0-0`
 | logs.access.fields.general.names | object | `{}` | Names of the fields to limit. |
 | logs.access.fields.headers.defaultmode | string | `"drop"` | [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization) |
 | logs.access.fields.headers.names | object | `{}` |  |
+| logs.access.fields.queryParameters.defaultmode | string | `nil` | Keep or drop all query parameters in the RequestPath access log field (v3.7.3+). |
 | logs.access.filters | object | See below | Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters) |
 | logs.access.filters.minduration | string | `""` | Set minDuration, to keep access logs when requests take longer than the specified duration |
 | logs.access.filters.retryattempts | bool | `false` | Set retryAttempts, to keep the access logs when at least one retry has happened |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -801,6 +801,9 @@
               {{- range $fieldname, $fieldaction := .access.fields.headers.names }}
           - "--accesslog.fields.headers.names.{{ $fieldname }}={{ $fieldaction }}"
               {{- end }}
+              {{- with .access.fields.queryParameters.defaultmode }}
+          - "--accesslog.fields.queryparameters.defaultmode={{ . }}"
+              {{- end }}
               {{- with .access.otlp }}
                 {{- include "traefik.oltpCommonParams" (dict "path" "accesslog.otlp" "oltp" .) | nindent 8 }}
               {{- end }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -85,6 +85,10 @@
   {{- fail "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0." }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.3-0" $version) .Values.logs.access.fields.queryParameters.defaultmode }}
+  {{- fail "ERROR: accesslog.fields.queryParameters.defaultmode is only available for traefik >= v3.7.3." }}
+{{- end }}
+
 {{- if and (semverCompare "<v3.7.0-0" $version) .Values.global.notAppendXForwardedFor }}
   {{- fail "ERROR: global.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}
 {{- end }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -1040,6 +1040,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.fields.names.StartUTC=drop"
+  - it: should not set accesslog query parameters defaultmode by default
+    set:
+      logs:
+        access:
+          enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--accesslog.fields.queryparameters.defaultmode=keep"
+  - it: should set accesslog query parameters defaultmode when configured
+    set:
+      logs:
+        access:
+          enabled: true
+          fields:
+            queryParameters:
+              defaultmode: drop
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--accesslog.fields.queryparameters.defaultmode=drop"
   - it: "should set traefik as user in env by default"
     asserts:
       - contains:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -448,6 +448,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0."
+  - it: should fail when using accesslog query parameters defaultmode on traefik < 3.7.3
+    set:
+      image:
+        tag: v3.7.1
+      logs:
+        access:
+          fields:
+            queryParameters:
+              defaultmode: drop
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: accesslog.fields.queryParameters.defaultmode is only available for traefik >= v3.7.3."
   - it: should fail when using notAppendXForwardedFor on traefik < 3.7.0
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1380,6 +1380,23 @@
                                             "type": "object"
                                         }
                                     }
+                                },
+                                "queryParameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "defaultmode": {
+                                            "description": "Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "enum": [
+                                                "keep",
+                                                "drop",
+                                                null
+                                            ]
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -603,6 +603,9 @@ logs:
         # -- [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)
         defaultmode: drop  # @schema enum:[keep, drop, redact]; default: drop
         names: {}
+      queryParameters:
+        # -- Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).
+        defaultmode:  # @schema enum:[keep, drop, null]; type:[string, null]; default: null
     otlp:
       # -- Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.
       enabled: false


### PR DESCRIPTION
### What does this PR do?

Expose `logs.access.fields.queryParameters.defaultmode` (keep | drop), the accesslog query parameters option added in Traefik Proxy v3.7.3. Gated to fail on Proxy < v3.7.3.

### Motivation

Required for #1867 (bump to Traefik Proxy v3.7.3).

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed