### PR TITLE
fix(crds): add missing hub.traefik.io_uplinks to kustomization

### DIFF
--- a/traefik/crds/kustomization.yaml
+++ b/traefik/crds/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - hub.traefik.io_contentitems.yaml
   - hub.traefik.io_managedapplications.yaml
   - hub.traefik.io_managedsubscriptions.yaml
+  - hub.traefik.io_uplinks.yaml
   - traefik.io_ingressroutes.yaml
   - traefik.io_ingressroutetcps.yaml
   - traefik.io_ingressrouteudps.yaml


### PR DESCRIPTION
# Motivation
`traefik/crds/hub.traefik.io_uplinks.yaml` ships in the chart and is referenced by the RBAC templates, but was missing from `crds/kustomization.yaml` — the only hub CRD not listed. This adds it so `kubectl kustomize traefik/crds/` renders the complete set (25 CRDs instead of 24).