### PR TITLE
feat(hub): support traefik hub v3.20.5

### DIFF
--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
   traefik.io/proxy-min-version: v3.6.0
   traefik.io/proxy-max-version: v3.7.5
   traefik.io/hub-min-version: v3.19.3
-  traefik.io/hub-max-version: v3.20.4
+  traefik.io/hub-max-version: v3.20.5
   artifacthub.io/changes: |
     - "fix(provider): :bug: emit kubernetesIngressNGINX publishService for external service"
     - "fix(notes): :memo: use traefik.image-name so NOTES match deployed image"

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -207,7 +207,7 @@ It requires a dict with "Version" and "Hub".
 {{- define "traefik.proxyVersionFromHub" -}}
  {{- $version := .Version -}}
  {{- if .Hub -}}
-   {{- $hubProxyVersion := "v3.7.1" }}
+   {{- $hubProxyVersion := "v3.7.5" }}
    {{- if regexMatch "v[0-9]+.[0-9]+.[0-9]+" (default "" $version) }}
      {{- if semverCompare "<v3.19.0-0" $version }}
         {{- $hubProxyVersion = "v3.6.3" }}
@@ -217,6 +217,8 @@ It requires a dict with "Version" and "Hub".
         {{- $hubProxyVersion = "v3.7.0-rc.1" }}
      {{- else if semverCompare "<v3.20.2-0" $version }}
         {{- $hubProxyVersion = "v3.7.0" }}
+     {{- else if semverCompare "<v3.20.5-0" $version }}
+        {{- $hubProxyVersion = "v3.7.1" }}
      {{- end -}}
    {{- end -}}
    {{- $hubProxyVersion }}

--- a/traefik/tests/container-config_test.yaml
+++ b/traefik/tests/container-config_test.yaml
@@ -84,9 +84,9 @@ tests:
       hub:
         token: xxx
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/traefik/traefik-hub:v3.20.4
+          pattern: ^ghcr.io/traefik/traefik-hub:v\d+.\d+.\d+
   - it: should respect user-provided registry, repository and tag when Hub is enabled
     set:
       hub:
@@ -106,9 +106,9 @@ tests:
       image:
         registry: docker.io
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: docker.io/traefik/traefik-hub:v3.20.4
+          pattern: ^docker.io/traefik/traefik-hub:v\d+.\d+.\d+
   - it: should respect user-provided registry, repository and tag for a Proxy install
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -135,7 +135,7 @@ tests:
         token: xxx
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: This Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.4."
+          errorMessage: "ERROR: This Chart does not support Traefik Hub v99.0.0, which is a major version above the supported v3.20.5."
   - it: should not fail when trying to use this Chart with an ea Hub version above max
     set:
       image:


### PR DESCRIPTION
### What does this PR do?

Add support for Traefik Hub v3.20.5 (bumps `traefik.io/hub-max-version`).

### Motivation

Traefik Hub v3.20.5 has been released.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
