### PR TITLE
fix: support enabling only kubernetesIngressNGINX with rbac.namespaced

### DIFF
--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -27,8 +27,8 @@
   {{- if .Values.providers.kubernetesGateway.enabled }}
     {{- fail "ERROR: Kubernetes Gateway provider requires ClusterRole. RBAC cannot be namespaced." }}
   {{- end }}
-  {{- if and (not .Values.providers.kubernetesIngress.enabled) (not .Values.providers.kubernetesCRD.enabled) }}
-    {{- fail "ERROR: namespaced rbac requires Kubernetes CRD or Kubernetes Ingress provider." }}
+  {{- if and (not .Values.providers.kubernetesIngress.enabled) (not .Values.providers.kubernetesCRD.enabled) (not .Values.providers.kubernetesIngressNGINX.enabled) }}
+    {{- fail "ERROR: namespaced rbac requires Kubernetes CRD, Kubernetes Ingress NGINX, or Kubernetes Ingress provider." }}
   {{- end }}
 {{- end }}
 

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -95,6 +95,31 @@ tests:
           count: 0
         template: rbac/clusterrolebinding.yaml
 
+  - it: rbac.namespaced should not fail when only KubernetesIngressNGINX provider is enabled
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+        kubernetesIngress:
+          enabled: false
+        kubernetesCRD:
+          enabled: false
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac/role.yaml
+      - isKind:
+          of: RoleBinding
+        template: rbac/rolebinding.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrole.yaml
+      - hasDocuments:
+          count: 0
+        template: rbac/clusterrolebinding.yaml
+
   - it: should use existing ServiceAccount
     set:
       serviceAccount:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1039,6 +1039,8 @@ tests:
           enabled: false
         kubernetesIngressNGINX:
           enabled: true
+        kubernetesCRD:
+          enabled: false
       rbac:
         namespaced: true
     asserts:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -95,31 +95,6 @@ tests:
           count: 0
         template: rbac/clusterrolebinding.yaml
 
-  - it: rbac.namespaced should not fail when only KubernetesIngressNGINX provider is enabled
-    set:
-      rbac:
-        namespaced: true
-      providers:
-        kubernetesIngressNGINX:
-          enabled: true
-        kubernetesIngress:
-          enabled: false
-        kubernetesCRD:
-          enabled: false
-    asserts:
-      - isKind:
-          of: Role
-        template: rbac/role.yaml
-      - isKind:
-          of: RoleBinding
-        template: rbac/rolebinding.yaml
-      - hasDocuments:
-          count: 0
-        template: rbac/clusterrole.yaml
-      - hasDocuments:
-          count: 0
-        template: rbac/clusterrolebinding.yaml
-
   - it: should use existing ServiceAccount
     set:
       serviceAccount:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -323,9 +323,9 @@ tests:
       providers:
         kubernetesCRD:
           enabled: false
-        kubernetesIngress:
-          enabled: false
         kubernetesIngressNGINX:
+          enabled: false
+        kubernetesIngress:
           enabled: false
     asserts:
       - failedTemplate:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -325,9 +325,11 @@ tests:
           enabled: false
         kubernetesIngress:
           enabled: false
+        kubernetesIngressNGINX:
+          enabled: false
     asserts:
       - failedTemplate:
-        errorMessage: "ERROR: namespaced rbac requires Kubernetes CRD or Kubernetes Ingress provider"
+        errorMessage: "ERROR: namespaced rbac requires Kubernetes CRD, Kubernetes Ingress NGINX, or Kubernetes Ingress provider."
   - it: should fail when enabling Kubernete Gateway provider with namespaced RBACs
     set:
       providers:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -330,6 +330,19 @@ tests:
     asserts:
       - failedTemplate:
         errorMessage: "ERROR: namespaced rbac requires Kubernetes CRD, Kubernetes Ingress NGINX, or Kubernetes Ingress provider."
+  - it: should be possible to namespace rbac with only kubernetesIngressNGINX provider
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesCRD:
+          enabled: false
+        kubernetesIngress:
+          enabled: false
+        kubernetesIngressNGINX:
+          enabled: true
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when enabling Kubernete Gateway provider with namespaced RBACs
     set:
       providers:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
Fixes #1928 

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

