### PR TITLE
feat(version): :sparkles: relax max-version guard to warn on minor/patch, fail only on major mismatch

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -8,11 +8,9 @@
 {{- $imageTag := (.Values.image.tag | default .Chart.AppVersion) -}}
 {{- $version := include "traefik.proxyVersion" $ -}}
 {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" -}}
-{{- if or (hasPrefix "experimental-" $imageTag) (and (eq (include "traefik.isStableVersion" $version) "false") (semverCompare (printf ">%s-0" $proxyMaxVersion) $version)) (and (eq (include "traefik.isStableVersion" $version) "true") (semverCompare (printf ">%s" $proxyMaxVersion) $version)) -}}
+{{- if or (hasPrefix "experimental-" $imageTag) (eq (include "traefik.isAboveMaxVersion" (dict "version" $version "max" $proxyMaxVersion)) "true") -}}
 {{- printf "\n" -}}
-⚠️ WARNING: You are using a non-standard image tag ({{ $imageTag }}). Non-standard versions can
-be unstable, may contain breaking changes, and are NOT recommended for production use.
-This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{ include "traefik.nonStandardVersionWarning" (dict "label" "image tag" "tag" $imageTag) }}
 {{- printf "\n" -}}
 {{- end -}}
 
@@ -21,11 +19,9 @@ This version is not officially supported by this chart. Use at your own risk. �
 {{- if .Values.hub.token -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}
 {{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
-{{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (or (and (eq (include "traefik.isStableVersion" $hubVersion) "false") (semverCompare (printf ">%s-0" $hubMaxVersion) $hubVersion)) (and (eq (include "traefik.isStableVersion" $hubVersion) "true") (semverCompare (printf ">%s" $hubMaxVersion) $hubVersion))) -}}
+{{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (eq (include "traefik.isAboveMaxVersion" (dict "version" $hubVersion "max" $hubMaxVersion)) "true") -}}
 {{- printf "\n" -}}
-⚠️ WARNING: You are using a non-standard Traefik Hub image tag ({{ $hubVersion }}). Non-standard versions can
-be unstable, may contain breaking changes, and are NOT recommended for production use.
-This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{ include "traefik.nonStandardVersionWarning" (dict "label" "Traefik Hub image tag" "tag" $hubVersion) }}
 {{- printf "\n" -}}
 {{- end -}}
 {{- end -}}

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -8,7 +8,7 @@
 {{- $imageTag := (.Values.image.tag | default .Chart.AppVersion) -}}
 {{- $version := include "traefik.proxyVersion" $ -}}
 {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" -}}
-{{- if or (hasPrefix "experimental-" $imageTag) (and (eq (include "traefik.isStableVersion" $version) "false") (semverCompare (printf ">%s-0" $proxyMaxVersion) $version)) -}}
+{{- if or (hasPrefix "experimental-" $imageTag) (and (eq (include "traefik.isStableVersion" $version) "false") (semverCompare (printf ">%s-0" $proxyMaxVersion) $version)) (and (eq (include "traefik.isStableVersion" $version) "true") (semverCompare (printf ">%s" $proxyMaxVersion) $version)) -}}
 {{- printf "\n" -}}
 ⚠️ WARNING: You are using a non-standard image tag ({{ $imageTag }}). Non-standard versions can
 be unstable, may contain breaking changes, and are NOT recommended for production use.

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -17,6 +17,20 @@ This version is not officially supported by this chart. Use at your own risk. �
 {{- end -}}
 
 
+{{/* Warn about non-standard Traefik Hub versions (pre-release or minor/patch above supported range) */}}
+{{- if .Values.hub.token -}}
+{{- $hubVersion := include "traefik.hubVersion" $ -}}
+{{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
+{{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (or (and (eq (include "traefik.isStableVersion" $hubVersion) "false") (semverCompare (printf ">%s-0" $hubMaxVersion) $hubVersion)) (and (eq (include "traefik.isStableVersion" $hubVersion) "true") (semverCompare (printf ">%s" $hubMaxVersion) $hubVersion))) -}}
+{{- printf "\n" -}}
+⚠️ WARNING: You are using a non-standard Traefik Hub image tag ({{ $hubVersion }}). Non-standard versions can
+be unstable, may contain breaking changes, and are NOT recommended for production use.
+This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{- printf "\n" -}}
+{{- end -}}
+{{- end -}}
+
+
 {{/* Warn about potential permission issue with persistence */}}
 {{- if .Values.persistence -}}
   {{- if and .Values.persistence.enabled (empty .Values.deployment.initContainers) -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -243,6 +243,21 @@ The version can comes many sources: appVersion, image.tag, override, marketplace
  {{- end -}}
 {{- end -}}
 
+{{/*
+Resolve the Traefik Hub image version from its sources (oci_meta, azure marketplace,
+image.tag, versionOverride), stripping any digest suffix.
+Returns an empty string when no version can be determined. Callers apply their own
+fallback policy (e.g. "v3.99" for floating tags, or skipping non-semver tags).
+*/}}
+{{- define "traefik.hubVersion" -}}
+ {{- $hubVersion := ($.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag) -}}
+ {{- $hubVersion = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $hubVersion) -}}
+ {{- if and (not $hubVersion) $.Values.versionOverride -}}
+   {{- $hubVersion = $.Values.versionOverride -}}
+ {{- end -}}
+ {{- (split "@" (default "" $hubVersion))._0 -}}
+{{- end -}}
+
 {{/* Generate/load self-signed certificate for admission webhooks */}}
 {{- define "traefik-hub.webhook_cert" -}}
 {{- if $.Values.hub.apimanagement.admission.customWebhookCertificate }}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -223,6 +223,36 @@ Non-standard versions include experimental, ea, rc, alpha, beta builds.
 {{- end -}}
 
 {{/*
+Returns "true" when version is above max but shares the same major (the "use at your own
+risk" warning case). Pre-releases compare against "max-0" to also flag pre-releases of a
+version above max. Expects a dict: version, max.
+*/}}
+{{- define "traefik.isAboveMaxVersion" -}}
+  {{- if eq (include "traefik.isStableVersion" .version) "true" -}}
+    {{- semverCompare (printf ">%s" .max) .version -}}
+  {{- else -}}
+    {{- semverCompare (printf ">%s-0" .max) .version -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when version's major is strictly above max's major (the hard-fail case).
+Expects a dict: version, max.
+*/}}
+{{- define "traefik.isMajorAboveMax" -}}
+  {{- semverCompare (printf ">=%d.0.0-0" (add1 (int (semver .max).Major))) .version -}}
+{{- end -}}
+
+{{/*
+Renders the non-standard version warning shown in NOTES.txt. Expects a dict: label, tag.
+*/}}
+{{- define "traefik.nonStandardVersionWarning" -}}
+⚠️ WARNING: You are using a non-standard {{ .label }} ({{ .tag }}). Non-standard versions can
+be unstable, may contain breaking changes, and are NOT recommended for production use.
+This version is not officially supported by this chart. Use at your own risk. ⚠️
+{{- end -}}
+
+{{/*
 The version can comes many sources: appVersion, image.tag, override, marketplace.
 */}}
 {{- define "traefik.proxyVersion" -}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -5,8 +5,9 @@
   {{- if (semverCompare (printf "<%s-0" $proxyMinVersion) $version) }}
     {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy %s+" $proxyMinVersion) -}}
   {{- end }}
-  {{- if and (eq (include "traefik.isStableVersion" $version) "true") (semverCompare (printf ">%s" $proxyMaxVersion) $version) }}
-    {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy up to %s." $proxyMaxVersion) -}}
+  {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
+  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $proxyMaxVersion).Major))) $version }}
+    {{- fail (printf "ERROR: This version of the Chart does not support Traefik Proxy %s, which is a major version above the supported %s. Breaking changes are likely." $version $proxyMaxVersion) -}}
   {{- end }}
 {{- end }}
 
@@ -151,8 +152,9 @@
   {{- if semverCompare (printf "<%s-0" $hubMinVersion) $hubVersion }}
     {{ fail (printf "ERROR: this Chart supports *only* Traefik Hub >= %s." $hubMinVersion) }}
   {{- end }}
-  {{- if and (eq (include "traefik.isStableVersion" $hubVersion) "true") (semverCompare (printf ">%s" $hubMaxVersion) $hubVersion) }}
-    {{ fail (printf "ERROR: this Chart only supports Traefik Hub up to %s." $hubMaxVersion) }}
+  {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
+  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $hubMaxVersion).Major))) $hubVersion }}
+    {{ fail (printf "ERROR: this Chart does not support Traefik Hub %s, which is a major version above the supported %s. Breaking changes are likely." $hubVersion $hubMaxVersion) }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -131,16 +131,10 @@
 {{- end }}
 
 {{- if $.Values.hub.token -}}
-  {{ $hubVersion := $.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag }}
-  {{ $hubVersion = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $hubVersion) }}
-  {{- if and (not $hubVersion) $.Values.versionOverride }}
-    {{- $hubVersion = $.Values.versionOverride }}
-  {{- end }}
+  {{- $hubVersion := include "traefik.hubVersion" $ }}
   {{ if not $hubVersion }}
     {{ fail "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride." }}
   {{- end -}}
