### PR TITLE
ci: track max-version assertions with relaxed guard wording

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,7 +92,7 @@
       versioningTemplate: 'docker',
       matchStrings: [
         'traefik\\.io/(?<product>proxy|hub)-max-version:\\s*(?<currentValue>\\S+)',
-        'only supports Traefik (?<product>Proxy|Hub) up to (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+        'support Traefik (?<product>Proxy|Hub) \\S+, which is a major version above the supported (?<currentValue>v\\d+\\.\\d+\\.\\d+)',
         // Default Hub image assertion (container-config_test.yaml) — bumped with hub-max-version.
         'ghcr\\.io/traefik/traefik-(?<product>hub):(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
       ],


### PR DESCRIPTION
## Context

Renovate keeps the Proxy/Hub `*-max-version` test assertions in sync via a `customManager` regex. 

#1884 reworded the guard message (`only supports... up to vX` → `... above the supported vX`), so the regex went stale and matched nothing.

## Motivation

With the stale regex, the assertions in `requirements-config_test.yaml` drift on every release, and each version-bump PR fails `make test` on the outdated string (e.g. #1888). This updates the matchString to the new wording so the assertions track `Chart.yaml` again.

Verified: `renovate-config-validator` passes; regex captures the supported version on the proxy/hub assertion lines and ignores the hard-coded test inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)