### PR TITLE
feat(proxy): :rocket: support traefik v3.7.4

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,7 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 40.2.0
-appVersion: v3.7.3
+appVersion: v3.7.4
 kubeVersion: '>=1.25.0-0'
 keywords:
   - traefik
@@ -22,7 +22,7 @@ maintainers:
 icon: https://raw.githubusercontent.com/traefik/traefik/master/docs/content/assets/img/traefik.logo.png
 annotations:
   traefik.io/proxy-min-version: v3.6.0
-  traefik.io/proxy-max-version: v3.7.3
+  traefik.io/proxy-max-version: v3.7.4
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.4
   artifacthub.io/changes: |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.3](https://img.shields.io/badge/AppVersion-v3.7.3-informational?style=flat-square)
+![Version: 40.2.0](https://img.shields.io/badge/Version-40.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.4](https://img.shields.io/badge/AppVersion-v3.7.4-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -44,7 +44,7 @@ tests:
         tag: v3.8.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.3."
+          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.4."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Adds support for Traefik Proxy v3.7.4:

- `appVersion` bumped to `v3.7.4`
- `traefik.io/proxy-max-version` bumped to `v3.7.4`
- Updated the proxy max-version assertion in `requirements-config_test.yaml`
- Regenerated the `AppVersion` badge in `VALUES.md`

> Based on top of #1876 (Hub v3.20.4 support); this PR only carries the Proxy changes.

### Motivation

Traefik Proxy v3.7.4 has been released. The `traefik --help` output is identical between v3.7.3 and v3.7.4, so no new CLI option needs to be exposed — this is a pure supported-version bump.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
