### PR TITLE
feat(hub): :sparkles: install out-of-box with only hub.token set

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,11 +87,14 @@
       managerFilePatterns: [
         '/^traefik/Chart\\.yaml$/',
         '/^traefik/tests/requirements-config_test\\.yaml$/',
+        '/^traefik/tests/container-config_test\\.yaml$/',
       ],
       versioningTemplate: 'docker',
       matchStrings: [
         'traefik\\.io/(?<product>proxy|hub)-max-version:\\s*(?<currentValue>\\S+)',
         'only supports Traefik (?<product>Proxy|Hub) up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+        // Default Hub image assertion (container-config_test.yaml) — bumped with hub-max-version.
+        'ghcr\\.io/traefik/traefik-(?<product>hub):(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
       ],
     }
   ],

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -216,8 +216,8 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
 | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
-| image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset. |
-| image.repository | string | `nil` | Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset. |
+| image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set). |
+| image.repository | string | `nil` | Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set). |
 | image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
 | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
 | ingressClass.isDefaultClass | bool | `true` |  |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -216,8 +216,8 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
 | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
-| image.registry | string | `"docker.io"` | Traefik image host registry |
-| image.repository | string | `"traefik"` | Traefik image repository |
+| image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset. |
+| image.repository | string | `nil` | Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset. |
 | image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
 | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
 | ingressClass.isDefaultClass | bool | `true` |  |

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -5,7 +5,7 @@
 
 
 {{/* Warn about non-standard versions (experimental, or pre-release outside supported range) */}}
-{{- $imageTag := (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- $imageTag := (.Values.image.tag | default (include "traefik.defaultTag" .)) -}}
 {{- $version := include "traefik.proxyVersion" $ -}}
 {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" -}}
 {{- if or (hasPrefix "experimental-" $imageTag) (eq (include "traefik.isAboveMaxVersion" (dict "version" $version "max" $proxyMaxVersion)) "true") -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,26 +15,30 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Image registry: defaults to ghcr.io for Traefik Hub (where the traefik-hub image lives)
-when left at the Proxy default, otherwise the user-provided value.
+Image registry: when left unset, defaults to ghcr.io for Traefik Hub (where the
+traefik-hub image lives) and docker.io for Traefik Proxy. Any explicit value is respected.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- if and .Values.hub.token (eq .Values.image.registry "docker.io") -}}
+{{- if .Values.image.registry -}}
+{{- .Values.image.registry -}}
+{{- else if .Values.hub.token -}}
 ghcr.io
 {{- else -}}
-{{- .Values.image.registry -}}
+docker.io
 {{- end -}}
 {{- end -}}
 
 {{/*
-Image repository: defaults to traefik/traefik-hub for Traefik Hub when left at the Proxy
-default, otherwise the user-provided value.
+Image repository: when left unset, defaults to traefik/traefik-hub for Traefik Hub and
+traefik for Traefik Proxy. Any explicit value is respected.
 */}}
 {{- define "traefik.imageRepository" -}}
-{{- if and .Values.hub.token (eq .Values.image.repository "traefik") -}}
+{{- if .Values.image.repository -}}
+{{- .Values.image.repository -}}
+{{- else if .Values.hub.token -}}
 traefik/traefik-hub
 {{- else -}}
-{{- .Values.image.repository -}}
+traefik
 {{- end -}}
 {{- end -}}
 

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,6 +15,42 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Image registry: defaults to ghcr.io for Traefik Hub (where the traefik-hub image lives)
+when left at the Proxy default, otherwise the user-provided value.
+*/}}
+{{- define "traefik.imageRegistry" -}}
+{{- if and .Values.hub.token (eq .Values.image.registry "docker.io") -}}
+ghcr.io
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image repository: defaults to traefik/traefik-hub for Traefik Hub when left at the Proxy
+default, otherwise the user-provided value.
+*/}}
+{{- define "traefik.imageRepository" -}}
+{{- if and .Values.hub.token (eq .Values.image.repository "traefik") -}}
+traefik/traefik-hub
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Default image tag: the latest (max) supported Hub version when Traefik Hub is enabled,
+otherwise the chart's appVersion (the latest supported Traefik Proxy version).
+*/}}
+{{- define "traefik.defaultTag" -}}
+{{- if .Values.hub.token -}}
+{{- index .Chart.Annotations "traefik.io/hub-max-version" -}}
+{{- else -}}
+{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
@@ -31,9 +67,9 @@ Create the chart image name.
 {{- printf "%s/%s:%s" .Values.global.azure.images.proxy.registry .Values.global.azure.images.proxy.image .Values.global.azure.images.proxy.tag }}
  {{- end -}}
 {{- else if .Values.image.digest -}}
-{{- printf "%s/%s@%s" .Values.image.registry .Values.image.repository .Values.image.digest }}
+{{- printf "%s/%s@%s" (include "traefik.imageRegistry" .) (include "traefik.imageRepository" .) .Values.image.digest }}
 {{- else -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- printf "%s/%s:%s" (include "traefik.imageRegistry" .) (include "traefik.imageRepository" .) (.Values.image.tag | default (include "traefik.defaultTag" .)) }}
 {{- end -}}
 {{- end -}}
 

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,43 +15,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Image registry: when left unset, defaults to ghcr.io for Traefik Hub (where the
-traefik-hub image lives) and docker.io for Traefik Proxy. Any explicit value is respected.
+Image defaults. An explicit image value always wins; otherwise the chart picks the
+Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwise.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- if .Values.image.registry -}}
-{{- .Values.image.registry -}}
-{{- else if .Values.hub.token -}}
-ghcr.io
-{{- else -}}
-docker.io
-{{- end -}}
+{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
 {{- end -}}
 
-{{/*
-Image repository: when left unset, defaults to traefik/traefik-hub for Traefik Hub and
-traefik for Traefik Proxy. Any explicit value is respected.
-*/}}
 {{- define "traefik.imageRepository" -}}
-{{- if .Values.image.repository -}}
-{{- .Values.image.repository -}}
-{{- else if .Values.hub.token -}}
-traefik/traefik-hub
-{{- else -}}
-traefik
-{{- end -}}
+{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token))) -}}
 {{- end -}}
 
-{{/*
-Default image tag: the latest (max) supported Hub version when Traefik Hub is enabled,
-otherwise the chart's appVersion (the latest supported Traefik Proxy version).
-*/}}
 {{- define "traefik.defaultTag" -}}
-{{- if .Values.hub.token -}}
-{{- index .Chart.Annotations "traefik.io/hub-max-version" -}}
-{{- else -}}
-{{- .Chart.AppVersion -}}
-{{- end -}}
+{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty .Values.hub.token)) -}}
 {{- end -}}
 
 {{/*

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -132,8 +132,12 @@
 
 {{- if $.Values.hub.token -}}
   {{- $hubVersion := include "traefik.hubVersion" $ }}
-  {{ if not $hubVersion }}
-    {{ fail "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride." }}
+  {{- if not $hubVersion }}
+    {{- if $.Values.image.digest }}
+      {{ fail "When using Traefik Hub with image.digest, versionOverride must be set." }}
+    {{- else }}
+      {{- $hubVersion = index $.Chart.Annotations "traefik.io/hub-max-version" }}
+    {{- end }}
   {{- end -}}
 
   {{/* Consider non semver versions as latest one  */}}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -11,7 +11,7 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hub.enabled (not (contains "traefik-hub" .Values.image.repository)) }}