-
-  {{ $hubVersion = (split "@" (default "v3" $hubVersion))._0 }}
 
   {{/* Consider non semver versions as latest one  */}}
   {{- if not (regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $hubVersion)) -}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -7,7 +7,7 @@
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
   {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $proxyMaxVersion).Major))) $version }}
-    {{- fail (printf "ERROR: This version of the Chart does not support Traefik Proxy %s, which is a major version above the supported %s. Breaking changes are likely." $version $proxyMaxVersion) -}}
+    {{- fail (printf "ERROR: This version of the Chart does not support Traefik Proxy %s, which is a major version above the supported %s." $version $proxyMaxVersion) -}}
   {{- end }}
 {{- end }}
 
@@ -154,7 +154,7 @@
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
   {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $hubMaxVersion).Major))) $hubVersion }}
-    {{ fail (printf "ERROR: this Chart does not support Traefik Hub %s, which is a major version above the supported %s. Breaking changes are likely." $hubVersion $hubMaxVersion) }}
+    {{ fail (printf "ERROR: this Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -6,8 +6,8 @@
     {{- fail (printf "ERROR: This version of the Chart only supports Traefik Proxy %s+" $proxyMinVersion) -}}
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
-  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $proxyMaxVersion).Major))) $version }}
-    {{- fail (printf "ERROR: This version of the Chart does not support Traefik Proxy %s, which is a major version above the supported %s." $version $proxyMaxVersion) -}}
+  {{- if eq (include "traefik.isMajorAboveMax" (dict "version" $version "max" $proxyMaxVersion)) "true" }}
+    {{- fail (printf "ERROR: This Chart does not support Traefik Proxy %s, which is a major version above the supported %s." $version $proxyMaxVersion) -}}
   {{- end }}
 {{- end }}
 
