### PR TITLE
ci(test): fix helm-unittest invocation for helm v4

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -13,7 +13,13 @@ if ! helm plugin list 2>/dev/null | awk 'NR>1 && $1=="unittest"{found=1} END{exi
   exit 1
 fi
 
-# NB: --color is intentionally omitted. Helm v4 introduced a global --color <mode>
-# persistent flag that shadows the helm-unittest boolean --color flag, breaking the
-# invocation. Color is auto-detected from the tty instead.
-helm unittest ./traefik
+# Helm v4 introduced a global --color <mode> persistent flag (never|auto|always) that
+# shadows the boolean --color flag of helm-unittest, breaking `helm unittest --color`.
+# So we only force color on Helm v3; on Helm v4+ color is auto-detected from the tty.
+HELM_MAJOR="$(helm version --template '{{.Version}}' 2>/dev/null | grep -oE '[0-9]+' | head -n1)"
+COLOR_FLAG="--color"
+if [ "${HELM_MAJOR:-0}" -ge 4 ]; then
+  COLOR_FLAG=""
+fi
+
+helm unittest ${COLOR_FLAG} ./traefik

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -9,8 +9,11 @@ fi
 
 if ! helm plugin list 2>/dev/null | awk 'NR>1 && $1=="unittest"{found=1} END{exit !found}'; then
   echo "Error: helm-unittest plugin is not installed." >&2
-  echo "Install: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.1" >&2
+  echo "Install: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.1.0" >&2
   exit 1
 fi
 
-helm unittest --color ./traefik
+# NB: --color is intentionally omitted. Helm v4 introduced a global --color <mode>
+# persistent flag that shadows the helm-unittest boolean --color flag, breaking the
+# invocation. Color is auto-detected from the tty instead.
+helm unittest ./traefik


### PR DESCRIPTION
### What does this PR do?

Makes the local `make test` invocation in `hack/test.sh` compatible with both Helm v3 and Helm v4:

- Detects the installed Helm major version and only passes `--color` to `helm unittest` on Helm v3 (where it forces colored output, as used in CI). On Helm v4+ the flag is omitted and color is auto-detected from the tty.
- Bumps the recommended helm-unittest plugin version from `1.0.1` to `1.1.0`.

### Motivation

Two issues surface when running `make test` with recent tooling:

- **Helm v4 conflict on `--color`:** Helm v4 introduced a global persistent `--color <mode>` flag (`never|auto|always`) that shadows the boolean `--color` flag of helm-unittest. The invocation `helm unittest --color ./traefik` then fails with `invalid color mode "./traefik": must be one of: never, auto, always`. Since CI still runs Helm v3 (see #1873, which bumps it to v3.21.0), a plain removal of `--color` would drop colored output there — hence the version-aware switch.
- **Notes tests fail on plugin 1.0.1:** The `NOTES.txt` assertions behave differently on helm-unittest `1.0.1` vs `1.1.0` (leading-newline handling). CI already uses `1.1.0`, so the recommended local version is aligned to match — no test files were changed.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
