### PR TITLE
feat(hub): :sparkles: support hub.existingSecret for the license token

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -145,6 +145,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
+| hub.existingSecret | string | `""` | Name of an existing `Secret` with a 'token' key holding the license token (enables Hub). This is the **recommended** way to provide the license: keep the token in a `Secret` you manage, not in cleartext in your values. Takes precedence over `hub.token`. |
 | hub.mcpgateway.enabled | bool | `false` | Set to true in order to enable AI MCP Gateway. Requires a valid license token. |
 | hub.mcpgateway.maxRequestBodySize | string | `nil` | Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB). |
 | hub.namespaces | list | `[]` | By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
@@ -239,7 +240,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.redis.tls.key | string | `""` | Path to the private key used for the secure connection. |
 | hub.redis.username | string | `""` | The username to use when connecting to Redis endpoints. Default: "". |
 | hub.sendlogs | string | `nil` |  |
-| hub.token | string | `""` | Name of `Secret` with key 'token' set to a valid license token. It enables API Gateway. |
+| hub.token | string | `""` | Traefik Hub license token (enables Hub). NOT RECOMMENDED: an inline literal token here ends up stored in cleartext in your values and release — prefer `hub.existingSecret` and reference a `Secret` you manage instead. When set to an inline literal token, the chart creates and mounts the `traefik-hub-license` Secret for you. DEPRECATED: a value of 64 characters or fewer is still treated as the name of an existing `Secret` holding the token — migrate that usage to `hub.existingSecret`. |
 | hub.tokenMountPath | string | `"/etc/secrets"` | Mount path for token secret. |
 | hub.tracing.additionalTraceHeaders.enabled | bool | See below | Tracing headers to duplicate. To configure the following, tracing.otlp.enabled needs to be set to true. |
 | hub.tracing.additionalTraceHeaders.traceContext.parentId | string | `""` | Name of the header that will contain the parent-id header copy. |

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -15,8 +15,18 @@
 {{- end -}}
 
 
+{{/* Deprecation: <=64-char hub.token used as an existing-Secret name. */}}
+{{- if eq (include "traefik-hub.usesLegacyTokenSecretName" .) "true" -}}
+{{- printf "\n" -}}
+⚠️ DEPRECATION: `hub.token` is set to a value of 64 characters or fewer, so it is treated as
+the name of an existing Secret holding the license token. This implicit behavior is deprecated —
+set `hub.existingSecret` to that Secret name instead. Referencing a Secret you manage is the
+recommended way to provide the license, rather than an inline token in cleartext. ⚠️
+{{- printf "\n" -}}
+{{- end -}}
+
 {{/* Warn about non-standard Traefik Hub versions (pre-release or minor/patch above supported range) */}}