+{{- if and .Values.hub.token (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
   {{- fail "ERROR: traefik-hub image is required when enabling Traefik Hub" -}}
 {{- end }}
 

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -99,6 +99,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: registry.example.com/acme/traefik-hub:v3.20.1
+  - it: should respect an explicit registry equal to the Proxy default when Hub is enabled
+    set:
+      hub:
+        token: xxx
+      image:
+        registry: docker.io
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik/traefik-hub:v3.20.4
   - it: should respect user-provided registry, repository and tag for a Proxy install
     set:
       image:

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -79,6 +79,36 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "image/digest.*does not match pattern"
+  - it: should default the full image to the Hub one (registry, repository and max version) when only hub.token is set
+    set:
+      hub:
+        token: xxx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/traefik/traefik-hub:v3.20.4
+  - it: should respect user-provided registry, repository and tag when Hub is enabled
+    set:
+      hub:
+        token: xxx
+      image:
+        registry: registry.example.com
+        repository: acme/traefik-hub
+        tag: v3.20.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/acme/traefik-hub:v3.20.1
+  - it: should respect user-provided registry, repository and tag for a Proxy install
+    set:
+      image:
+        registry: registry.example.com
+        repository: acme/traefik
+        tag: v3.7.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/acme/traefik:v3.7.0
 
   - it: should have no resource limit by default
     asserts:

--- a/traefik/tests/daemonset-config_test.yaml
+++ b/traefik/tests/daemonset-config_test.yaml
@@ -54,7 +54,7 @@ tests:
           traefik/powpow: podLabels
           traefik/name: '{{ template "traefik.name" . }}'
           traefik/{{ template "traefik.name" . }}.logs: 'log_processing_rules'
-          traefik/repository: '{{ .Values.image.repository }}'
+          traefik/repository: '{{ include "traefik.imageRepository" . }}'
     asserts:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -132,7 +132,7 @@ tests:
           traefik/powpow: podAnnotations
           traefik/name: '{{ template "traefik.name" . }}'
           traefik/{{ template "traefik.name" . }}.logs: 'log_processing_rules'
-          traefik/repository: '{{ .Values.image.repository }}'
+          traefik/repository: '{{ include "traefik.imageRepository" . }}'
     asserts:
       - equal:
           path: spec.template.metadata.annotations.traefik/powpow
@@ -167,7 +167,7 @@ tests:
           traefik/powpow: podLabels
           traefik/name: '{{ template "traefik.name" . }}'
           traefik/{{ template "traefik.name" . }}.logs: 'log_processing_rules'
-          traefik/repository: '{{ .Values.image.repository }}'
+          traefik/repository: '{{ include "traefik.imageRepository" . }}'
     asserts:
       - equal:
           path: spec.template.metadata.labels.traefik/powpow

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -204,7 +204,7 @@ tests:
     asserts:
       - equalRaw:
           value: |
-            RELEASE-NAME with docker.io/traefik:v3 has been deployed successfully on NAMESPACE namespace!
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3 has been deployed successfully on NAMESPACE namespace!
             WARNING: kubernetesCRD provider is configured to watch namespaces [ns2] but those ones are not watched by Hub provider.
             WARNING: kubernetesIngress provider is configured to watch all namespaces but Hub provider only watches [ns1].
   - it: should display warning when hub namespaces doesn't match kubernetesGateway namespaces
@@ -229,7 +229,7 @@ tests:
     asserts:
       - equalRaw:
           value: |
-            RELEASE-NAME with docker.io/traefik:v3 has been deployed successfully on NAMESPACE namespace!
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3 has been deployed successfully on NAMESPACE namespace!
             WARNING: kubernetesCRD provider is configured to watch all namespaces but Hub provider only watches [ns1].
             WARNING: kubernetesGateway provider is configured to watch namespaces [ns2] but those ones are not watched by Hub provider.
             WARNING: kubernetesIngress provider is configured to watch all namespaces but Hub provider only watches [ns1].
@@ -259,7 +259,7 @@ tests:
     asserts:
       - equalRaw:
           value: |
-            RELEASE-NAME with docker.io/traefik:v3 has been deployed successfully on NAMESPACE namespace!
+            RELEASE-NAME with ghcr.io/traefik/traefik-hub:v3 has been deployed successfully on NAMESPACE namespace!
   - it: should display the OCI image in release notes when oci_meta and Hub are enabled
     set:
       oci_meta:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -64,13 +64,15 @@ tests:
         tag: v3.8.0-ea.1
     asserts:
       - notFailedTemplate: {}
-  - it: should fail when trying to use this Chart with Traefik Proxy v3 and Hub enabled
+  - it: should default to the hub-max-version when Hub is enabled and no tag is set
     set:
+      image:
+        registry: ghcr.io
+        repository: traefik/traefik-hub
       hub:
         token: xxx
     asserts:
-      - failedTemplate:
-          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
+      - notFailedTemplate: {}
   - it: should fail when trying to use this Chart with Traefik Hub < v3.19.3
     set:
       image:
@@ -103,7 +105,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
+          errorMessage: "When using Traefik Hub with image.digest, versionOverride must be set."
   - it: should succeed when using Traefik Hub with image.digest and versionOverride
     set:
       image:
@@ -353,13 +355,12 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "values don't meet the specifications of the schema"
-  - it: should fail when using Traefik Hub without image registry and repository specified.
+  - it: should default to the hub-max-version when Traefik Hub is enabled and no tag is set
     set:
       hub:
         token: "xxx"
     asserts:
-      - failedTemplate:
-          errorMessage: "When using Traefik Hub, image.tag must be set, or image.digest with versionOverride."
+      - notFailedTemplate: {}
   - it: should not fail when using Traefik Hub with tag set for OCI
     set:
       hub:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -372,6 +372,15 @@ tests:
             tag: v3.19.3
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using Traefik Hub with a non-hub image repository
+    set:
+      hub:
+        token: "xxx"
+      image:
+        repository: traefik
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: traefik-hub image is required when enabling Traefik Hub"
   - it: should fail when using hub.tracing.additionalTraceHeaders without tracing.otlp enabled
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -66,9 +66,6 @@ tests:
       - notFailedTemplate: {}
   - it: should default to the hub-max-version when Hub is enabled and no tag is set
     set:
-      image:
-        registry: ghcr.io
-        repository: traefik/traefik-hub
       hub:
         token: xxx
     asserts:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -352,12 +352,6 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "values don't meet the specifications of the schema"
-  - it: should default to the hub-max-version when Traefik Hub is enabled and no tag is set
-    set:
-      hub:
-        token: "xxx"
-    asserts:
-      - notFailedTemplate: {}
   - it: should not fail when using Traefik Hub with tag set for OCI
     set:
       hub:

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -727,7 +727,7 @@ tests:
     set:
       additionalVolumeMounts:
         - name: foo-logs
-          mountPath: /var/log/{{ .Values.image.repository }}
+          mountPath: /var/log/{{ include "traefik.imageRepository" . }}
     asserts:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1145,14 +1145,14 @@
                     "type": "string"
                 },
                 "registry": {
-                    "description": "Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset.",
+                    "description": "Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set).",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
                 "repository": {
-                    "description": "Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset.",
+                    "description": "Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set).",
                     "type": [
                         "string",
                         "null"

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -1145,12 +1145,18 @@
                     "type": "string"
                 },
                 "registry": {
-                    "description": "Traefik image host registry",
-                    "type": "string"
+                    "description": "Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "repository": {
-                    "description": "Traefik image repository",
-                    "type": "string"
+                    "description": "Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "tag": {
                     "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `\u003cversion\u003e@\u003cdigest\u003e` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into templates
 
 image:  # @schema additionalProperties: false
-  # -- Traefik image host registry
-  registry: docker.io
-  # -- Traefik image repository
-  repository: traefik
+  # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset.
+  registry:  # @schema type:[string, null]
+  # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset.
+  repository:  # @schema type:[string, null]
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
   tag:  # @schema type:[string, null]

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into templates
 
 image:  # @schema additionalProperties: false
-  # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set) if left unset.
+  # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set).
   registry:  # @schema type:[string, null]
-  # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set) if left unset.
+  # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set).
   repository:  # @schema type:[string, null]
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).


### PR DESCRIPTION
### What does this PR do?

Aligns a default Traefik Hub install with Traefik Proxy. With only `hub.token` set and the image left at its defaults, the chart now resolves the full Hub image automatically:

- `registry` → `ghcr.io`
- `repository` → `traefik/traefik-hub`
- `tag` → `traefik.io/hub-max-version`

So `--set hub.token=xxx` installs a working Hub on the latest supported version, just as Proxy installs `Chart.AppVersion` out of the box. Any field the user provides explicitly is respected; the `image.digest` case still requires `versionOverride`.

Driven by three helpers (`traefik.imageRegistry`, `traefik.imageRepository`, `traefik.defaultTag`) used by `image-name`, `NOTES.txt` and the `requirements.yaml` guard.

### Motivation

Hub previously failed with `image.tag must be set` and forced the user to spell out registry, repository and tag, while Proxy worked out of the box. This makes both behave the same.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed