### PR TITLE
fix(notes): :memo: use traefik.image-name so NOTES match deployed image

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{/* Print release information */}}
 {{- printf "\n\n" -}}
-{{ .Release.Name }} with {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }} has been deployed successfully on {{ template "traefik.namespace" . }} namespace!
+{{ .Release.Name }} with {{ include "traefik.image-name" . }} has been deployed successfully on {{ template "traefik.namespace" . }} namespace!
 {{- printf "\n" -}}
 
 

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -203,3 +203,30 @@ tests:
       - equalRaw:
           value: |
             RELEASE-NAME with docker.io/traefik:v3 has been deployed successfully on NAMESPACE namespace!
+  - it: should display the OCI image in release notes when oci_meta and Hub are enabled
+    set:
+      oci_meta:
+        enabled: true
+        repo: myrepo
+        images:
+          hub:
+            image: traefik-hub
+            tag: v3.20.4
+
+      rbac:
+        enabled: true
+        namespaced: true
+
+      hub:
+        token: "token"
+        namespaces: []
+        apimanagement:
+          enabled: true
+
+      providers:
+        kubernetesCRD:
+          namespaces: [ns1, ns2]
+    asserts:
+      - equalRaw:
+          value: |
+            RELEASE-NAME with myrepo/traefik-hub:v3.20.4 has been deployed successfully on NAMESPACE namespace!


### PR DESCRIPTION
### What does this PR do?

Makes the install NOTES print the same image the container actually runs.
For `oci_meta` and `global.azure` installs, NOTES showed the plain `image.registry/image.repository` instead of the OCI/Azure image. NOTES now delegates to `traefik.image-name`, the helper the container spec uses.

### Motivation

The post-install message should never lie about what was deployed. Single source of truth for the image string across container spec and NOTES.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

> [!NOTE]
> Overlaps #1885 (both touch the NOTES image line) — whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)