### PR TITLE
feat(CRDs): update Traefik Hub CRDs to v1.31.0

### DIFF
--- a/traefik/crds/hub.traefik.io_accesscontrolpolicies.yaml
+++ b/traefik/crds/hub.traefik.io_accesscontrolpolicies.yaml
@@ -152,8 +152,8 @@ spec:
                         type: object
                       maxRetries:
                         default: 3
-                        description: MaxRetries defines the number of retries for
-                          introspection requests.
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
                         type: integer
                       timeoutSeconds:
                         default: 5
@@ -161,16 +161,15 @@ spec:
                           of seconds to wait before giving up on requests.
                         type: integer
                       tls:
-                        description: TLS configures TLS communication with the Authorization
-                          Server.
+                        description: TLS configures TLS for the HTTP client.
                         properties:
                           ca:
-                            description: CA sets the CA bundle used to sign the Authorization
-                              Server certificate.
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
                             type: string
                           insecureSkipVerify:
                             description: |-
-                              InsecureSkipVerify skips the Authorization Server certificate validation.
+                              InsecureSkipVerify skips the server certificate validation.
                               For testing purposes only, do not use in production.
                             type: boolean
                         type: object

--- a/traefik/crds/hub.traefik.io_apiauths.yaml
+++ b/traefik/crds/hub.traefik.io_apiauths.yaml
@@ -81,6 +81,34 @@ spec:
                       AppIDClaim is the name of the claim holding the identifier of the application.
                       This field is sometimes named `client_id`.
                     type: string
+                  clientConfig:
+                    description: ClientConfig configures the HTTP client used to fetch
+                      the JWKS from the JWKS URL or the trusted issuers.
+                    properties:
+                      maxRetries:
+                        default: 3
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
+                        type: integer
+                      timeoutSeconds:
+                        default: 5
+                        description: TimeoutSeconds configures the maximum amount
+                          of seconds to wait before giving up on requests.
+                        type: integer
+                      tls:
+                        description: TLS configures TLS for the HTTP client.
+                        properties:
+                          ca:
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
+                            type: string
+                          insecureSkipVerify:
+                            description: |-
+                              InsecureSkipVerify skips the server certificate validation.
+                              For testing purposes only, do not use in production.
+                            type: boolean
+                        type: object
+                    type: object
                   forwardHeaders:
                     additionalProperties:
                       type: string

--- a/traefik/crds/hub.traefik.io_apiportalauths.yaml
+++ b/traefik/crds/hub.traefik.io_apiportalauths.yaml
@@ -167,6 +167,34 @@ spec:
                     required:
                     - groups
                     type: object
+                  clientConfig:
+                    description: ClientConfig configures the HTTP client used to communicate
+                      with the OIDC provider.
+                    properties:
+                      maxRetries:
+                        default: 3
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
+                        type: integer
+                      timeoutSeconds:
+                        default: 5
+                        description: TimeoutSeconds configures the maximum amount
+                          of seconds to wait before giving up on requests.
+                        type: integer
+                      tls:
+                        description: TLS configures TLS for the HTTP client.
+                        properties:
+                          ca:
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
+                            type: string
+                          insecureSkipVerify:
+                            description: |-
+                              InsecureSkipVerify skips the server certificate validation.
+                              For testing purposes only, do not use in production.
+                            type: boolean
+                        type: object
+                    type: object
                   issuerUrl:
                     description: IssuerURL is the OIDC provider issuer URL.
                     type: string

--- a/traefik/crds/hub.traefik.io_apis.yaml
+++ b/traefik/crds/hub.traefik.io_apis.yaml
@@ -195,6 +195,11 @@ spec:
                       rule: self.startsWith('/')
                     - message: cannot contains '../'
                       rule: '!self.matches(r"""(\/\.\.\/)|(\/\.\.$)""")'
+                  refreshInterval:
+                    description: RefreshInterval defines the rate at which the OpenAPI
+                      specification is refreshed.
+                    format: duration
+                    type: string
                   url:
                     description: |-
                       URL is a Traefik Hub agent accessible URL for obtaining the OpenAPI specification.

--- a/traefik/crds/hub.traefik.io_apiversions.yaml
+++ b/traefik/crds/hub.traefik.io_apiversions.yaml
@@ -199,6 +199,11 @@ spec:
                       rule: self.startsWith('/')
                     - message: cannot contains '../'
                       rule: '!self.matches(r"""(\/\.\.\/)|(\/\.\.$)""")'
+                  refreshInterval:
+                    description: RefreshInterval defines the rate at which the OpenAPI
+                      specification is refreshed.
+                    format: duration
+                    type: string
                   url:
                     description: |-
                       URL is a Traefik Hub agent accessible URL for obtaining the OpenAPI specification.


### PR DESCRIPTION
### What does this PR do?

Syncs the vendored Traefik Hub CRDs with the upstream [`traefik/hub-crds@v1.31.0`](https://github.com/traefik/hub-crds/tree/v1.31.0/pkg/apis/hub/v1alpha1/crd) bundle, which Traefik Hub depends on starting from **v3.19.8** (3.19 line) and **v3.20.3** (3.20 line) — `traefik-hub` bumped `hub-crds` to v1.31.0 in those releases.

The Traefik Proxy CRDs (`traefik.io_*`) were also checked against [`traefik/traefik@v3.7`](https://github.com/traefik/traefik/tree/v3.7/docs/content/reference/dynamic-configuration) and are already up to date — no change needed.

### Motivation

The vendored Hub CRDs were last synced at Hub v3.20.0-ea.1, so they lagged behind the bundle required by the Hub versions this chart supports (v3.19.3 up to v3.20.4).

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed
