### PR TITLE
chore(release): 🚀 publish 41.0.2

### DIFF
--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -4,6 +4,7 @@
 
 **Release date:** 2026-07-06
 
+* fix(crds): add missing hub.traefik.io_uplinks to kustomization
 * feat(deps): update traefik docker tag to v3.7.6
 * feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.6
 * chore(release): 🚀 publish 41.0.2

--- a/traefik/Changelog.md
+++ b/traefik/Changelog.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## 41.0.2  ![AppVersion: v3.7.6](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.6&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2026-07-06
+
+* feat(deps): update traefik docker tag to v3.7.6
+* feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.6
+* chore(release): 🚀 publish 41.0.2
+
+### Default value changes
+
+```diff
+diff --git a/traefik/values.yaml b/traefik/values.yaml
+index 50a1629..e3eb6af 100644
+--- a/traefik/values.yaml
++++ b/traefik/values.yaml
+@@ -1033,6 +1033,9 @@ ports:
+       middlewares: []  # @schema type: [array, null]
+       # -- See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#path-sanitization)
+       sanitizePath:  # @schema type:[boolean, null]
++      # -- Defines how request headers with underscores in their names are handled (v3.7.6+).
++      # See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)
++      underscoreHeadersStrategy:  # @schema enum:[keep, delete, reject, null]; type:[string, null]
+       tls:
+         # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-http-tls)
+         # @default -- true
+```
+
+
 ## 41.0.1  ![AppVersion: v3.7.5](https://img.shields.io/static/v1?label=AppVersion&message=v3.7.5&color=success&logo=) ![Kubernetes: >=1.25.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D1.25.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2026-06-29

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -27,6 +27,7 @@ annotations:
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.6
   artifacthub.io/changes: |
+    - "fix(crds): add missing hub.traefik.io_uplinks to kustomization"
     - "feat(deps): update traefik docker tag to v3.7.6"
     - "feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.6"
     - "chore(release): 🚀 publish 41.0.2"

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
-version: 41.0.1
+version: 41.0.2
 # renovate: image=traefik
 appVersion: v3.7.6
 kubeVersion: '>=1.25.0-0'
@@ -27,7 +27,6 @@ annotations:
   traefik.io/hub-min-version: v3.19.3
   traefik.io/hub-max-version: v3.20.6
   artifacthub.io/changes: |
-    - "fix(ingressroute): fail fast on uppercase ingressRoute keys (RFC 1123)"
-    - "feat(hub): support traefik hub v3.20.5"
-    - "docs(hub): deprecate inline literal token in values"
-    - "chore(release): publish 41.0.1"
+    - "feat(deps): update traefik docker tag to v3.7.6"
+    - "feat(deps): update ghcr.io/traefik/traefik-hub docker tag to v3.20.6"
+    - "chore(release): 🚀 publish 41.0.2"

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -1,6 +1,6 @@
 # traefik
 
-![Version: 41.0.1](https://img.shields.io/badge/Version-41.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.6](https://img.shields.io/badge/AppVersion-v3.7.6-informational?style=flat-square)
+![Version: 41.0.2](https://img.shields.io/badge/Version-41.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.7.6](https://img.shields.io/badge/AppVersion-v3.7.6-informational?style=flat-square)
 
 A Traefik based Kubernetes ingress controller
 


### PR DESCRIPTION
### What does this PR do?

Release 41.0.2

### Motivation

Add official support for Proxy v3.7.6 & Hub v3.20.6
