### PR TITLE
chore(release): publish 41.0.1

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 41.0.1  ![AppVersion: v3.7.5](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.5&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2026-06-29
+
+* fix(ingressroute): fail fast on uppercase ingressRoute keys (RFC 1123)
+* feat(hub): support traefik hub v3.20.5
+* docs(hub): deprecate inline literal token in values
+* chore(release): publish 41.0.1
+
+
+
 ## 41.0.0  ![AppVersion: v3.7.5](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.5&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2026-06-15

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 41.0.0
+version: 41.0.1
 # renovate: image=traefik
 appVersion: v3.7.5
 kubeVersion: '>=1.25.0-0'
@@ -27,13 +27,7 @@ annotations:
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.5
   artifacthub.io/changes: |
-    - "fix(provider): :bug: emit kubernetesIngressNGINX publishService for external service"
-    - "fix(notes): :memo: use traefik.image-name so NOTES match deployed image"
-    - "fix(logs)!: align syntax with upstream (#1887)"
-    - "fix(deployment): omit spec.replicas when replicas is null"
-    - "feat(version): :sparkles: relax max-version guard to warn on minor/patch, fail only on major mismatch"
-    - "feat(providers.file)!: switch content to an object"
-    - "feat(hub): :sparkles: install out-of-box with only hub.token set"
-    - "feat(deps): update traefik docker tag to v3.7.5"
-    - "ci(renovate): restore update on appVersion"
-    - "chore(release): publish 41.0.0"
+    - "fix(ingressroute): fail fast on uppercase ingressRoute keys (RFC 1123)"
+    - "feat(hub): support traefik hub v3.20.5"
+    - "docs(hub): deprecate inline literal token in values"
+    - "chore(release): publish 41.0.1"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 41.0.0](https://img.shields.io/badge/Version-41.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.5](https://img.shields.io/badge/AppVersion-v3.7.5-informational?style=flat-square)
+![Version: 41.0.1](https://img.shields.io/badge/Version-41.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.5](https://img.shields.io/badge/AppVersion-v3.7.5-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Release a new version of the Chart.

### Motivation

Introduce official support of Traefik Hub v3.20.5

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed
