### PR TITLE
chore(ci): track proxy & hub max-version annotations with renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,34 +77,21 @@
         "\\(https:\\/\\/img\\.shields\\.io\\/badge\\/AppVersion-(?<currentValue>[\\w+\\.\\-]*)-informational.+\\)"
       ]
     },
-    // Update traefik.io/proxy-max-version annotation (and the matching test assertion) with the latest stable Traefik Proxy release.
+    // Update traefik.io/{proxy,hub}-max-version annotations (and the matching test
+    // assertions) with the latest stable Traefik Proxy / Hub releases. The captured
+    // `product` routes each match to the right datasource depName.
     {
       customType: 'regex',
       datasourceTemplate: 'docker',
-      depNameTemplate: 'traefik',
+      depNameTemplate: '{{#if (equals (lowercase product) "hub")}}ghcr.io/traefik/traefik-hub{{else}}traefik{{/if}}',
       managerFilePatterns: [
         '/^traefik/Chart\\.yaml$/',
         '/^traefik/tests/requirements-config_test\\.yaml$/',
       ],
       versioningTemplate: 'docker',
       matchStrings: [
-        'traefik\\.io/proxy-max-version:\\s*(?<currentValue>\\S+)',
-        'only supports Traefik Proxy up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
-      ],
-    },
-    // Update traefik.io/hub-max-version annotation (and the matching test assertion) with the latest stable Traefik Hub release.
-    {
-      customType: 'regex',
-      datasourceTemplate: 'docker',
-      depNameTemplate: 'ghcr.io/traefik/traefik-hub',
-      managerFilePatterns: [
-        '/^traefik/Chart\\.yaml$/',
-        '/^traefik/tests/requirements-config_test\\.yaml$/',
-      ],
-      versioningTemplate: 'docker',
-      matchStrings: [
-        'traefik\\.io/hub-max-version:\\s*(?<currentValue>\\S+)',
-        'only supports Traefik Hub up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+        'traefik\\.io/(?<product>proxy|hub)-max-version:\\s*(?<currentValue>\\S+)',
+        'only supports Traefik (?<product>Proxy|Hub) up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
       ],
     }
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,17 @@
   rebaseWhen: 'conflicted',
   labels: ['📌 dependencies'],
   enabledManagers: ['github-actions', 'custom.regex'],
+  // config:recommended ignores **/tests/** by default; keep the rest of that list but
+  // allow traefik/tests so the *-max-version assertions can be kept in sync by Renovate.
+  ignorePaths: [
+    '**/node_modules/**',
+    '**/bower_components/**',
+    '**/vendor/**',
+    '**/examples/**',
+    '**/__tests__/**',
+    '**/test/**',
+    '**/__fixtures__/**',
+  ],
   hostRules: [
     {
       abortIgnoreStatusCodes: [404],
@@ -31,6 +42,12 @@
     {
       matchPackageNames: ['traefik'],
       extends: [':semanticCommitTypeAll(feat)'],
+    },
+    {
+      matchPackageNames: ['ghcr.io/traefik/traefik-hub'],
+      extends: [':semanticCommitTypeAll(feat)'],
+      // Only track stable Hub releases for hub-max-version (exclude -ea / -rc).
+      allowedVersions: '/^v\\d+\\.\\d+\\.\\d+$/',
     },
     {
       matchPackageNames: ['bpsoraggi/helm-gh-pages'],
@@ -59,6 +76,36 @@
         "!\\[AppVersion:\\s*(?<currentValue>[\\w+\\.\\-]*)\\]",
         "\\(https:\\/\\/img\\.shields\\.io\\/badge\\/AppVersion-(?<currentValue>[\\w+\\.\\-]*)-informational.+\\)"
       ]
+    },
+    // Update traefik.io/proxy-max-version annotation (and the matching test assertion) with the latest stable Traefik Proxy release.
+    {
+      customType: 'regex',
+      datasourceTemplate: 'docker',
+      depNameTemplate: 'traefik',
+      managerFilePatterns: [
+        '/^traefik/Chart\\.yaml$/',
+        '/^traefik/tests/requirements-config_test\\.yaml$/',
+      ],
+      versioningTemplate: 'docker',
+      matchStrings: [
+        'traefik\\.io/proxy-max-version:\\s*(?<currentValue>\\S+)',
+        'only supports Traefik Proxy up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+      ],
+    },
+    // Update traefik.io/hub-max-version annotation (and the matching test assertion) with the latest stable Traefik Hub release.
+    {
+      customType: 'regex',
+      datasourceTemplate: 'docker',
+      depNameTemplate: 'ghcr.io/traefik/traefik-hub',
+      managerFilePatterns: [
+        '/^traefik/Chart\\.yaml$/',
+        '/^traefik/tests/requirements-config_test\\.yaml$/',
+      ],
+      versioningTemplate: 'docker',
+      matchStrings: [
+        'traefik\\.io/hub-max-version:\\s*(?<currentValue>\\S+)',
+        'only supports Traefik Hub up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+      ],
     }
   ],
 }

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -41,7 +41,7 @@ tests:
   - it: should fail when trying to use this Chart with a stable Proxy version above max
     set:
       image:
-        tag: v3.8.0
+        tag: v99.0.0
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.4."
@@ -108,7 +108,7 @@ tests:
       image:
         registry: ghcr.io
         repository: traefik/traefik-hub
-        tag: v3.21.0
+        tag: v99.0.0
       hub:
         token: xxx
     asserts:


### PR DESCRIPTION
### What does this PR do?

Lets Renovate auto-bump the `traefik.io/proxy-max-version` and `traefik.io/hub-max-version` annotations in `Chart.yaml` (and the matching version in the requirements tests' error-message assertions) from the latest stable `traefik` / `ghcr.io/traefik/traefik-hub` releases.

### Motivation

These annotations were bumped by hand because Renovate only tracked the bare `appVersion`, so new Traefik Hub / Proxy releases never opened a PR.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
