### PR TITLE
feat(hub): :rocket: support traefik hub v3.20.4

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
   traefik.io/proxy-min-version: v3.6.0
   traefik.io/proxy-max-version: v3.7.3
   traefik.io/hub-min-version: v3.19.3
-  traefik.io/hub-max-version: v3.20.3
+  traefik.io/hub-max-version: v3.20.4
   artifacthub.io/changes: |
     - "fix: remove Gateway API CRDs"
     - "feat(provider): :sparkles: support crossProviderNamespaces on kubernetes providers"

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -113,7 +113,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.3."
+          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.4."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Add support for Traefik Hub v3.20.4 (bumps `traefik.io/hub-max-version`).

### Motivation

Traefik Hub v3.20.4 has been released.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
