### PR TITLE
feat(provider): :sparkles: support qps and burst on kubernetesGateway

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -460,12 +460,14 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
 | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
 | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
+| providers.kubernetesGateway.burst | string | `nil` | Maximum burst of requests to the Kubernetes API server (v3.7.3+). Defaults to 100. |
 | providers.kubernetesGateway.crossProviderNamespaces | list | `[]` | List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+. |
 | providers.kubernetesGateway.enabled | bool | `false` | Enable Traefik Gateway provider for Gateway API |
 | providers.kubernetesGateway.experimentalChannel | bool | `false` | Toggles support for the Experimental Channel resources (Gateway API release channels documentation). This option currently enables support for TCPRoute and TLSRoute. |
 | providers.kubernetesGateway.labelSelector | string | `""` | A label selector can be defined to filter on specific GatewayClass objects only. |
 | providers.kubernetesGateway.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. kubernetesGateway provider requires ClusterRole and as a consequence `rbac.namespaced` is not supported. |
 | providers.kubernetesGateway.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
+| providers.kubernetesGateway.qps | string | `nil` | Maximum QPS to the Kubernetes API server. A negative value disables client-side ratelimiting (v3.7.3+). Defaults to 50. |
 | providers.kubernetesGateway.statusAddress.hostname | string | `""` | This Hostname will get copied to the Gateway status.addresses. |
 | providers.kubernetesGateway.statusAddress.ip | string | `""` | This IP will get copied to the Gateway status.addresses, and currently only supports one IP value (IPv4 or IPv6). |
 | providers.kubernetesGateway.statusAddress.service.enabled | bool | `true` | The Kubernetes service to copy status addresses from. When using third parties tools like External-DNS, this option can be used to copy the service loadbalancer.status (containing the service's endpoints IPs) to the gateways. Default to Service of this Chart. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -590,6 +590,12 @@
             {{- with .labelSelector }}
           - "--providers.kubernetesgateway.labelSelector={{ . }}"
             {{- end }}
+            {{- with .qps }}
+          - "--providers.kubernetesgateway.qps={{ . }}"
+            {{- end }}
+            {{- with .burst }}
+          - "--providers.kubernetesgateway.burst={{ . }}"
+            {{- end }}
            {{- end }}
           {{- end }}
           {{- with .Values.providers.kubernetesIngress }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -97,6 +97,13 @@
   {{- fail "ERROR: providers.kubernetes{CRD,Ingress,Gateway}.crossProviderNamespaces is only available for traefik >= v3.7.1" }}
 {{- end }}
 
+{{- if and (semverCompare "<v3.7.3-0" $version) (or
+    (not (empty .Values.providers.kubernetesGateway.qps))
+    (not (empty .Values.providers.kubernetesGateway.burst))
+    ) }}
+  {{- fail "ERROR: providers.kubernetesGateway.qps and .burst are only available for traefik >= v3.7.3." }}
+{{- end }}
+
 {{- range $name, $config := .Values.ports }}
   {{- if and $config (($config.forwardedHeaders).notAppendXForwardedFor) (semverCompare "<v3.7.0-0" $version) }}
   {{- fail "ERROR: forwardedHeaders.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -395,6 +395,30 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesgateway.statusaddress.service.namespace=foo"
+  - it: should not set kubernetesGateway qps and burst by default
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "--providers.kubernetesgateway.qps="
+      - notMatchRegexRaw:
+          pattern: "--providers.kubernetesgateway.burst="
+  - it: should set kubernetesGateway qps and burst when configured
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+          qps: 20
+          burst: 40
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesgateway.qps=20"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesgateway.burst=40"
 
   - it: should be able to enable knative provider
     set:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -448,6 +448,28 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0."
+  - it: should fail when using kubernetesGateway qps on traefik < 3.7.3
+    set:
+      image:
+        tag: v3.7.1
+      providers:
+        kubernetesGateway:
+          enabled: true
+          qps: 20
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: providers.kubernetesGateway.qps and .burst are only available for traefik >= v3.7.3."
+  - it: should fail when using kubernetesGateway burst on traefik < 3.7.3
+    set:
+      image:
+        tag: v3.7.1
+      providers:
+        kubernetesGateway:
+          enabled: true
+          burst: 40
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: providers.kubernetesGateway.qps and .burst are only available for traefik >= v3.7.3."
   - it: should fail when using notAppendXForwardedFor on traefik < 3.7.0
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2537,6 +2537,13 @@
                 "kubernetesGateway": {
                     "type": "object",
                     "properties": {
+                        "burst": {
+                            "description": "Maximum burst of requests to the Kubernetes API server (v3.7.3+). Defaults to 100.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
                         "crossProviderNamespaces": {
                             "description": "List of namespaces from which Gateway API routes are allowed to declare TraefikService backendRef references. Requires traefik v3.7.1+.",
                             "type": "array"
@@ -2560,6 +2567,13 @@
                         "nativeLBByDefault": {
                             "description": "Defines whether to use Native Kubernetes load-balancing mode by default.",
                             "type": "boolean"
+                        },
+                        "qps": {
+                            "description": "Maximum QPS to the Kubernetes API server. A negative value disables client-side ratelimiting (v3.7.3+). Defaults to 50.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
                         },
                         "statusAddress": {
                             "type": "object",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -373,6 +373,10 @@ providers:
     labelSelector: ""
     # -- Defines whether to use Native Kubernetes load-balancing mode by default.
     nativeLBByDefault: false
+    # -- Maximum QPS to the Kubernetes API server. A negative value disables client-side ratelimiting (v3.7.3+). Defaults to 50.
+    qps:  # @schema type:[integer, null]
+    # -- Maximum burst of requests to the Kubernetes API server (v3.7.3+). Defaults to 100.
+    burst:  # @schema type:[integer, null]
     statusAddress:
       # -- This IP will get copied to the Gateway status.addresses, and currently only supports one IP value (IPv4 or IPv6).
       ip: ""


### PR DESCRIPTION
### What does this PR do?

Expose `providers.kubernetesGateway.qps` and `providers.kubernetesGateway.burst` (Kubernetes API client rate limiting), added in Traefik Proxy v3.7.3. Unset by default so Traefik defaults (50 / 100) apply; gated to fail on Proxy < v3.7.3.

### Motivation

Required for #1867 (bump to Traefik Proxy v3.7.3).

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed