### PR TITLE
fix(provider): :bug: emit kubernetesIngressNGINX publishService for external service

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -523,8 +523,8 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.proxyReadTimeout | string | `nil` | Amount of time between two successive read operations. Unitless, in seconds (default: 60) |
 | providers.kubernetesIngressNGINX.proxyRequestBuffering | string | `nil` | Defines whether to enable request buffering (default: false) |
 | providers.kubernetesIngressNGINX.proxySendTimeout | string | `nil` | Amount of time between two successive write operations. Unitless, in seconds (default: 60) |
-| providers.kubernetesIngressNGINX.publishService.enabled | bool | `false` | Service fronting the Ingress controller. Takes the form 'namespace/name' |
-| providers.kubernetesIngressNGINX.publishService.pathOverride | string | `""` |  |
+| providers.kubernetesIngressNGINX.publishService.enabled | bool | `false` | Enable publishService. Service fronting the Ingress controller, used to set the load-balancer status of Ingress objects. Usually the Service provided by this Chart. It's possible to use it with an external Service using pathOverride. |
+| providers.kubernetesIngressNGINX.publishService.pathOverride | string | `""` | Override path of Kubernetes Service used to copy status from. Format: namespace/servicename. Default to Service deployed with this Chart. |
 | providers.kubernetesIngressNGINX.publishStatusAddress | string | `""` | Customized address (or addresses, separated by comma) to set as the load-balancer status of Ingress objects this controller satisfies |
 | providers.kubernetesIngressNGINX.strictValidatePathType | string | `nil` | Defines whether to reject the entire ingress when any path contains regex characters and pathType is Prefix or Exact (default: true) |
 | providers.kubernetesIngressNGINX.throttleDuration | string | `""` | Ingress refresh throttle duration |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -524,8 +524,10 @@
           - "--providers.kubernetesingress.allowEmptyServices={{ . }}"
             {{- end }}
            {{- end }}
-           {{- if or (and .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.enabled) (and .Values.providers.kubernetesIngress.publishedService.enabled .Values.providers.kubernetesIngress.publishedService.pathOverride)}}
+           {{- if .Values.providers.kubernetesIngress.publishedService.enabled }}
+            {{- if or .Values.service.enabled .Values.providers.kubernetesIngress.publishedService.pathOverride }}
           - "--providers.kubernetesingress.ingressendpoint.publishedservice={{ template "providers.kubernetesIngress.publishedServicePath" . }}"
+            {{- end }}
            {{- end }}
            {{- with .Values.providers.kubernetesIngress.ingressEndpoint.hostname }}
           - "--providers.kubernetesingress.ingressendpoint.hostname={{ . }}"
@@ -617,8 +619,10 @@
             {{- if or .watchNamespace (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}
           - "--providers.kubernetesingressnginx.watchnamespace={{ template "providers.kubernetesIngressNGINX.namespaces" $ }}"
             {{- end }}
-            {{- if and $.Values.service.enabled .publishService.enabled }}
+            {{- if .publishService.enabled }}
+             {{- if or $.Values.service.enabled .publishService.pathOverride }}
           - "--providers.kubernetesingressnginx.publishservice={{ template "providers.kubernetesIngressNGINX.publishServicePath" $ }}"
+             {{- end }}
             {{- end }}
             {{- if .modsec.enabled }}
           - "--providers.kubernetesingressnginx.modsec=true"

--- a/traefik/tests/provider-kubernetesingressnginx_test.yaml
+++ b/traefik/tests/provider-kubernetesingressnginx_test.yaml
@@ -94,6 +94,21 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--providers.kubernetesingressnginx.publishservice=custom-namespace/custom-service"
 
+  - it: should add publishService with pathOverride when chart service is disabled
+    set:
+      service:
+        enabled: false
+      providers:
+        kubernetesIngressNGINX:
+          publishService:
+            enabled: true
+            pathOverride: "kube-system/rke2-nginx-ingress"
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--providers.kubernetesingressnginx.publishservice=kube-system/rke2-nginx-ingress"
+
   - it: should add publishStatusAddress
     set:
       providers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2899,10 +2899,11 @@
                             "type": "object",
                             "properties": {
                                 "enabled": {
-                                    "description": "Service fronting the Ingress controller. Takes the form 'namespace/name'",
+                                    "description": "Enable publishService. Service fronting the Ingress controller, used to set the load-balancer status of Ingress objects. Usually the Service provided by this Chart. It's possible to use it with an external Service using pathOverride.",
                                     "type": "boolean"
                                 },
                                 "pathOverride": {
+                                    "description": "Override path of Kubernetes Service used to copy status from. Format: namespace/servicename. Default to Service deployed with this Chart.",
                                     "type": "string"
                                 }
                             }

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -415,8 +415,11 @@ providers:
     # -- Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.
     watchNamespaceSelector: ""
     publishService:
-      # -- Service fronting the Ingress controller. Takes the form 'namespace/name'
+      # -- Enable publishService. Service fronting the Ingress controller, used to set the load-balancer status of Ingress objects.
+      # Usually the Service provided by this Chart. It's possible to use it with an external Service using pathOverride.
       enabled: false
+      # -- Override path of Kubernetes Service used to copy status from. Format: namespace/servicename.
+      # Default to Service deployed with this Chart.
       pathOverride: ""
     # -- Customized address (or addresses, separated by comma) to set as the load-balancer status of Ingress objects this controller satisfies
     publishStatusAddress: ""


### PR DESCRIPTION
### What does this PR do?

1. Emits `--providers.kubernetesingressnginx.publishservice` when `publishService.enabled` is set with a `pathOverride`, even if the chart Service is disabled. 
2. Refactors both to nested ifs (no `kubernetesIngress` behavior change), and adds helm-docs for `pathOverride`.

### Motivation

Aligns `kubernetesIngressNGINX` with `kubernetesIngress`, 

Closes #1896. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed