### PR TITLE
feat(gateway-api): add support for ListenerSets

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -117,6 +117,7 @@ Kubernetes: `>=1.25.0-0`
 | experimental.plugins | object | `{}` | Enable experimental plugins |
 | extraObjects | list | `[]` | Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example. |
 | fullnameOverride | string | `""` | Overrides the resource name for templates (i.e deployment, service, etc..) |
+| gateway.allowedListeners | string | `nil` | Configure which namespaces can attach [ListenerSets](https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/) to this Gateway. See [AllowedListeners](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.AllowedListeners). |
 | gateway.annotations | object | `{}` | Additional gateway annotations (e.g. for cert-manager.io/issuer) |
 | gateway.defaultScope | string | `nil` | Configure this Gateway as a [Default Gateway](https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/#introducing-default-gateways) by setting the `defaultScope` field (e.g. `All` or `Namespace`). |
 | gateway.enabled | bool | `true` | When providers.kubernetesGateway.enabled, deploy a default gateway |

--- a/traefik/templates/gateway.yaml
+++ b/traefik/templates/gateway.yaml
@@ -23,6 +23,10 @@ spec:
   {{- with .Values.gateway.defaultScope }}
   defaultScope: {{ . }}
   {{- end }}
+  {{- with .Values.gateway.allowedListeners }}
+  allowedListeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   listeners:
     {{- range $name, $config := .Values.gateway.listeners }}
     - name: {{ $name }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -19,8 +19,13 @@
   {{- fail "ERROR: Knative is experimental. Enable it by setting experimental.knative to true" -}}
 {{- end }}
 
-{{- if and (.Values.providers.kubernetesGateway.enabled) (.Values.gateway.defaultScope) (not .Values.providers.kubernetesGateway.experimentalChannel) }}
-  {{- fail "ERROR: The Gateway 'defaultScope' field is experimental. Enable it by setting providers.kubernetesGateway.experimentalChannel=true" }}
+{{- if and (.Values.providers.kubernetesGateway.enabled) (not .Values.providers.kubernetesGateway.experimentalChannel) }}
+  {{- if .Values.gateway.defaultScope }}
+    {{- fail "ERROR: The Gateway 'defaultScope' field is experimental. Enable it by setting providers.kubernetesGateway.experimentalChannel=true" }}
+  {{- end }}
+  {{- if .Values.gateway.allowedListeners }}
+    {{- fail "ERROR: The Gateway 'allowedListeners' field is experimental. Enable it by setting providers.kubernetesGateway.experimentalChannel=true" }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.rbac.namespaced }}

--- a/traefik/tests/gateway-config_test.yaml
+++ b/traefik/tests/gateway-config_test.yaml
@@ -340,3 +340,54 @@ tests:
       - equal:
           path: spec.defaultScope
           value: "All"
+  - it: should configure "Same" allowedListeners on the Gateway
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+          experimentalChannel: true
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: Same
+    asserts:
+      - equal:
+          path: spec.allowedListeners.namespaces
+          value:
+            from: "Same"
+  - it: should configure "All" allowedListeners on the Gateway
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+          experimentalChannel: true
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: All
+    asserts:
+      - equal:
+          path: spec.allowedListeners.namespaces
+          value:
+            from: "All"
+  - it: should configure Selector for allowedListeners on the Gateway
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+          experimentalChannel: true
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: Selector
+            selector:
+              matchLabels:
+                shared-gateway-access: "true"
+    asserts:
+      - equal:
+          path: spec.allowedListeners.namespaces
+          value:
+            from: "Selector"
+            selector:
+              matchLabels:
+                shared-gateway-access: "true"

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -513,6 +513,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: providers.kubernetesGateway.qps and .burst are only available for traefik >= v3.7.3."
+  - it: should fail when allowedListeners is set without experimentalChannel
+    set:
+      providers:
+        kubernetesGateway:
+          enabled: true
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: Same
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: The Gateway 'allowedListeners' field is experimental. Enable it by setting providers.kubernetesGateway.experimentalChannel=true"
   - it: should fail when using notAppendXForwardedFor on traefik < 3.7.0
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -551,6 +551,13 @@
         "gateway": {
             "type": "object",
             "properties": {
+                "allowedListeners": {
+                    "description": "Configure which namespaces can attach [ListenerSets](https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/) to this Gateway. See [AllowedListeners](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.AllowedListeners).",
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
                 "annotations": {
                     "description": "Additional gateway annotations (e.g. for cert-manager.io/issuer)",
                     "type": "object"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -167,6 +167,9 @@ gateway:
   # -- Configure this Gateway as a [Default Gateway](https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/#introducing-default-gateways)
   # by setting the `defaultScope` field (e.g. `All` or `Namespace`).
   defaultScope: null  # @schema enum:["All", "None", null]; type:[string, null]; default: null
+  # -- Configure which namespaces can attach [ListenerSets](https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/) to this Gateway.
+  # See [AllowedListeners](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.AllowedListeners).
+  allowedListeners: null  # @schema type:[object, null]
   listeners:
     web:
       # -- Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.


### PR DESCRIPTION
### What does this PR do?

Add support for Gateway API for ListenerSet. Fixes #1915 

### Motivation

Traefik does now support Gateway API 1.5.0 which includes ListenerSet CRDs.

### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I updated the schema accordingly
- [X] Yes, I ran `make test` and all the tests passed


