### PR TITLE
fix(logs)!: align syntax with upstream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,9 @@ Traefik can run as a `Deployment` or `DaemonSet` — controlled by `deployment.k
 
 Example pattern:
 ```yaml
-logs:
-  general:
-    # -- Set [logs format](https://doc.traefik.io/traefik/observability/logs/#format)
-    format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
+log:
+  # -- Set [logs format](https://doc.traefik.io/traefik/observability/logs/#format)
+  format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
 ```
 
 ## Templating Conventions

--- a/traefik/Guidelines.md
+++ b/traefik/Guidelines.md
@@ -9,10 +9,9 @@ It comes with a JSON schema generated from values with [helm schema](https://git
 ## Feature Example
 
 ```yaml
-logs:
-  general:
-    # -- Set [logs format](https://doc.traefik.io/traefik/observability/logs/#format)
-    format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
+log:
+  # -- Set [logs format](https://doc.traefik.io/traefik/observability/logs/#format)
+  format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
 ```
 
 Documention is on the first comment, starting with `# --`

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -27,6 +27,38 @@ Kubernetes: `>=1.25.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| accessLog | object | `{"addInternals":false,"bufferingSize":null,"dualOutput":false,"enabled":false,"fields":{"defaultMode":"keep","headers":{"defaultMode":"drop","names":{}},"names":{},"queryParameters":{"defaultMode":null}},"filters":{"minDuration":"","retryAttempts":false,"statusCodes":""},"format":null,"otlp":{"enabled":false,"grpc":{"enabled":false,"endpoint":"","insecure":false,"tls":{"ca":"","cert":"","insecureSkipVerify":null,"key":""}},"http":{"enabled":false,"endpoint":"","headers":{},"tls":{"ca":"","cert":"","insecureSkipVerify":null,"key":""}},"resourceAttributes":{},"serviceName":null},"timezone":""}` | See [access logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/) |
+| accessLog.addInternals | bool | `false` | Enables accessLogs for internal resources. Default: false. |
+| accessLog.bufferingSize | string | `nil` | Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize) |
+| accessLog.dualOutput | bool | `false` | Enables access log output alongside OTLP (v3.7+). |
+| accessLog.enabled | bool | `false` | To enable access logs |
+| accessLog.fields.defaultMode | string | `"keep"` | Set default mode for fields.names |
+| accessLog.fields.headers.defaultMode | string | `"drop"` | [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization) |
+| accessLog.fields.names | object | `{}` | Names of the fields to limit. |
+| accessLog.fields.queryParameters.defaultMode | string | `nil` | Keep or drop all query parameters in the RequestPath access log field (v3.7.3+). |
+| accessLog.filters | object | See below | Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters) |
+| accessLog.filters.minDuration | string | `""` | Set minDuration, to keep access logs when requests take longer than the specified duration |
+| accessLog.filters.retryAttempts | bool | `false` | Set retryAttempts, to keep the access logs when at least one retry has happened |
+| accessLog.filters.statusCodes | string | `""` | Set statusCodes, to limit the access logs to requests with a status codes in the specified range |
+| accessLog.format | string | `nil` | Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format) |
+| accessLog.otlp.enabled | bool | `false` | Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled. |
+| accessLog.otlp.grpc.enabled | bool | `false` | Set to true in order to send access logs to the OpenTelemetry Collector using gRPC |
+| accessLog.otlp.grpc.endpoint | string | `""` | Format: <host>:<port>. Default: "localhost:4317" |
+| accessLog.otlp.grpc.insecure | bool | `false` | Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol. |
+| accessLog.otlp.grpc.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
+| accessLog.otlp.grpc.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
+| accessLog.otlp.grpc.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
+| accessLog.otlp.grpc.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
+| accessLog.otlp.http.enabled | bool | `false` | Set to true in order to send access logs to the OpenTelemetry Collector using HTTP. |
+| accessLog.otlp.http.endpoint | string | `""` | Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs |
+| accessLog.otlp.http.headers | object | `{}` | Additional headers sent with access logs by the reporter to the OpenTelemetry Collector. |
+| accessLog.otlp.http.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
+| accessLog.otlp.http.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
+| accessLog.otlp.http.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
+| accessLog.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
+| accessLog.otlp.resourceAttributes | object | `{}` | Defines additional resource attributes to be sent to the collector. |
+| accessLog.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
+| accessLog.timezone | string | `""` | Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones) |
 | additionalArguments | list | `[]` | Additional arguments to be passed at Traefik's binary See [CLI Reference](https://docs.traefik.io/reference/static-configuration/cli/) Use curly braces to pass values: `helm install --set="additionalArguments={--providers.kubernetesingress.ingressclass=traefik-internal,--log.level=DEBUG}"` |
 | additionalVolumeMounts | list | `[]` | Additional volumeMounts to add to the Traefik container |
 | affinity | object | `{}` | on nodes where no other traefik pods are scheduled. It should be used when hostNetwork: true to prevent port conflicts |
@@ -245,59 +277,28 @@ Kubernetes: `>=1.25.0-0`
 | livenessProbe.periodSeconds | int | `10` | The number of seconds to wait between consecutive probes. |
 | livenessProbe.successThreshold | int | `1` | The minimum consecutive successes required to consider the probe successful. |
 | livenessProbe.timeoutSeconds | int | `2` | The number of seconds to wait for a probe response before considering it as failed. |
-| logs.access.addInternals | bool | `false` | Enables accessLogs for internal resources. Default: false. |
-| logs.access.bufferingSize | string | `nil` | Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize) |
-| logs.access.dualOutput | bool | `false` | Enables access log output alongside OTLP (v3.7+). |
-| logs.access.enabled | bool | `false` | To enable access logs |
-| logs.access.fields.general.defaultmode | string | `"keep"` | Set default mode for fields.names |
-| logs.access.fields.general.names | object | `{}` | Names of the fields to limit. |
-| logs.access.fields.headers.defaultmode | string | `"drop"` | [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization) |
-| logs.access.fields.headers.names | object | `{}` |  |
-| logs.access.fields.queryParameters.defaultmode | string | `nil` | Keep or drop all query parameters in the RequestPath access log field (v3.7.3+). |
-| logs.access.filters | object | See below | Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters) |
-| logs.access.filters.minduration | string | `""` | Set minDuration, to keep access logs when requests take longer than the specified duration |
-| logs.access.filters.retryattempts | bool | `false` | Set retryAttempts, to keep the access logs when at least one retry has happened |
-| logs.access.filters.statuscodes | string | `""` | Set statusCodes, to limit the access logs to requests with a status codes in the specified range |
-| logs.access.format | string | `nil` | Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format) |
-| logs.access.otlp.enabled | bool | `false` | Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled. |
-| logs.access.otlp.grpc.enabled | bool | `false` | Set to true in order to send access logs to the OpenTelemetry Collector using gRPC |
-| logs.access.otlp.grpc.endpoint | string | `""` | Format: <host>:<port>. Default: "localhost:4317" |
-| logs.access.otlp.grpc.insecure | bool | `false` | Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol. |
-| logs.access.otlp.grpc.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
-| logs.access.otlp.grpc.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
-| logs.access.otlp.grpc.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
-| logs.access.otlp.grpc.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
-| logs.access.otlp.http.enabled | bool | `false` | Set to true in order to send access logs to the OpenTelemetry Collector using HTTP. |
-| logs.access.otlp.http.endpoint | string | `""` | Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs |
-| logs.access.otlp.http.headers | object | `{}` | Additional headers sent with access logs by the reporter to the OpenTelemetry Collector. |
-| logs.access.otlp.http.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
-| logs.access.otlp.http.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
-| logs.access.otlp.http.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
-| logs.access.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
-| logs.access.otlp.resourceAttributes | object | `{}` | Defines additional resource attributes to be sent to the collector. |
-| logs.access.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
-| logs.access.timezone | string | `""` | Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones) |
-| logs.general.filePath | string | `""` | To write the logs into a log file, use the filePath option. |
-| logs.general.format | string | `nil` | Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format) |
-| logs.general.level | string | `"INFO"` | Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC. |
-| logs.general.noColor | bool | `false` | When set to true and format is common, it disables the colorized output. |
-| logs.general.otlp.enabled | bool | `false` | Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled. |
-| logs.general.otlp.grpc.enabled | bool | `false` | Set to true in order to send logs  to the OpenTelemetry Collector using gRPC |
-| logs.general.otlp.grpc.endpoint | string | `""` | Format: <host>:<port>. Default: "localhost:4317" |
-| logs.general.otlp.grpc.insecure | bool | `false` | Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol. |
-| logs.general.otlp.grpc.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
-| logs.general.otlp.grpc.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
-| logs.general.otlp.grpc.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
-| logs.general.otlp.grpc.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
-| logs.general.otlp.http.enabled | bool | `false` | Set to true in order to send logs to the OpenTelemetry Collector using HTTP. |
-| logs.general.otlp.http.endpoint | string | `""` | Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs |
-| logs.general.otlp.http.headers | object | `{}` | Additional headers sent with logs by the reporter to the OpenTelemetry Collector. |
-| logs.general.otlp.http.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
-| logs.general.otlp.http.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
-| logs.general.otlp.http.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
-| logs.general.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
-| logs.general.otlp.resourceAttributes | object | `{}` | Defines additional resource attributes to be sent to the collector. |
-| logs.general.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
+| log | object | `{"filePath":"","format":null,"level":"INFO","noColor":false,"otlp":{"enabled":false,"grpc":{"enabled":false,"endpoint":"","insecure":false,"tls":{"ca":"","cert":"","insecureSkipVerify":null,"key":""}},"http":{"enabled":false,"endpoint":"","headers":{},"tls":{"ca":"","cert":"","insecureSkipVerify":null,"key":""}},"resourceAttributes":{},"serviceName":null}}` | See [logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/) |
+| log.filePath | string | `""` | To write the logs into a log file, use the filePath option. |
+| log.format | string | `nil` | Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format) |
+| log.level | string | `"INFO"` | Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC. |
+| log.noColor | bool | `false` | When set to true and format is common, it disables the colorized output. |
+| log.otlp.enabled | bool | `false` | Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled. |
+| log.otlp.grpc.enabled | bool | `false` | Set to true in order to send logs  to the OpenTelemetry Collector using gRPC |
+| log.otlp.grpc.endpoint | string | `""` | Format: <host>:<port>. Default: "localhost:4317" |
+| log.otlp.grpc.insecure | bool | `false` | Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol. |
+| log.otlp.grpc.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
+| log.otlp.grpc.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
+| log.otlp.grpc.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
+| log.otlp.grpc.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
+| log.otlp.http.enabled | bool | `false` | Set to true in order to send logs to the OpenTelemetry Collector using HTTP. |
+| log.otlp.http.endpoint | string | `""` | Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs |
+| log.otlp.http.headers | object | `{}` | Additional headers sent with logs by the reporter to the OpenTelemetry Collector. |
+| log.otlp.http.tls.ca | string | `""` | The path to the certificate authority, it defaults to the system bundle. |
+| log.otlp.http.tls.cert | string | `""` | The path to the public certificate. When using this option, setting the key option is required. |
+| log.otlp.http.tls.insecureSkipVerify | string | `nil` | When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers. |
+| log.otlp.http.tls.key | string | `""` | The path to the private key. When using this option, setting the cert option is required. |
+| log.otlp.resourceAttributes | object | `{}` | Defines additional resource attributes to be sent to the collector. |
+| log.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
 | metrics.addInternals | bool | `false` | Enable metrics for internal resources. Default: false |
 | metrics.otlp.addEntryPointsLabels | string | `nil` | Enable metrics on entry points. Default: true |
 | metrics.otlp.addRoutersLabels | string | `nil` | Enable metrics on routers. Default: false |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -752,65 +752,67 @@
             {{- end }}
           {{- end }}
           {{- end }}
-          {{- with .Values.logs }}
-            {{- with .general.format }}
+          {{- with .Values.log }}
+            {{- with .format }}
           - "--log.format={{ . }}"
             {{- end }}
-            {{- with .general.filePath }}
+            {{- with .filePath }}
           - "--log.filePath={{ . }}"
             {{- end }}
-            {{- if and (or (eq .general.format "common") (not .general.format)) (eq .general.noColor true) }}
-          - "--log.noColor={{ .general.noColor }}"
+            {{- if and (or (eq .format "common") (not .format)) (eq .noColor true) }}
+          - "--log.noColor={{ .noColor }}"
             {{- end }}
-            {{- with .general.level }}
+            {{- with .level }}
           - "--log.level={{ . | upper }}"
             {{- end }}
-            {{- with .general.otlp }}
+            {{- with .otlp }}
              {{- include "traefik.oltpCommonParams" (dict "path" "log.otlp" "oltp" .) | nindent 8 }}
             {{- end }}
-            {{- if .access.enabled }}
+          {{- end }}
+          {{- with .Values.accessLog }}
+            {{- if .enabled }}
           - "--accesslog=true"
-              {{- with .access.format }}
+              {{- with .format }}
           - "--accesslog.format={{ . }}"
               {{- end }}
-              {{- with .access.filePath }}
+              {{- with .filePath }}
           - "--accesslog.filepath={{ . }}"
               {{- end }}
-              {{- if .access.addInternals }}
+              {{- if .addInternals }}
           - "--accesslog.addinternals"
               {{- end }}
-              {{- if .access.dualOutput }}
+              {{- if .dualOutput }}
           - "--accesslog.dualOutput=true"
               {{- end }}
-              {{- with .access.bufferingSize }}
+              {{- with .bufferingSize }}
           - "--accesslog.bufferingsize={{ . }}"
               {{- end }}
-              {{- if .access.timezone }}
+              {{- if .timezone }}
           - "--accesslog.fields.names.StartUTC=drop"
               {{- end }}
-              {{- with .access.filters }}
-                {{- with .statuscodes }}
+              {{- with .filters }}
+                {{- with .statusCodes }}
           - "--accesslog.filters.statuscodes={{ . }}"
                 {{- end }}
-                {{- if .retryattempts }}
+                {{- if .retryAttempts }}
           - "--accesslog.filters.retryattempts"
                 {{- end }}
-                {{- with .minduration }}
+                {{- with .minDuration }}
           - "--accesslog.filters.minduration={{ . }}"
                 {{- end }}
               {{- end }}
-          - "--accesslog.fields.defaultmode={{ .access.fields.general.defaultmode }}"
-              {{- range $fieldname, $fieldaction := .access.fields.general.names }}
+          - "--accesslog.fields.defaultmode={{ .fields.defaultMode }}"
+              {{- range $fieldname, $fieldaction := .fields.names }}
           - "--accesslog.fields.names.{{ $fieldname }}={{ $fieldaction }}"
               {{- end }}
-          - "--accesslog.fields.headers.defaultmode={{ .access.fields.headers.defaultmode }}"
-              {{- range $fieldname, $fieldaction := .access.fields.headers.names }}
+          - "--accesslog.fields.headers.defaultmode={{ .fields.headers.defaultMode }}"
+              {{- range $fieldname, $fieldaction := .fields.headers.names }}
           - "--accesslog.fields.headers.names.{{ $fieldname }}={{ $fieldaction }}"
               {{- end }}
-              {{- with .access.fields.queryParameters.defaultmode }}
+              {{- with .fields.queryParameters.defaultMode }}
           - "--accesslog.fields.queryparameters.defaultmode={{ . }}"
               {{- end }}
-              {{- with .access.otlp }}
+              {{- with .otlp }}
                 {{- include "traefik.oltpCommonParams" (dict "path" "accesslog.otlp" "oltp" .) | nindent 8 }}
               {{- end }}
             {{- end }}
@@ -974,9 +976,9 @@
           - name: GOMEMLIMIT
             value: {{ include "traefik.gomemlimit" (dict "memory" .Values.resources.limits.memory "percentage" .Values.deployment.goMemLimitPercentage) | quote }}
           {{- end }}
-          {{- if .Values.logs.access.timezone }}
+          {{- if .Values.accessLog.timezone }}
           - name: TZ
-            value: {{ .Values.logs.access.timezone }}
+            value: {{ .Values.accessLog.timezone }}
           {{- end }}
         {{- with .Values.env }}
           {{- toYaml . | nindent 10 }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -78,15 +78,15 @@
   {{- fail "ERROR: Kubernetes Ingress NGINX provider globalAuthUrl option requires traefik >= v3.7.0-rc.1." }}
 {{- end }}
 
-{{- if and (not .Values.experimental.otlpLogs) (or (.Values.logs.general.otlp.enabled) (.Values.logs.access.otlp.enabled))}}
+{{- if and (not .Values.experimental.otlpLogs) (or (.Values.log.otlp.enabled) (.Values.accessLog.otlp.enabled))}}
   {{- fail "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true." }}
 {{- end }}
 
-{{- if and (semverCompare "<v3.7.0-0" $version) .Values.logs.access.dualOutput }}
+{{- if and (semverCompare "<v3.7.0-0" $version) .Values.accessLog.dualOutput }}
   {{- fail "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0." }}
 {{- end }}
 
-{{- if and (semverCompare "<v3.7.3-0" $version) .Values.logs.access.fields.queryParameters.defaultmode }}
+{{- if and (semverCompare "<v3.7.3-0" $version) .Values.accessLog.fields.queryParameters.defaultMode }}
   {{- fail "ERROR: accesslog.fields.queryParameters.defaultmode is only available for traefik >= v3.7.3." }}
 {{- end }}
 

--- a/traefik/tests/pod-config_test.yaml
+++ b/traefik/tests/pod-config_test.yaml
@@ -851,81 +851,75 @@ tests:
           content: "--core.defaultRuleSyntax=v2"
   - it: should fail when providing bad log format
     set:
-      logs:
-        general:
-          format: "test"
+      log:
+        format: "test"
     asserts:
       - failedTemplate:
           errorPattern: "format"
   - it: should set log filePath when configured
     set:
-      logs:
-        general:
-          filePath: "/var/log/traefik.log"
+      log:
+        filePath: "/var/log/traefik.log"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--log.filePath=/var/log/traefik.log"
   - it: should set log noColor when configured
     set:
-      logs:
-        general:
-          noColor: true
+      log:
+        noColor: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--log.noColor=true"
   - it: should set log noColor when configured to false as it's default
     set:
-      logs:
-        general:
-          noColor: false
+      log:
+        noColor: false
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--log.noColor=false"
   - it: should not set log noColor when configured and log format is not common
     set:
-      logs:
-        general:
-          format: json
-          noColor: true
+      log:
+        format: json
+        noColor: true
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--log.noColor=true"
   - it: should be possible to configure OTLP general logging
     set:
-      logs:
-        general:
-          otlp:
+      log:
+        otlp:
+          enabled: true
+          serviceName: traefikTest
+          http:
             enabled: true
-            serviceName: traefikTest
-            http:
-              enabled: true
-              endpoint: "http://localhost:4318/v1/metrics"
-              headers:
-                foo: http
-                test: http
-              tls:
-                ca: path/to/ca.crt
-                cert: path/to/foo.cert
-                key: path/to/foo.key
-                insecureSkipVerify: true
-            grpc:
-              enabled: true
-              endpoint: "http://localhost:4318/v1/metrics"
-              insecure: false
-              headers:
-                foo: grpc
-                test: grpc
-              tls:
-                ca: gpath/to/ca.crt
-                cert: gpath/to/foo.cert
-                key: gpath/to/foo.key
-                insecureSkipVerify: true
-            resourceAttributes:
-              foo: bar
+            endpoint: "http://localhost:4318/v1/metrics"
+            headers:
+              foo: http
+              test: http
+            tls:
+              ca: path/to/ca.crt
+              cert: path/to/foo.cert
+              key: path/to/foo.key
+              insecureSkipVerify: true
+          grpc:
+            enabled: true
+            endpoint: "http://localhost:4318/v1/metrics"
+            insecure: false
+            headers:
+              foo: grpc
+              test: grpc
+            tls:
+              ca: gpath/to/ca.crt
+              cert: gpath/to/foo.cert
+              key: gpath/to/foo.key
+              insecureSkipVerify: true
+          resourceAttributes:
+            foo: bar
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -989,27 +983,24 @@ tests:
           content: "--log.otlp.resourceAttributes.foo=bar"
   - it: should be possible to set genericCLF accesslog format with Proxy v3.5.2
     set:
-      logs:
-        access:
-          enabled: true
-          format: genericCLF
+      accessLog:
+        enabled: true
+        format: genericCLF
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.format=genericCLF"
   - it: should fail on schema level when trying to set genericCLF log format
     set:
-      logs:
-        general:
-          format: genericCLF
+      log:
+        format: genericCLF
     asserts:
       - failedTemplate:
           errorPattern: "values don't meet the specifications"
   - it: should fail when setting unknown log level
     set:
-      logs:
-        general:
-          level: test
+      log:
+        level: test
     asserts:
       - failedTemplate:
           errorPattern: "level"
@@ -1051,10 +1042,9 @@ tests:
           content: "--providers.kubernetesingress.allowEmptyServices=false"
   - it: should drop utc and set TZ env when access log timezone is set
     set:
-      logs:
-        access:
-          enabled: true
-          timezone: US/Alaska
+      accessLog:
+        enabled: true
+        timezone: US/Alaska
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -1066,21 +1056,19 @@ tests:
           content: "--accesslog.fields.names.StartUTC=drop"
   - it: should not set accesslog query parameters defaultmode by default
     set:
-      logs:
-        access:
-          enabled: true
+      accessLog:
+        enabled: true
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--accesslog.fields.queryparameters.defaultmode=keep"
   - it: should set accesslog query parameters defaultmode when configured
     set:
-      logs:
-        access:
-          enabled: true
-          fields:
-            queryParameters:
-              defaultmode: drop
+      accessLog:
+        enabled: true
+        fields:
+          queryParameters:
+            defaultMode: drop
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -1094,37 +1082,36 @@ tests:
             value: traefik
   - it: should be possible to configure OTLP access logging
     set:
-      logs:
-        access:
+      accessLog:
+        enabled: true
+        otlp:
           enabled: true
-          otlp:
+          serviceName: traefikTest
+          http:
             enabled: true
-            serviceName: traefikTest
-            http:
-              enabled: true
-              endpoint: "http://localhost:4318/v1/metrics"
-              headers:
-                foo: http
-                test: http
-              tls:
-                ca: path/to/ca.crt
-                cert: path/to/foo.cert
-                key: path/to/foo.key
-                insecureSkipVerify: true
-            grpc:
-              enabled: true
-              endpoint: "http://localhost:4318/v1/metrics"
-              insecure: false
-              headers:
-                foo: grpc
-                test: grpc
-              tls:
-                ca: gpath/to/ca.crt
-                cert: gpath/to/foo.cert
-                key: gpath/to/foo.key
-                insecureSkipVerify: true
-            resourceAttributes:
-              foo: bar
+            endpoint: "http://localhost:4318/v1/metrics"
+            headers:
+              foo: http
+              test: http
+            tls:
+              ca: path/to/ca.crt
+              cert: path/to/foo.cert
+              key: path/to/foo.key
+              insecureSkipVerify: true
+          grpc:
+            enabled: true
+            endpoint: "http://localhost:4318/v1/metrics"
+            insecure: false
+            headers:
+              foo: grpc
+              test: grpc
+            tls:
+              ca: gpath/to/ca.crt
+              cert: gpath/to/foo.cert
+              key: gpath/to/foo.key
+              insecureSkipVerify: true
+          resourceAttributes:
+            foo: bar
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -1188,14 +1175,13 @@ tests:
           content: "--accesslog.otlp.resourceAttributes.foo=bar"
   - it: should not render otlp tls options when insecure is true for access logging
     set:
-      logs:
-        access:
+      accessLog:
+        enabled: true
+        otlp:
           enabled: true
-          otlp:
+          grpc:
             enabled: true
-            grpc:
-              enabled: true
-              insecure: true
+            insecure: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -423,19 +423,17 @@ tests:
           errorPattern: "values don't meet the specifications of the schema"
   - it: should fail when using otlp logs without experimental flag
     set:
-      logs:
-        general:
-          otlp:
-            enabled: true
+      log:
+        otlp:
+          enabled: true
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true."
   - it: should fail when using otlp access logs without experimental flag
     set:
-      logs:
-        general:
-          otlp:
-            enabled: true
+      accessLog:
+        otlp:
+          enabled: true
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: otlp on logs or access logs is an experimental feature and needs experimental.otlpLogs=true."
@@ -466,9 +464,8 @@ tests:
     set:
       image:
         tag: v3.6.10
-      logs:
-        access:
-          dualOutput: true
+      accessLog:
+        dualOutput: true
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0."
@@ -476,11 +473,10 @@ tests:
     set:
       image:
         tag: v3.7.1
-      logs:
-        access:
-          fields:
-            queryParameters:
-              defaultmode: drop
+      accessLog:
+        fields:
+          queryParameters:
+            defaultMode: drop
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: accesslog.fields.queryParameters.defaultmode is only available for traefik >= v3.7.3."

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -978,15 +978,14 @@ tests:
           content: "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=42s"
   - it: should be possible to configure access logs
     set:
-      logs:
-        access:
-          enabled: true
-          format: json
-          filePath: "/data/log"
-          bufferingSize: 100
-          addInternals: true
-          filters:
-            statuscodes: "200,300-302"
+      accessLog:
+        enabled: true
+        format: json
+        filePath: "/data/log"
+        bufferingSize: 100
+        addInternals: true
+        filters:
+          statusCodes: "200,300-302"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -1011,10 +1010,9 @@ tests:
           content: "--accesslog.dualOutput=true"
   - it: should be possible to enable access log dualOutput
     set:
-      logs:
-        access:
-          enabled: true
-          dualOutput: true
+      accessLog:
+        enabled: true
+        dualOutput: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -5,6 +5,224 @@
     "description": "The Cloud Native Application Proxy",
     "type": "object",
     "properties": {
+        "accessLog": {
+            "description": "See [access logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/)",
+            "type": "object",
+            "properties": {
+                "addInternals": {
+                    "description": "Enables accessLogs for internal resources. Default: false.",
+                    "type": "boolean"
+                },
+                "bufferingSize": {
+                    "description": "Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize)",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "dualOutput": {
+                    "description": "Enables access log output alongside OTLP (v3.7+).",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "description": "To enable access logs",
+                    "type": "boolean"
+                },
+                "fields": {
+                    "type": "object",
+                    "properties": {
+                        "defaultMode": {
+                            "description": "Set default mode for fields.names",
+                            "default": "keep",
+                            "type": "string",
+                            "enum": [
+                                "keep",
+                                "drop",
+                                "redact"
+                            ]
+                        },
+                        "headers": {
+                            "type": "object",
+                            "properties": {
+                                "defaultMode": {
+                                    "description": "[Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)",
+                                    "default": "drop",
+                                    "type": "string",
+                                    "enum": [
+                                        "keep",
+                                        "drop",
+                                        "redact"
+                                    ]
+                                },
+                                "names": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "names": {
+                            "description": "Names of the fields to limit.",
+                            "type": "object"
+                        },
+                        "queryParameters": {
+                            "type": "object",
+                            "properties": {
+                                "defaultMode": {
+                                    "description": "Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "enum": [
+                                        "keep",
+                                        "drop",
+                                        null
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "filters": {
+                    "description": "Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters)",
+                    "type": "object",
+                    "properties": {
+                        "minDuration": {
+                            "description": "Set minDuration, to keep access logs when requests take longer than the specified duration",
+                            "type": "string"
+                        },
+                        "retryAttempts": {
+                            "description": "Set retryAttempts, to keep the access logs when at least one retry has happened",
+                            "type": "boolean"
+                        },
+                        "statusCodes": {
+                            "description": "Set statusCodes, to limit the access logs to requests with a status codes in the specified range",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "format": {
+                    "description": "Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format)",
+                    "default": "common",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "common",
+                        "genericCLF",
+                        "json",
+                        null
+                    ]
+                },
+                "otlp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.",
+                            "type": "boolean"
+                        },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send access logs to the OpenTelemetry Collector using gRPC",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                    "type": "string"
+                                },
+                                "insecure": {
+                                    "description": "Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol.",
+                                    "type": "boolean"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send access logs to the OpenTelemetry Collector using HTTP.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
+                                    "type": "string"
+                                },
+                                "headers": {
+                                    "description": "Additional headers sent with access logs by the reporter to the OpenTelemetry Collector.",
+                                    "type": "object"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resourceAttributes": {
+                            "description": "Defines additional resource attributes to be sent to the collector.",
+                            "type": "object"
+                        },
+                        "serviceName": {
+                            "description": "Service name used in OTLP backend. Default: traefik.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "timezone": {
+                    "description": "Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones)",
+                    "type": "string"
+                }
+            }
+        },
         "additionalArguments": {
             "description": "Additional arguments to be passed at Traefik's binary See [CLI Reference](https://docs.traefik.io/reference/static-configuration/cli/)",
             "type": "array"
@@ -1322,370 +1540,144 @@
             },
             "additionalProperties": false
         },
-        "logs": {
+        "log": {
+            "description": "See [logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/)",
             "type": "object",
             "properties": {
-                "access": {
+                "filePath": {
+                    "description": "To write the logs into a log file, use the filePath option.",
+                    "type": "string"
+                },
+                "format": {
+                    "description": "Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format)",
+                    "default": "common",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "common",
+                        "json",
+                        null
+                    ]
+                },
+                "level": {
+                    "description": "Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC.",
+                    "default": "INFO",
+                    "type": "string",
+                    "enum": [
+                        "TRACE",
+                        "DEBUG",
+                        "INFO",
+                        "WARN",
+                        "ERROR",
+                        "FATAL",
+                        "PANIC"
+                    ]
+                },
+                "noColor": {
+                    "description": "When set to true and format is common, it disables the colorized output.",
+                    "type": "boolean"
+                },
+                "otlp": {
                     "type": "object",
                     "properties": {
-                        "addInternals": {
-                            "description": "Enables accessLogs for internal resources. Default: false.",
-                            "type": "boolean"
-                        },
-                        "bufferingSize": {
-                            "description": "Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize)",
-                            "type": [
-                                "integer",
-                                "null"
-                            ]
-                        },
-                        "dualOutput": {
-                            "description": "Enables access log output alongside OTLP (v3.7+).",
-                            "type": "boolean"
-                        },
                         "enabled": {
-                            "description": "To enable access logs",
+                            "description": "Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled.",
                             "type": "boolean"
                         },
-                        "fields": {
+                        "grpc": {
                             "type": "object",
                             "properties": {
-                                "general": {
+                                "enabled": {
+                                    "description": "Set to true in order to send logs  to the OpenTelemetry Collector using gRPC",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                    "type": "string"
+                                },
+                                "insecure": {
+                                    "description": "Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol.",
+                                    "type": "boolean"
+                                },
+                                "tls": {
                                     "type": "object",
                                     "properties": {
-                                        "defaultmode": {
-                                            "description": "Set default mode for fields.names",
-                                            "default": "keep",
-                                            "type": "string",
-                                            "enum": [
-                                                "keep",
-                                                "drop",
-                                                "redact"
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
                                             ]
                                         },
-                                        "names": {
-                                            "description": "Names of the fields to limit.",
-                                            "type": "object"
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send logs to the OpenTelemetry Collector using HTTP.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
+                                    "type": "string"
                                 },
                                 "headers": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultmode": {
-                                            "description": "[Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)",
-                                            "default": "drop",
-                                            "type": "string",
-                                            "enum": [
-                                                "keep",
-                                                "drop",
-                                                "redact"
-                                            ]
-                                        },
-                                        "names": {
-                                            "type": "object"
-                                        }
-                                    }
+                                    "description": "Additional headers sent with logs by the reporter to the OpenTelemetry Collector.",
+                                    "type": "object"
                                 },
-                                "queryParameters": {
+                                "tls": {
                                     "type": "object",
                                     "properties": {
-                                        "defaultmode": {
-                                            "description": "Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).",
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
                                             "type": [
-                                                "string",
+                                                "boolean",
                                                 "null"
-                                            ],
-                                            "enum": [
-                                                "keep",
-                                                "drop",
-                                                null
                                             ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
                                         }
                                     }
                                 }
                             }
                         },
-                        "filters": {
-                            "description": "Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters)",
-                            "type": "object",
-                            "properties": {
-                                "minduration": {
-                                    "description": "Set minDuration, to keep access logs when requests take longer than the specified duration",
-                                    "type": "string"
-                                },
-                                "retryattempts": {
-                                    "description": "Set retryAttempts, to keep the access logs when at least one retry has happened",
-                                    "type": "boolean"
-                                },
-                                "statuscodes": {
-                                    "description": "Set statusCodes, to limit the access logs to requests with a status codes in the specified range",
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
+                        "resourceAttributes": {
+                            "description": "Defines additional resource attributes to be sent to the collector.",
+                            "type": "object"
                         },
-                        "format": {
-                            "description": "Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format)",
-                            "default": "common",
+                        "serviceName": {
+                            "description": "Service name used in OTLP backend. Default: traefik.",
                             "type": [
                                 "string",
                                 "null"
-                            ],
-                            "enum": [
-                                "common",
-                                "genericCLF",
-                                "json",
-                                null
                             ]
-                        },
-                        "otlp": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "description": "Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.",
-                                    "type": "boolean"
-                                },
-                                "grpc": {
-                                    "type": "object",
-                                    "properties": {
-                                        "enabled": {
-                                            "description": "Set to true in order to send access logs to the OpenTelemetry Collector using gRPC",
-                                            "type": "boolean"
-                                        },
-                                        "endpoint": {
-                                            "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
-                                            "type": "string"
-                                        },
-                                        "insecure": {
-                                            "description": "Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol.",
-                                            "type": "boolean"
-                                        },
-                                        "tls": {
-                                            "type": "object",
-                                            "properties": {
-                                                "ca": {
-                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
-                                                    "type": "string"
-                                                },
-                                                "cert": {
-                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
-                                                    "type": "string"
-                                                },
-                                                "insecureSkipVerify": {
-                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
-                                                    "type": [
-                                                        "boolean",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "key": {
-                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "http": {
-                                    "type": "object",
-                                    "properties": {
-                                        "enabled": {
-                                            "description": "Set to true in order to send access logs to the OpenTelemetry Collector using HTTP.",
-                                            "type": "boolean"
-                                        },
-                                        "endpoint": {
-                                            "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
-                                            "type": "string"
-                                        },
-                                        "headers": {
-                                            "description": "Additional headers sent with access logs by the reporter to the OpenTelemetry Collector.",
-                                            "type": "object"
-                                        },
-                                        "tls": {
-                                            "type": "object",
-                                            "properties": {
-                                                "ca": {
-                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
-                                                    "type": "string"
-                                                },
-                                                "cert": {
-                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
-                                                    "type": "string"
-                                                },
-                                                "insecureSkipVerify": {
-                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
-                                                    "type": [
-                                                        "boolean",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "key": {
-                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "resourceAttributes": {
-                                    "description": "Defines additional resource attributes to be sent to the collector.",
-                                    "type": "object"
-                                },
-                                "serviceName": {
-                                    "description": "Service name used in OTLP backend. Default: traefik.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "timezone": {
-                            "description": "Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones)",
-                            "type": "string"
-                        }
-                    }
-                },
-                "general": {
-                    "type": "object",
-                    "properties": {
-                        "filePath": {
-                            "description": "To write the logs into a log file, use the filePath option.",
-                            "type": "string"
-                        },
-                        "format": {
-                            "description": "Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format)",
-                            "default": "common",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "common",
-                                "json",
-                                null
-                            ]
-                        },
-                        "level": {
-                            "description": "Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC.",
-                            "default": "INFO",
-                            "type": "string",
-                            "enum": [
-                                "TRACE",
-                                "DEBUG",
-                                "INFO",
-                                "WARN",
-                                "ERROR",
-                                "FATAL",
-                                "PANIC"
-                            ]
-                        },
-                        "noColor": {
-                            "description": "When set to true and format is common, it disables the colorized output.",
-                            "type": "boolean"
-                        },
-                        "otlp": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "description": "Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled.",
-                                    "type": "boolean"
-                                },
-                                "grpc": {
-                                    "type": "object",
-                                    "properties": {
-                                        "enabled": {
-                                            "description": "Set to true in order to send logs  to the OpenTelemetry Collector using gRPC",
-                                            "type": "boolean"
-                                        },
-                                        "endpoint": {
-                                            "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
-                                            "type": "string"
-                                        },
-                                        "insecure": {
-                                            "description": "Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol.",
-                                            "type": "boolean"
-                                        },
-                                        "tls": {
-                                            "type": "object",
-                                            "properties": {
-                                                "ca": {
-                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
-                                                    "type": "string"
-                                                },
-                                                "cert": {
-                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
-                                                    "type": "string"
-                                                },
-                                                "insecureSkipVerify": {
-                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
-                                                    "type": [
-                                                        "boolean",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "key": {
-                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "http": {
-                                    "type": "object",
-                                    "properties": {
-                                        "enabled": {
-                                            "description": "Set to true in order to send logs to the OpenTelemetry Collector using HTTP.",
-                                            "type": "boolean"
-                                        },
-                                        "endpoint": {
-                                            "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
-                                            "type": "string"
-                                        },
-                                        "headers": {
-                                            "description": "Additional headers sent with logs by the reporter to the OpenTelemetry Collector.",
-                                            "type": "object"
-                                        },
-                                        "tls": {
-                                            "type": "object",
-                                            "properties": {
-                                                "ca": {
-                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
-                                                    "type": "string"
-                                                },
-                                                "cert": {
-                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
-                                                    "type": "string"
-                                                },
-                                                "insecureSkipVerify": {
-                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
-                                                    "type": [
-                                                        "boolean",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "key": {
-                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "resourceAttributes": {
-                                    "description": "Defines additional resource attributes to be sent to the collector.",
-                                    "type": "object"
-                                },
-                                "serviceName": {
-                                    "description": "Service name used in OTLP backend. Default: traefik.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
                         }
                     }
                 }

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -521,136 +521,136 @@ additionalVolumeMounts: []
 # - name: traefik-logs
 #   mountPath: /var/log/traefik
 
-logs:
-  general:
-    # -- Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format)
-    format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
-    # By default, the level is set to INFO.
-    # -- Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC.
-    level: "INFO"  # @schema enum:[TRACE,DEBUG,INFO,WARN,ERROR,FATAL,PANIC]; default: "INFO"
-    # -- To write the logs into a log file, use the filePath option.
-    filePath: ""
-    # -- When set to true and format is common, it disables the colorized output.
-    noColor: false
-    otlp:
-      # -- Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled.
-      enabled: false
-      # -- Service name used in OTLP backend. Default: traefik.
-      serviceName:  # @schema type:[string, null]
-      http:
-        # -- Set to true in order to send logs to the OpenTelemetry Collector using HTTP.
-        enabled: false
-        # -- Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs
-        endpoint: ""
-        # -- Additional headers sent with logs by the reporter to the OpenTelemetry Collector.
-        headers: {}
-        ## Defines the TLS configuration used by the reporter to send logs to the OpenTelemetry Collector.
-        tls:
-          # -- The path to the certificate authority, it defaults to the system bundle.
-          ca: ""
-          # -- The path to the public certificate. When using this option, setting the key option is required.
-          cert: ""
-          # -- The path to the private key. When using this option, setting the cert option is required.
-          key: ""
-          # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
-          insecureSkipVerify:  # @schema type:[boolean, null]
-      grpc:
-        # -- Set to true in order to send logs  to the OpenTelemetry Collector using gRPC
-        enabled: false
-        # -- Format: <host>:<port>. Default: "localhost:4317"
-        endpoint: ""
-        # -- Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol.
-        insecure: false
-        ## Defines the TLS configuration used by the reporter to send logs to the OpenTelemetry Collector.
-        tls:
-          # -- The path to the certificate authority, it defaults to the system bundle.
-          ca: ""
-          # -- The path to the public certificate. When using this option, setting the key option is required.
-          cert: ""
-          # -- The path to the private key. When using this option, setting the cert option is required.
-          key: ""
-          # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
-          insecureSkipVerify:  # @schema type:[boolean, null]
-      # -- Defines additional resource attributes to be sent to the collector.
-      resourceAttributes: {}
-
-  access:
-    # -- To enable access logs
+# -- See [logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/)
+log:
+  # -- Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format)
+  format:  # @schema enum:["common", "json", null]; type:[string, null]; default: "common"
+  # By default, the level is set to INFO.
+  # -- Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC.
+  level: "INFO"  # @schema enum:[TRACE,DEBUG,INFO,WARN,ERROR,FATAL,PANIC]; default: "INFO"
+  # -- To write the logs into a log file, use the filePath option.
+  filePath: ""
+  # -- When set to true and format is common, it disables the colorized output.
+  noColor: false
+  otlp:
+    # -- Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled.
     enabled: false
-    # -- Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format)
-    format:  # @schema enum:["common", "genericCLF", "json", null]; type:[string, null]; default: "common"
-    # filePath: "/var/log/traefik/access.log
-    # -- Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize)
-    bufferingSize:  # @schema type:[integer, null]
-    # -- Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones)
-    timezone: ""
-    # -- Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters)
-    # @default -- See below
-    filters:  # @schema additionalProperties: false
-      # -- Set statusCodes, to limit the access logs to requests with a status codes in the specified range
-      statuscodes: ""
-      # -- Set retryAttempts, to keep the access logs when at least one retry has happened
-      retryattempts: false
-      # -- Set minDuration, to keep access logs when requests take longer than the specified duration
-      minduration: ""
-    # -- Enables accessLogs for internal resources. Default: false.
-    addInternals: false
-    # -- Enables access log output alongside OTLP (v3.7+).
-    dualOutput: false
-    fields:
-      general:
-        # -- Set default mode for fields.names
-        defaultmode: keep  # @schema enum:[keep, drop, redact]; default: keep
-        # -- Names of the fields to limit.
-        names: {}
-      headers:
-        # -- [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)
-        defaultmode: drop  # @schema enum:[keep, drop, redact]; default: drop
-        names: {}
-      queryParameters:
-        # -- Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).
-        defaultmode:  # @schema enum:[keep, drop, null]; type:[string, null]; default: null
-    otlp:
-      # -- Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.
+    # -- Service name used in OTLP backend. Default: traefik.
+    serviceName:  # @schema type:[string, null]
+    http:
+      # -- Set to true in order to send logs to the OpenTelemetry Collector using HTTP.
       enabled: false
-      # -- Service name used in OTLP backend. Default: traefik.
-      serviceName:  # @schema type:[string, null]
-      http:
-        # -- Set to true in order to send access logs to the OpenTelemetry Collector using HTTP.
-        enabled: false
-        # -- Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs
-        endpoint: ""
-        # -- Additional headers sent with access logs by the reporter to the OpenTelemetry Collector.
-        headers: {}
-        ## Defines the TLS configuration used by the reporter to send access logs to the OpenTelemetry Collector.
-        tls:
-          # -- The path to the certificate authority, it defaults to the system bundle.
-          ca: ""
-          # -- The path to the public certificate. When using this option, setting the key option is required.
-          cert: ""
-          # -- The path to the private key. When using this option, setting the cert option is required.
-          key: ""
-          # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
-          insecureSkipVerify:  # @schema type:[boolean, null]
-      grpc:
-        # -- Set to true in order to send access logs to the OpenTelemetry Collector using gRPC
-        enabled: false
-        # -- Format: <host>:<port>. Default: "localhost:4317"
-        endpoint: ""
-        # -- Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol.
-        insecure: false
-        ## Defines the TLS configuration used by the reporter to send access logs to the OpenTelemetry Collector.
-        tls:
-          # -- The path to the certificate authority, it defaults to the system bundle.
-          ca: ""
-          # -- The path to the public certificate. When using this option, setting the key option is required.
-          cert: ""
-          # -- The path to the private key. When using this option, setting the cert option is required.
-          key: ""
-          # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
-          insecureSkipVerify:  # @schema type:[boolean, null]
-      # -- Defines additional resource attributes to be sent to the collector.
-      resourceAttributes: {}
+      # -- Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs
+      endpoint: ""
+      # -- Additional headers sent with logs by the reporter to the OpenTelemetry Collector.
+      headers: {}
+      ## Defines the TLS configuration used by the reporter to send logs to the OpenTelemetry Collector.
+      tls:
+        # -- The path to the certificate authority, it defaults to the system bundle.
+        ca: ""
+        # -- The path to the public certificate. When using this option, setting the key option is required.
+        cert: ""
+        # -- The path to the private key. When using this option, setting the cert option is required.
+        key: ""
+        # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
+        insecureSkipVerify:  # @schema type:[boolean, null]
+    grpc:
+      # -- Set to true in order to send logs  to the OpenTelemetry Collector using gRPC
+      enabled: false
+      # -- Format: <host>:<port>. Default: "localhost:4317"
+      endpoint: ""
+      # -- Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol.
+      insecure: false
+      ## Defines the TLS configuration used by the reporter to send logs to the OpenTelemetry Collector.
+      tls:
+        # -- The path to the certificate authority, it defaults to the system bundle.
+        ca: ""
+        # -- The path to the public certificate. When using this option, setting the key option is required.
+        cert: ""
+        # -- The path to the private key. When using this option, setting the cert option is required.
+        key: ""
+        # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
+        insecureSkipVerify:  # @schema type:[boolean, null]
+    # -- Defines additional resource attributes to be sent to the collector.
+    resourceAttributes: {}
+
+# -- See [access logs reference](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/)
+accessLog:
+  # -- To enable access logs
+  enabled: false
+  # -- Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format)
+  format:  # @schema enum:["common", "genericCLF", "json", null]; type:[string, null]; default: "common"
+  # filePath: "/var/log/traefik/access.log
+  # -- Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize)
+  bufferingSize:  # @schema type:[integer, null]
+  # -- Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones)
+  timezone: ""
+  # -- Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters)
+  # @default -- See below
+  filters:  # @schema additionalProperties: false
+    # -- Set statusCodes, to limit the access logs to requests with a status codes in the specified range
+    statusCodes: ""
+    # -- Set retryAttempts, to keep the access logs when at least one retry has happened
+    retryAttempts: false
+    # -- Set minDuration, to keep access logs when requests take longer than the specified duration
+    minDuration: ""
+  # -- Enables accessLogs for internal resources. Default: false.
+  addInternals: false
+  # -- Enables access log output alongside OTLP (v3.7+).
+  dualOutput: false
+  fields:
+    # -- Set default mode for fields.names
+    defaultMode: keep  # @schema enum:[keep, drop, redact]; default: keep
+    # -- Names of the fields to limit.
+    names: {}
+    headers:
+      # -- [Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)
+      defaultMode: drop  # @schema enum:[keep, drop, redact]; default: drop
+      names: {}
+    queryParameters:
+      # -- Keep or drop all query parameters in the RequestPath access log field (v3.7.3+).
+      defaultMode:  # @schema enum:[keep, drop, null]; type:[string, null]; default: null
+  otlp:
+    # -- Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.
+    enabled: false
+    # -- Service name used in OTLP backend. Default: traefik.
+    serviceName:  # @schema type:[string, null]
+    http:
+      # -- Set to true in order to send access logs to the OpenTelemetry Collector using HTTP.
+      enabled: false
+      # -- Format: <scheme>://<host>:<port><path>. Default: https://localhost:4318/v1/logs
+      endpoint: ""
+      # -- Additional headers sent with access logs by the reporter to the OpenTelemetry Collector.
+      headers: {}
+      ## Defines the TLS configuration used by the reporter to send access logs to the OpenTelemetry Collector.
+      tls:
+        # -- The path to the certificate authority, it defaults to the system bundle.
+        ca: ""
+        # -- The path to the public certificate. When using this option, setting the key option is required.
+        cert: ""
+        # -- The path to the private key. When using this option, setting the cert option is required.
+        key: ""
+        # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
+        insecureSkipVerify:  # @schema type:[boolean, null]
+    grpc:
+      # -- Set to true in order to send access logs to the OpenTelemetry Collector using gRPC
+      enabled: false
+      # -- Format: <host>:<port>. Default: "localhost:4317"
+      endpoint: ""
+      # -- Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol.
+      insecure: false
+      ## Defines the TLS configuration used by the reporter to send access logs to the OpenTelemetry Collector.
+      tls:
+        # -- The path to the certificate authority, it defaults to the system bundle.
+        ca: ""
+        # -- The path to the public certificate. When using this option, setting the key option is required.
+        cert: ""
+        # -- The path to the private key. When using this option, setting the cert option is required.
+        key: ""
+        # -- When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.
+        insecureSkipVerify:  # @schema type:[boolean, null]
+    # -- Defines additional resource attributes to be sent to the collector.
+    resourceAttributes: {}
 
 metrics:
   # -- Enable metrics for internal resources. Default: false


### PR DESCRIPTION
## Motivation

Improve user experience by reducing divergence between this chart and Traefik's own config. 

Values now match the `log` and `accessLog` keys from the [Traefik logs reference](https://doc.traefik.io/traefik/observe/logs-and-access-logs/), so config can be copy-pasted directly.

## ⚠️ Breaking change

### Before

```yaml
logs:
  general:
    level: DEBUG
    format: json
    filePath: "/var/log/traefik.log"
    noColor: true
    otlp:
      enabled: true
  access:
    enabled: true
    format: json
    timezone: "Europe/Paris"
    filters:
      statuscodes: "200,300-302"
      retryattempts: true
      minduration: "10ms"
    fields:
      general:
        defaultmode: keep
        names:
          ClientUsername: drop
      headers:
        defaultmode: drop
      queryParameters:
        defaultmode: drop