@@ -147,8 +147,8 @@
     {{ fail (printf "ERROR: this Chart supports *only* Traefik Hub >= %s." $hubMinVersion) }}
   {{- end }}
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
-  {{- if semverCompare (printf ">=%d.0.0-0" (add1 (int (semver $hubMaxVersion).Major))) $hubVersion }}
-    {{ fail (printf "ERROR: this Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
+  {{- if eq (include "traefik.isMajorAboveMax" (dict "version" $hubVersion "max" $hubMaxVersion)) "true" }}
+    {{ fail (printf "ERROR: This Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -74,6 +74,50 @@ tests:
       - equalRaw:
           value: |
             RELEASE-NAME with docker.io/traefik:v3.6.8 has been deployed successfully on NAMESPACE namespace!
+  - it: should display warning when using a stable Hub minor/patch version above max
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.99.0
+      hub:
+        token: "xxx"
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.99.0 has been deployed successfully on NAMESPACE namespace!
+
+            ⚠️ WARNING: You are using a non-standard Traefik Hub image tag (v3.99.0). Non-standard versions can
+            be unstable, may contain breaking changes, and are NOT recommended for production use.
+            This version is not officially supported by this chart. Use at your own risk. ⚠️
+  - it: should display warning when using an ea Hub version above max
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.21.0-ea.1
+      hub:
+        token: "xxx"
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.21.0-ea.1 has been deployed successfully on NAMESPACE namespace!
+
+            ⚠️ WARNING: You are using a non-standard Traefik Hub image tag (v3.21.0-ea.1). Non-standard versions can
+            be unstable, may contain breaking changes, and are NOT recommended for production use.
+            This version is not officially supported by this chart. Use at your own risk. ⚠️
+  - it: should not display warning when using a stable Hub version within range
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.19.5
+      hub:
+        token: "xxx"
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3.19.5 has been deployed successfully on NAMESPACE namespace!
   - it: should not display a warning when persistence and initContainer are enabled
     set:
       persistence:

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -53,6 +53,19 @@ tests:
             be unstable, may contain breaking changes, and are NOT recommended for production use.
             This version is not officially supported by this chart. Use at your own risk. ⚠️
 
+  - it: should display warning when using a stable minor/patch version above max
+    set:
+      image:
+        tag: v3.99.0
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with docker.io/traefik:v3.99.0 has been deployed successfully on NAMESPACE namespace!
+
+            ⚠️ WARNING: You are using a non-standard image tag (v3.99.0). Non-standard versions can
+            be unstable, may contain breaking changes, and are NOT recommended for production use.
+            This version is not officially supported by this chart. Use at your own risk. ⚠️
+
   - it: should not display warning when using a stable Proxy version within range
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -38,13 +38,26 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: version \"unknown\" is not supported"
-  - it: should fail when trying to use this Chart with a stable Proxy version above max
+  - it: should not fail with a stable Proxy minor/patch version above max
+    set:
+      image:
+        tag: v3.99.0
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when trying to use this Chart with a Proxy major version above max
     set:
       image:
         tag: v99.0.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart only supports Traefik Proxy up to v3.7.4."
+          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4. Breaking changes are likely."
+  - it: should fail when trying to use this Chart with a Proxy major pre-release above max
+    set:
+      image:
+        tag: v4.0.0-rc.1
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4. Breaking changes are likely."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:
@@ -103,7 +116,17 @@ tests:
         token: xxx
     asserts:
       - notFailedTemplate: {}
-  - it: should fail when trying to use this Chart with a stable Hub version above max
+  - it: should not fail with a stable Hub minor/patch version above max
+    set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
+        tag: v3.99.0
+      hub:
+        token: xxx
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when trying to use this Chart with a Hub major version above max
     set:
       image:
         registry: ghcr.io
@@ -113,7 +136,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart only supports Traefik Hub up to v3.20.4."
+          errorMessage: "ERROR: this Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4. Breaking changes are likely."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -50,14 +50,14 @@ tests:
         tag: v99.0.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4."
   - it: should fail when trying to use this Chart with a Proxy major pre-release above max
     set:
       image:
         tag: v4.0.0-rc.1
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:
@@ -136,7 +136,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -50,14 +50,14 @@ tests:
         tag: v99.0.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4. Breaking changes are likely."
+          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v99.0.0, which is a major version above the supported v3.7.4."
   - it: should fail when trying to use this Chart with a Proxy major pre-release above max
     set:
       image:
         tag: v4.0.0-rc.1
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4. Breaking changes are likely."
+          errorMessage: "ERROR: This version of the Chart does not support Traefik Proxy v4.0.0-rc.1, which is a major version above the supported v3.7.4."
   - it: should not fail when trying to use this Chart with an ea Proxy version above max
     set:
       image:
@@ -136,7 +136,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: this Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4. Breaking changes are likely."
+          errorMessage: "ERROR: this Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Reworks the Traefik Proxy/Hub max-version install guard so it no longer blocks benign upgrades, implementing the proposal in #1883.

Previously, a stable version above `proxy-max-version` / `hub-max-version` hard-failed at template time, while pre-releases above max only triggered a warning. This forced a chart release for every new proxy/hub patch and prevented bumping the image ahead of the chart (e.g. to pick up a CVE fix quickly).

New behavior:

- **Minor/patch above max → warning, not failure.** A version above max but with the same major (e.g. `v3.99.0` on a chart targeting `v3.7.4`) now templates successfully and prints a "use at your own risk" warning in `NOTES.txt`, consistent with how pre-releases were already treated.
- **Major-version mismatch → hard failure.** A version with a higher major (e.g. `v4.x` on a `v3.x` chart, stable or pre-release) still fails, since breaking CRD/config changes are plausible.
- **Min-version guard unchanged.** Versions below the supported minimum keep failing — they are genuinely incompatible.

The same logic is applied symmetrically to the Hub max version.

This supersedes the previous `skipMaxVersionGuard` opt-in flag approach: no new chart value is introduced.

Closes #1883

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
