### PR TITLE
fix(hub): :bug: guard nil hub.token in hub-license template

### DIFF
--- a/traefik/templates/hub-license.yaml
+++ b/traefik/templates/hub-license.yaml
@@ -1,4 +1,4 @@
-{{- if ge (len .Values.hub.token) 65 }}
+{{- if ge (len (.Values.hub.token | default "")) 65 }}
 ---
 apiVersion: v1
 kind: Secret

--- a/traefik/tests/hub-license-config_test.yaml
+++ b/traefik/tests/hub-license-config_test.yaml
@@ -107,3 +107,15 @@ tests:
           name: traefik-hub-license
           namespace: NAMESPACE
         template: hub-license.yaml
+
+  - it: should not crash when hub.token is explicitly null
+    set:
+      hub:
+        token: null
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub-license.yaml
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml


### PR DESCRIPTION
### What does this PR do?

Guards a nil-pointer crash in `templates/hub-license.yaml`. The template calls
`len .Values.hub.token` directly; when `hub.token` is `null` (Helm drops the key
during value coalescing), `len` fails with `len of nil pointer`. Defaulting the
token to `""` before measuring its length fixes it:

```diff
-{{- if ge (len .Values.hub.token) 65 }}
+{{- if ge (len (.Values.hub.token | default "")) 65 }}
```

A null/empty token renders cleanly (no license Secret — the correct behaviour);
real tokens (>= 65 chars) are unaffected.

### Motivation

`hub.token` can legitimately be `null` rather than a string — e.g. `--set hub.token=null`,
an empty or templated value in a GitOps overlay, or simply clearing the token. Today
that produces an opaque failure instead of rendering:

```
template: traefik/templates/hub-license.yaml:1:11: executing "..." at
<len .Values.hub.token>: error calling len: len of nil pointer
```

Only an explicit `null` triggers it — the default `""`, an omitted key and real
tokens all already render fine.

### More

- [x] Yes, I updated the tests accordingly
- [ ] No schema change — template-only fix
- [x] Yes, I ran `make test` and all the tests passed
