### PR TITLE
fix(deployment): omit spec.replicas when replicas is null

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -85,6 +85,20 @@ autoscaling:
         averageUtilization: 80
 ```
 
+## Install with an external scaler (KEDA)
+
+When an external controller like [KEDA](https://keda.sh/) brings its own
+`ScaledObject` (and HPA), the chart's HPA stays disabled and `spec.replicas` must
+be omitted. Otherwise a GitOps tool like Argo CD reconciles the Deployment back to
+the chart value, fighting the scaler.
+
+```yaml
+deployment:
+  replicas: null
+autoscaling:
+  enabled: false
+```
+
 ## Install with Argo Rollouts
 
 When using [ArgoCD Rollouts](https://argoproj.github.io/rollouts/), one can delegate replica management to a `Rollout` resource, enabling progressive delivery strategies like canary and blue-green deployments.

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -99,7 +99,7 @@ Kubernetes: `>=1.25.0-0`
 | deployment.podAnnotations | object | `{}` | Additional pod annotations (e.g. for mesh injection or prometheus scraping) It supports templating. One can set it with values like traefik/name: '{{ template "traefik.name" . }}' |
 | deployment.podLabels | object | `{}` | Additional Pod labels (e.g. for filtering Pod by custom labels) It supports templating. One can set it with values like traefik/name: '{{ template "traefik.name" . }}' |
 | deployment.readinessPath | string | `""` |  |
-| deployment.replicas | int | `1` | Number of pods of the deployment (only applies when kind == Deployment) |
+| deployment.replicas | int | `1` | Number of pods of the deployment (only applies when kind == Deployment). Set to null to omit spec.replicas, e.g. when an external controller (HPA/KEDA) owns scaling. |
 | deployment.revisionHistoryLimit | string | `nil` | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) |
 | deployment.runtimeClassName | string | `""` | Set a runtimeClassName on pod |
 | deployment.shareProcessNamespace | bool | `false` | Use process namespace sharing |

--- a/traefik/templates/deployment.yaml
+++ b/traefik/templates/deployment.yaml
@@ -35,8 +35,8 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ default 1 .Values.deployment.replicas }}
+  {{- if and (not .Values.autoscaling.enabled) (ne .Values.deployment.replicas nil) }}
+  replicas: {{ .Values.deployment.replicas }}
   {{- else if and
     .Values.autoscaling.scaleTargetRef
     (not (and

--- a/traefik/tests/deployment-config_test.yaml
+++ b/traefik/tests/deployment-config_test.yaml
@@ -30,6 +30,15 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
+  - it: should not have replicas when replicas is null and autoscaling is disabled
+    set:
+      deployment:
+        replicas: null
+      autoscaling:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.replicas
   - it: should not have replicas when autoscaling is enabled
     set:
       autoscaling:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -452,8 +452,12 @@
                     "type": "string"
                 },
                 "replicas": {
-                    "description": "Number of pods of the deployment (only applies when kind == Deployment)",
-                    "type": "integer"
+                    "description": "Number of pods of the deployment (only applies when kind == Deployment). Set to null to omit spec.replicas, e.g. when an external controller (HPA/KEDA) owns scaling.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
                 },
                 "revisionHistoryLimit": {
                     "description": "Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -23,8 +23,9 @@ deployment:
   enabled: true
   # -- Deployment or DaemonSet
   kind: Deployment
-  # -- Number of pods of the deployment (only applies when kind == Deployment)
-  replicas: 1
+  # -- Number of pods of the deployment (only applies when kind == Deployment).
+  # Set to null to omit spec.replicas, e.g. when an external controller (HPA/KEDA) owns scaling.
+  replicas: 1  # @schema type:[integer, null];minimum:0
   # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
   revisionHistoryLimit:  # @schema type:[integer, null];minimum:0
   # -- Amount of time (in seconds) before Kubernetes will send the SIGKILL signal if Traefik does not shut down


### PR DESCRIPTION
## What does this PR do?

When `deployment.replicas` is set to `null` (and `autoscaling.enabled` is `false`), the rendered Deployment no longer includes a `spec.replicas` field.

## Motivation

Closes #1864.

The chart always rendered `spec.replicas` when `autoscaling.enabled: false`, defaulting to `1`. This prevents an external controller — such as KEDA, which brings its own `ScaledObject`/HPA — from owning the replica count: a GitOps tool like Argo CD detects drift and reconciles the Deployment back to the chart value, fighting the scaler.

Default behavior is unchanged (`replicas: 1`); only an explicit `null` drops the field.

## More

- Added unit test covering `replicas: null` → no `spec.replicas`.
- Documented the case in `EXAMPLES.md` (external scaler / KEDA).
- Regenerated `VALUES.md` and `values.schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)