### PR TITLE
fix(ports): support IPv6 hostIP values

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -86,7 +86,7 @@
         readinessProbe:
           httpGet:
             {{- with $healthchecksHost }}
-            host: {{ . }}
+            host: {{ . | quote }}
             {{- end }}
             path: {{ $readinessPath }}
             port: {{ $healthchecksPort }}
@@ -95,7 +95,7 @@
         livenessProbe:
           httpGet:
             {{- with $healthchecksHost }}
-            host: {{ . }}
+            host: {{ . | quote }}
             {{- end }}
             path: {{ $livenessPath }}
             port: {{ $healthchecksPort }}
@@ -124,7 +124,7 @@
           hostPort: {{ $config.hostPort }}
           {{- end }}
           {{- if $config.hostIP }}
-          hostIP: {{ $config.hostIP }}
+          hostIP: {{ $config.hostIP | quote }}
           {{- end }}
           protocol: {{ default "TCP" $config.protocol }}
           {{- if ($config.http3).enabled }}
@@ -216,7 +216,11 @@
           {{- range $name, $config := .Values.ports }}
            {{- if $config }}
             {{- $entryPoints := (empty $config.uplink) | ternary "entryPoints" "hub.uplinkEntryPoints" }}
-          - "--{{$entryPoints}}.{{$name}}.address={{ $config.hostIP }}:{{ $config.port }}/{{ default "tcp" $config.protocol | lower }}"
+            {{- $hostIP := default "" $config.hostIP }}
+            {{- if contains ":" $hostIP }}
+              {{- $hostIP = printf "[%s]" $hostIP }}
+            {{- end }}
+          - "--{{$entryPoints}}.{{$name}}.address={{ $hostIP }}:{{ $config.port }}/{{ default "tcp" $config.protocol | lower }}"
             {{- with $config.asDefault }}
           - "--{{$entryPoints}}.{{$name}}.asDefault={{ . }}"
             {{- end }}

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -187,7 +187,7 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--entryPoints.traefik.address=:8080/tcp"
 
-  - it: should quote IPv6 hostIP and bracket the entrypoint address
+  - it: should render IPv6 hostIP in ports and bracket the entrypoint address
     template: deployment.yaml
     set:
       ports:
@@ -205,7 +205,7 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--entryPoints.web.address=[::]:8000/tcp"
 
-  - it: should quote IPv6 hostIP when used as the probes host
+  - it: should render IPv6 hostIP as the probes host
     template: deployment.yaml
     set:
       ports:

--- a/traefik/tests/ports-config_test.yaml
+++ b/traefik/tests/ports-config_test.yaml
@@ -187,6 +187,41 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--entryPoints.traefik.address=:8080/tcp"
 
+  - it: should quote IPv6 hostIP and bracket the entrypoint address
+    template: deployment.yaml
+    set:
+      ports:
+        web:
+          hostIP: "::"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: web
+            containerPort: 8000
+            hostIP: "::"
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.web.address=[::]:8000/tcp"
+
+  - it: should quote IPv6 hostIP when used as the probes host
+    template: deployment.yaml
+    set:
+      ports:
+        traefik:
+          hostIP: "::"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--entryPoints.traefik.address=[::]:8080/tcp"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.host
+          value: "::"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.host
+          value: "::"
+
   - it: should set probes host when hostIP is configured
     template: deployment.yaml
     set:


### PR DESCRIPTION
### What does this PR do?

- Quotes `hostIP` in container ports and HTTP probe hosts so IPv6 values render as valid YAML.
- Brackets IPv6 `hostIP` values in Traefik entrypoint addresses while preserving IPv4, hostname, and empty-host rendering.
- Adds Deployment regression coverage for both regular ports and the `ports.traefik.hostIP` probe path.

This supersedes #1859 and incorporates its unresolved review feedback by covering IPv6 probe hosts and keeping Deployment assertions in the Deployment test suite.

### Motivation

Fixes #1788.

Without this change, `hostIP: ::` produces invalid YAML in container port and probe host fields, plus an unbracketed Traefik entrypoint address.

### More

- [x] Yes, I updated the tests accordingly
- [x] Schema update is not required; no values or types changed
- [x] The full Helm unit suite passes (698 tests), and `helm lint traefik` passes