```

### After

```yaml
log:
  level: DEBUG
  format: json
  filePath: "/var/log/traefik.log"
  noColor: true
  otlp:
    enabled: true
accessLog:
  enabled: true
  format: json
  timezone: "Europe/Paris"
  filters:
    statusCodes: "200,300-302"
    retryAttempts: true
    minDuration: "10ms"
  fields:
    defaultMode: keep
    names:
      ClientUsername: drop
    headers:
      defaultMode: drop
    queryParameters:
      defaultMode: drop
```

### Key mapping

| Before | After |
|---|---|
| `logs.general.*` | `log.*` |
| `logs.access.*` | `accessLog.*` |
| `logs.access.filters.statuscodes` | `accessLog.filters.statusCodes` |
| `logs.access.filters.retryattempts` | `accessLog.filters.retryAttempts` |
| `logs.access.filters.minduration` | `accessLog.filters.minDuration` |
| `logs.access.fields.general.defaultmode` | `accessLog.fields.defaultMode` |
| `logs.access.fields.general.names` | `accessLog.fields.names` |
| `logs.access.fields.headers.defaultmode` | `accessLog.fields.headers.defaultMode` |
| `logs.access.fields.queryParameters.defaultmode` | `accessLog.fields.queryParameters.defaultMode` |

`accessLog.enabled` and `accessLog.timezone` are chart-only UX helpers (no native equivalent) and are kept.

## Testing

- `make test` → 688 passed
- `make lint` → success
- `make docs` + `make schema` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