-{{- if .Values.hub.token -}}
+{{- if (include "traefik-hub.enabled" .) -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}
 {{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
 {{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (eq (include "traefik.isAboveMaxVersion" (dict "version" $hubVersion "max" $hubMaxVersion)) "true") -}}
@@ -85,7 +95,7 @@ for more info. 🚨
 
 
 {{/* Warn about hub not watching namespaces configured in providers */}}
-{{- if and .Values.hub.token (and .Values.rbac.enabled .Values.rbac.namespaced) }}
+{{- if and (include "traefik-hub.enabled" .) (and .Values.rbac.enabled .Values.rbac.namespaced) }}
     {{- if .Values.hub.namespaces -}}
         {{- range (list "kubernetesCRD" "kubernetesGateway" "kubernetesIngress") }}
             {{- $provider := . -}}
@@ -141,7 +151,7 @@ You will need to install them yourself before deploying Traefik v3.7:
 
 
 {{/* Warn about missing secret when enabling managed certificate with Hub admission controller */}}
-{{- if and .Values.hub.token .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.selfManagedCertificate }}
+{{- if and (include "traefik-hub.enabled" .) .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.selfManagedCertificate }}
   {{- $cert := lookup "v1" "Secret" (include "traefik.namespace" .) $.Values.hub.apimanagement.admission.secretName -}}
   {{- if not $cert }}
     {{- printf "\nWARNING: webhook secret %s for Traefik hub is self managed and was not found in %s namespace.\n" $.Values.hub.apimanagement.admission.secretName (include "traefik.namespace" .) -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -16,18 +16,45 @@ Create chart name and version as used by the chart label.
 
 {{/*
 Image defaults. An explicit image value always wins; otherwise the chart picks the
-Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwise.
+Traefik Hub default when hub.token or hub.existingSecret are set, and the Traefik Proxy default otherwise.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
+{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (eq (include "traefik-hub.enabled" .) "true")) -}}
 {{- end -}}
 
 {{- define "traefik.imageRepository" -}}
-{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token))) -}}
+{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (eq (include "traefik-hub.enabled" .) "true")) -}}
 {{- end -}}
 
 {{- define "traefik.defaultTag" -}}
-{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty .Values.hub.token)) -}}
+{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (eq (include "traefik-hub.enabled" .) "true") -}}
+{{- end -}}
+
+{{/* Hub is enabled by an inline `hub.token` or a BYO `hub.existingSecret`. */}}
+{{- define "traefik-hub.enabled" -}}
+{{- if or .Values.hub.token .Values.hub.existingSecret -}}true{{- end -}}
+{{- end -}}
+
+{{/* Secret name for the license token: existingSecret (BYO), else the chart-managed
+traefik-hub-license for an inline token (>=65), else (DEPRECATED) hub.token as a Secret name (<=64). */}}
+{{- define "traefik-hub.tokenSecretName" -}}
+{{- if .Values.hub.existingSecret -}}
+{{- .Values.hub.existingSecret -}}
+{{- else if ge (len (.Values.hub.token | default "")) 65 -}}
+traefik-hub-license
+{{- else -}}
+{{- .Values.hub.token -}}
+{{- end -}}
+{{- end -}}
+
+{{/* True when the chart must create the license Secret from an inline literal token. */}}
+{{- define "traefik-hub.createLicenseSecret" -}}
+{{- if and (not .Values.hub.existingSecret) (ge (len (.Values.hub.token | default "")) 65) -}}true{{- end -}}
+{{- end -}}
+
+{{/* True when the DEPRECATED <= 64-char `hub.token`-as-Secret-name path is in use. */}}
+{{- define "traefik-hub.usesLegacyTokenSecretName" -}}
+{{- if and (not .Values.hub.existingSecret) .Values.hub.token (le (len .Values.hub.token) 64) -}}true{{- end -}}
 {{- end -}}
 
 {{/*
@@ -35,13 +62,13 @@ Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
 {{- if .Values.oci_meta.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if (include "traefik-hub.enabled" .) -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.hub.image .Values.oci_meta.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.proxy.image .Values.oci_meta.images.proxy.tag }}
  {{- end -}}
 {{- else if .Values.global.azure.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if (include "traefik-hub.enabled" .) -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.hub.registry .Values.global.azure.images.hub.image .Values.global.azure.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.proxy.registry .Values.global.azure.images.proxy.image .Values.global.azure.images.proxy.tag }}
@@ -273,8 +300,8 @@ The version can comes many sources: appVersion, image.tag, override, marketplace
 */}}
 {{- define "traefik.proxyVersion" -}}
  {{- if $.Values.versionOverride }}
-  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" $.Values.hub.token) }}
- {{- else if $.Values.hub.token -}}
+  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" (include "traefik-hub.enabled" $)) }}
+ {{- else if (include "traefik-hub.enabled" $) -}}
   {{- $version := ($.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag) -}}
   {{- $version = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $version) -}}
   {{- include "traefik.proxyVersionFromHub" (dict "Version" $version "Hub" true) }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -20,7 +20,7 @@
       {{- if .Values.global.azure.enabled }}
         azure-extensions-usage-release-identifier: {{ .Release.Name }}
       {{- end }}
-      {{- if and .Values.hub.token .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.restartOnCertificateChange }}
+      {{- if and (include "traefik-hub.enabled" .) .Values.hub.apimanagement.enabled .Values.hub.apimanagement.admission.restartOnCertificateChange }}
         {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
         hub-cert-hash: {{ $cert.Hash }}
       {{- end }}
@@ -137,7 +137,7 @@
           {{- end }}
          {{- end }}
         {{- end }}
-        {{- if .Values.hub.token }}
+        {{- if (include "traefik-hub.enabled" .) }}
           {{- if not .Values.hub.offline }}
           {{- $listenAddr := default ":9943" .Values.hub.apimanagement.admission.listenAddr }}
         - name: admission
@@ -162,7 +162,7 @@
             {{- end }}
           - name: tmp
             mountPath: /tmp
-          {{- if .Values.hub.token }}
+          {{- if (include "traefik-hub.enabled" .) }}
           - name: hub-token
             mountPath: {{ .Values.hub.tokenMountPath }}
             readOnly: true
@@ -826,7 +826,7 @@
           {{- end }}
           {{- end }}
           {{- with .Values.hub }}
-           {{- if .token }}
+           {{- if (include "traefik-hub.enabled" $) }}
           - "--hub.tokenFilePath={{ include "traefik.hubTokenFilePath" $ }}"
             {{- if and (not .apimanagement.enabled) ($.Values.hub.apimanagement.admission.listenAddr) }}
                {{- fail "ERROR: Cannot configure admission without enabling hub.apimanagement" }}
@@ -1000,10 +1000,10 @@
           {{- end }}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.hub.token }}
+        {{- if (include "traefik-hub.enabled" .) }}
         - name: hub-token
           secret:
-            secretName: {{ le (len .Values.hub.token) 64 | ternary .Values.hub.token "traefik-hub-license" }}
+            secretName: {{ include "traefik-hub.tokenSecretName" . }}
         {{- end }}
         {{- range .Values.volumes }}
         - name: {{ tpl (.name) $ | replace "." "-" }}

--- a/traefik/templates/hub-admission-controller.yaml
+++ b/traefik/templates/hub-admission-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hub.token -}}
+{{- if (include "traefik-hub.enabled" .) -}}
 {{- if and .Values.hub.apimanagement.enabled (not .Values.hub.offline) }}
 {{- $cert := include "traefik-hub.webhook_cert" . | fromYaml }}
 {{- if or (not .Values.hub.apimanagement.admission.selfManagedCertificate) .Values.hub.apimanagement.admission.customWebhookCertificate}}

--- a/traefik/templates/hub-license.yaml
+++ b/traefik/templates/hub-license.yaml
@@ -1,4 +1,4 @@
-{{- if ge (len (.Values.hub.token | default "")) 65 }}
+{{- if eq (include "traefik-hub.createLicenseSecret" .) "true" }}
 ---
 apiVersion: v1
 kind: Secret

--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -42,7 +42,7 @@ rules:
       - get
       - list
       - watch
-    {{- if and .Values.hub.token }}
+    {{- if (include "traefik-hub.enabled" .) }}
       - update
       - create
       - delete
@@ -156,7 +156,7 @@ rules:
     verbs:
       - update
   {{- end }}
-  {{- if .Values.hub.token }}
+  {{- if (include "traefik-hub.enabled" .) }}
   - apiGroups:
       - coordination.k8s.io
     resources:

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -100,7 +100,7 @@ rules:
     verbs:
       - update
 {{- end }}
-{{- if (and (has . $hubNamespaces) $.Values.hub.token) }}
+{{- if (and (has . $hubNamespaces) (include "traefik-hub.enabled" $)) }}
   - apiGroups:
       - ""
     resources:

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -11,7 +11,7 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hub.token (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
+{{- if and (include "traefik-hub.enabled" .) (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
   {{- fail "ERROR: traefik-hub image is required when enabling Traefik Hub" -}}
 {{- end }}
 
@@ -36,7 +36,7 @@
   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
 {{- end }}
 
-{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
+{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not (include "traefik-hub.enabled" $)) }}
   {{- fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub." }}
 {{- end }}
 
@@ -113,7 +113,7 @@
   {{- if and $config (($config.forwardedHeaders).notAppendXForwardedFor) (semverCompare "<v3.7.0-0" $version) }}
   {{- fail "ERROR: forwardedHeaders.notAppendXForwardedFor is only available for traefik >= v3.7.0." }}
   {{- end }}
-  {{- if and $config.uplink (empty $.Values.hub.token) }}
+  {{- if and $config.uplink (not (include "traefik-hub.enabled" $)) }}
     {{ fail "ERROR: uplink EntryPoints can only be used with Traefik Hub" }}
   {{- end }}
 {{- end }}
@@ -130,7 +130,7 @@
   {{- fail "ERROR: request path security options are only available for traefik >= v3.6.4." }}
 {{- end }}
 
-{{- if $.Values.hub.token -}}
+{{- if (include "traefik-hub.enabled" $) -}}
   {{- $hubVersion := include "traefik.hubVersion" $ }}
   {{- if not $hubVersion }}
     {{- if $.Values.image.digest }}

--- a/traefik/tests/hub-license-config_test.yaml
+++ b/traefik/tests/hub-license-config_test.yaml
@@ -119,3 +119,47 @@ tests:
       - hasDocuments:
           count: 1
         template: deployment.yaml
+
+  - it: existingSecret enables Hub and mounts the BYO secret without creating one
+    set:
+      hub:
+        existingSecret: my-hub-license
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub-license.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: hub-token
+            secret:
+              secretName: my-hub-license
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: hub-token
+            mountPath: /etc/secrets
+            readOnly: true
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tokenFilePath=/etc/secrets/token"
+        template: deployment.yaml
+
+  - it: existingSecret takes precedence over an inline hub.token
+    set:
+      hub:
+        existingSecret: my-hub-license
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub-license.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: hub-token
+            secret:
+              secretName: my-hub-license
+        template: deployment.yaml

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -12,6 +12,27 @@ tests:
       - equalRaw:
           value: |2
             RELEASE-NAME with docker.io/traefik:3.6.10 has been deployed successfully on NAMESPACE namespace!
+  - it: should warn that a short hub.token (<=64) is the deprecated secret-name path
+    set:
+      hub:
+        token: "my-hub-license"
+    asserts:
+      - matchRegexRaw:
+          pattern: 'DEPRECATION: `hub.token` is set to a value of 64 characters or fewer'
+  - it: should not warn about the deprecated path when using hub.existingSecret
+    set:
+      hub:
+        existingSecret: my-hub-license
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "DEPRECATION: .hub.token"
+  - it: should not warn about the deprecated path for an inline literal token
+    set:
+      hub:
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "DEPRECATION: .hub.token"
   - it: should use helm managed namespace in release notes output
     set:
       namespaceOverride: "traefik-ns-override"
@@ -81,7 +102,7 @@ tests:
         repository: traefik/traefik-hub
         tag: v3.99.0
       hub:
-        token: "xxx"
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     asserts:
       - equalRaw:
           value: |
@@ -97,7 +118,7 @@ tests:
         repository: traefik/traefik-hub
         tag: v3.21.0-ea.1
       hub:
-        token: "xxx"
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     asserts:
       - equalRaw:
           value: |
@@ -113,7 +134,7 @@ tests:
         repository: traefik/traefik-hub
         tag: v3.19.5
       hub:
-        token: "xxx"
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     asserts:
       - equalRaw:
           value: |
@@ -193,7 +214,7 @@ tests:
         namespaced: true
 
       hub:
-        token: "token"
+        token: "tokentokentokentokentokentokentokentokentokentokentokentokentoken"
         namespaces: [ns1]
         apimanagement:
           enabled: true
@@ -217,7 +238,7 @@ tests:
         namespaced: true
 
       hub:
-        token: "token"
+        token: "tokentokentokentokentokentokentokentokentokentokentokentokentoken"
         namespaces: [ns1]
         apimanagement:
           enabled: true
@@ -248,7 +269,7 @@ tests:
         namespaced: true
 
       hub:
-        token: "token"
+        token: "tokentokentokentokentokentokentokentokentokentokentokentokentoken"
         namespaces: []
         apimanagement:
           enabled: true
@@ -275,7 +296,7 @@ tests:
         namespaced: true
 
       hub:
-        token: "token"
+        token: "tokentokentokentokentokentokentokentokentokentokentokentokentoken"
         namespaces: []
         apimanagement:
           enabled: true

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -763,6 +763,10 @@
                         }
                     }
                 },
+                "existingSecret": {
+                    "description": "Name of an existing `Secret` with a 'token' key holding the license token (enables Hub). This is the **recommended** way to provide the license: keep the token in a `Secret` you manage, not in cleartext in your values. Takes precedence over `hub.token`.",
+                    "type": "string"
+                },
                 "mcpgateway": {
                     "type": "object",
                     "properties": {
@@ -1306,7 +1310,7 @@
                     ]
                 },
                 "token": {
-                    "description": "Name of `Secret` with key 'token' set to a valid license token. It enables API Gateway.",
+                    "description": "Traefik Hub license token (enables Hub). NOT RECOMMENDED: an inline literal token here ends up stored in cleartext in your values and release — prefer `hub.existingSecret` and reference a `Secret` you manage instead. When set to an inline literal token, the chart creates and mounts the `traefik-hub-license` Secret for you. DEPRECATED: a value of 64 characters or fewer is still treated as the name of an existing `Secret` holding the token — migrate that usage to `hub.existingSecret`.",
                     "type": "string"
                 },
                 "tokenMountPath": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1274,8 +1274,17 @@ fullnameOverride: ""
 
 # Traefik Hub configuration. See https://doc.traefik.io/traefik-hub/
 hub:  # @schema additionalProperties: false
-  # -- Name of `Secret` with key 'token' set to a valid license token.
-  # It enables API Gateway.
+  # -- Name of an existing `Secret` with a 'token' key holding the license token (enables Hub).
+  # This is the **recommended** way to provide the license: keep the token in a `Secret` you
+  # manage, not in cleartext in your values. Takes precedence over `hub.token`.
+  existingSecret: ""
+  # -- Traefik Hub license token (enables Hub).
+  # NOT RECOMMENDED: an inline literal token here ends up stored in cleartext in your values
+  # and release — prefer `hub.existingSecret` and reference a `Secret` you manage instead.
+  # When set to an inline literal token, the chart creates and mounts the `traefik-hub-license`
+  # Secret for you.
+  # DEPRECATED: a value of 64 characters or fewer is still treated as the name of an
+  # existing `Secret` holding the token — migrate that usage to `hub.existingSecret`.
   token: ""
   # -- Mount path for token secret.
   tokenMountPath: "/etc/secrets"


### PR DESCRIPTION
### What does this PR do?

Adds `hub.existingSecret` — an explicit way to reference an existing `Secret` (with a `token` key) that holds the Traefik Hub license — and makes `hub.token` unambiguously the *inline literal token*.

Today `hub.token` is overloaded by **length**: a value of 65+ chars is treated as a literal token (the chart creates the `traefik-hub-license` Secret), while a shorter value is silently treated as the *name* of an existing Secret — and the doc comment even says "Name of `Secret`", which is misleading.

- **`hub.existingSecret`** (new): name of an existing Secret to use (BYO). Takes precedence over `hub.token`; also enables Hub.
- **`hub.token`**: the inline literal token (chart creates `traefik-hub-license`).
- **Backward compatible**: a ≤ 64-char `hub.token` with no `existingSecret` still works as an existing-Secret name, now with a deprecation notice in `NOTES.txt` pointing to `hub.existingSecret`. Nothing breaks.

### Motivation

Removes a quiet footgun (length-based magic with a misleading comment) and aligns the BYO-license path with the upcoming experimental chart, where `hub.token` is always the literal token and BYO is explicit — so users can adopt the explicit form now and migrate cleanly later.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
