### PR TITLE
docs(hub): deprecate inline literal token in values

### DIFF
--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -15,6 +15,17 @@
 {{- end -}}
 
 
+{{/* Deprecation: inline literal hub.token in values (chart creates the license Secret). */}}
+{{- if ge (len (.Values.hub.token | default "")) 65 -}}
+{{- printf "\n" -}}
+⚠️ DEPRECATION: providing the Traefik Hub license token inline in values is deprecated and will
+be removed in a future release. A token in `values.yaml` is a sensitive value that leaks into
+release state, version control and CI logs. Instead, create a `Secret` yourself (with a 'token'
+key) and set `hub.token` to that Secret's name. ⚠️
+{{- printf "\n" -}}
+{{- end -}}
+
+
 {{/* Warn about non-standard Traefik Hub versions (pre-release or minor/patch above supported range) */}}
 {{- if .Values.hub.token -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -27,6 +27,20 @@ tests:
       - equalRaw:
           value: |2
             RELEASE-NAME with docker.io/traefik:v3.7.0 has been deployed successfully on NAMESPACE namespace!
+  - it: should warn that an inline literal hub.token in values is deprecated
+    set:
+      hub:
+        token: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    asserts:
+      - matchRegexRaw:
+          pattern: 'DEPRECATION: providing the Traefik Hub license token inline in values'
+  - it: should not warn about inline token when hub.token references an existing Secret name
+    set:
+      hub:
+        token: "my-hub-license"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "DEPRECATION: providing the Traefik Hub license token inline"
   - it: should display warning when using an experimental image tag
     set:
       image:


### PR DESCRIPTION
### Context

`hub.token` accepts two things by length: a value ≥65 chars is treated as the
inline literal license token (the chart creates the `traefik-hub-license`
Secret from it), while a shorter value is the name of an existing Secret.

The inline-literal path puts a sensitive token in `values.yaml` — it leaks into
release state, version control and CI logs. This was never the documented intent.

### Motivation

Deprecate the inline-literal path via a NOTES.txt warning and announce its
removal in a future release, steering users to bring their own Secret and set
`hub.token` to its name.

This is a counter-proposal to #1900, which goes the other way (promotes the
inline literal as primary, deprecates the existing-Secret-name path).
