### PR TITLE
feat(hub): :sparkles: add hub.enabled to run Traefik Hub in proxy mode

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -864,6 +864,31 @@ experimental:
 > - **Scalable**: Centralized plugin storage, no per-node requirements
 > - **Consistent**: Uses existing Helm chart patterns (`additionalVolumes`)
 
+## Install Traefik Hub without a license (proxy mode)
+
+Traefik Hub can run without a license token. In this _proxy mode_, it behaves as a Traefik Proxy:
+no commercial feature is enabled, and no external connection is made. It requires Traefik Hub
+>= `v3.21.0-ea`, which is above the version this chart defaults to, so `image.tag` must be set:
+
+```yaml
+hub:
+  enabled: true
+image:
+  tag: v3.21.0-ea.1
+```
+
+This installs `ghcr.io/traefik/traefik-hub` instead of `docker.io/traefik`. To enable API Gateway
+later, set `hub.token` to the name of a `Secret` holding your license, on the same release and
+without changing the image:
+
+```yaml
+hub:
+  enabled: true
+  token: traefik-hub-license
+```
+
+Setting `hub.token` alone is enough: `hub.enabled` defaults to `true` when a token is set.
+
 ## Using Traefik-Hub with private plugin registries
 
 With Traefik Hub, it's possible to use plugins deployed on both public or private registries.

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -145,7 +145,8 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
-| hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub >= v3.21.0-ea. |
+| hub.enabled | bool | `true` when `hub.token` is set | Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub >= v3.21.0-ea. |
+| hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea. |
 | hub.mcpgateway.enabled | bool | `false` | Set to true in order to enable AI MCP Gateway. Requires a valid license token. |
 | hub.mcpgateway.maxRequestBodySize | string | `nil` | Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB). |
 | hub.namespaces | list | `[]` | By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
@@ -249,8 +250,8 @@ Kubernetes: `>=1.25.0-0`
 | hub.tracing.additionalTraceHeaders.traceContext.traceState | string | `""` | Name of the header that will contain the tracestate copy. |
 | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
 | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
-| image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set). |
-| image.repository | string | `nil` | Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set). |
+| image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.enabled` is true). |
+| image.repository | string | `nil` | Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.enabled` is true). |
 | image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
 | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
 | ingressClass.isDefaultClass | bool | `true` |  |

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -26,8 +26,18 @@ key) and set `hub.token` to that Secret's name. ⚠️
 {{- end -}}
 
 
+{{/* Inform about Traefik Hub running in proxy mode */}}
+{{- if and (eq (include "traefik.hub.enabled" .) "true") (not .Values.hub.token) -}}
+{{- printf "\n" -}}
+ℹ️ Traefik Hub is running in proxy mode: it behaves as a Traefik Proxy and no commercial
+feature is enabled. Set `hub.token` to a Secret containing your license to enable API Gateway,
+without changing the image. ℹ️
+{{- printf "\n" -}}
+{{- end -}}
+
+
 {{/* Warn about non-standard Traefik Hub versions (pre-release or minor/patch above supported range) */}}
-{{- if .Values.hub.token -}}
+{{- if eq (include "traefik.hub.enabled" .) "true" -}}
 {{- $hubVersion := include "traefik.hubVersion" $ -}}
 {{- $hubMaxVersion := index .Chart.Annotations "traefik.io/hub-max-version" -}}
 {{- if and (regexMatch "v[0-9]+.[0-9]+.[0-9]+" $hubVersion) (eq (include "traefik.isAboveMaxVersion" (dict "version" $hubVersion "max" $hubMaxVersion)) "true") -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,21 +15,32 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Install the Traefik Hub distribution. Enabled without a token means proxy mode. Returns "true" or "false".
+*/}}
+{{- define "traefik.hub.enabled" -}}
+{{- if kindIs "invalid" .Values.hub.enabled -}}
+{{- not (empty .Values.hub.token) -}}
+{{- else -}}
+{{- .Values.hub.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Image defaults. An explicit image value always wins; otherwise the chart picks the hardened
-default, then the Traefik Hub one when hub.token is set, then Traefik Proxy.
+default, then the Traefik Hub one when hub is enabled, then Traefik Proxy.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- $default := ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token)) -}}
+{{- $default := ternary "ghcr.io" "docker.io" (eq (include "traefik.hub.enabled" .) "true") -}}
 {{- .Values.image.registry | default (ternary "registry.traefik.io" $default .Values.hub.hardened) -}}
 {{- end -}}
 
 {{- define "traefik.imageRepository" -}}
-{{- $default := ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token)) -}}
+{{- $default := ternary "traefik/traefik-hub" "traefik" (eq (include "traefik.hub.enabled" .) "true") -}}
 {{- .Values.image.repository | default (ternary "traefik-hub" $default .Values.hub.hardened) -}}
 {{- end -}}
 
 {{- define "traefik.defaultTag" -}}
-{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (not (empty .Values.hub.token)) -}}
+{{- ternary (index .Chart.Annotations "traefik.io/hub-max-version") .Chart.AppVersion (eq (include "traefik.hub.enabled" .) "true") -}}
 {{- end -}}
 
 {{/*
@@ -37,13 +48,13 @@ Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
 {{- if .Values.oci_meta.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if eq (include "traefik.hub.enabled" .) "true" -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.hub.image .Values.oci_meta.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.proxy.image .Values.oci_meta.images.proxy.tag }}
  {{- end -}}
 {{- else if .Values.global.azure.enabled -}}
- {{- if .Values.hub.token -}}
+ {{- if eq (include "traefik.hub.enabled" .) "true" -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.hub.registry .Values.global.azure.images.hub.image .Values.global.azure.images.hub.tag }}
  {{- else -}}
 {{- printf "%s/%s:%s" .Values.global.azure.images.proxy.registry .Values.global.azure.images.proxy.image .Values.global.azure.images.proxy.tag }}
@@ -278,9 +289,10 @@ This version is not officially supported by this chart. Use at your own risk. âš
 The version can comes many sources: appVersion, image.tag, override, marketplace.
 */}}
 {{- define "traefik.proxyVersion" -}}
+ {{- $hubEnabled := eq (include "traefik.hub.enabled" $) "true" -}}
  {{- if $.Values.versionOverride }}
-  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" $.Values.hub.token) }}
- {{- else if $.Values.hub.token -}}
+  {{- include "traefik.proxyVersionFromHub" (dict "Version" $.Values.versionOverride "Hub" $hubEnabled) }}
+ {{- else if $hubEnabled -}}
   {{- $version := ($.Values.oci_meta.enabled | ternary $.Values.oci_meta.images.hub.tag $.Values.image.tag) -}}
   {{- $version = ($.Values.global.azure.enabled | ternary $.Values.global.azure.images.hub.tag $version) -}}
   {{- include "traefik.proxyVersionFromHub" (dict "Version" $version "Hub" true) }}

--- a/traefik/templates/hub-apiportal.yaml
+++ b/traefik/templates/hub-apiportal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hub.apimanagement.enabled }}
+{{- if and .Values.hub.token .Values.hub.apimanagement.enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -11,7 +11,11 @@
   {{- end }}
 {{- end }}
 
-{{- if and .Values.hub.token (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
+{{- if and .Values.hub.token (eq (include "traefik.hub.enabled" .) "false") }}
+  {{- fail "ERROR: hub.enabled cannot be false when hub.token is set." -}}
+{{- end }}
+
+{{- if and (eq (include "traefik.hub.enabled" .) "true") (not (contains "traefik-hub" (include "traefik.imageRepository" .))) }}
   {{- fail "ERROR: traefik-hub image is required when enabling Traefik Hub" -}}
 {{- end }}
 
@@ -139,11 +143,11 @@
   {{- fail "ERROR: request path security options are only available for traefik >= v3.6.4." }}
 {{- end }}
 
-{{- if and $.Values.hub.hardened (not $.Values.hub.token) }}
-  {{ fail "ERROR: hub.hardened requires a Traefik Hub license token, set hub.token." }}
+{{- if and $.Values.hub.hardened (eq (include "traefik.hub.enabled" $) "false") }}
+  {{ fail "ERROR: hub.hardened requires the Traefik Hub distribution, set hub.enabled." }}
 {{- end }}
 
-{{- if $.Values.hub.token -}}
+{{- if eq (include "traefik.hub.enabled" $) "true" -}}
   {{- $hubVersion := include "traefik.hubVersion" $ }}
   {{- if not $hubVersion }}
     {{- if $.Values.image.digest }}
@@ -166,6 +170,10 @@
   {{/* Only a major-version jump is a hard failure; minor/patch above max is just a warning (see NOTES.txt). */}}
   {{- if eq (include "traefik.isMajorAboveMax" (dict "version" $hubVersion "max" $hubMaxVersion)) "true" }}
     {{ fail (printf "ERROR: This Chart does not support Traefik Hub %s, which is a major version above the supported %s." $hubVersion $hubMaxVersion) }}
+  {{- end }}
+
+  {{- if and (not $.Values.hub.token) (semverCompare "<v3.21.0-ea" $hubVersion) }}
+    {{ fail "ERROR: Traefik Hub proxy mode requires Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
   {{- if and (not $.Values.tracing.otlp.enabled) .Values.hub.tracing.additionalTraceHeaders.enabled }}

--- a/traefik/tests/hub-apiportal_test.yaml
+++ b/traefik/tests/hub-apiportal_test.yaml
@@ -19,6 +19,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should not provide api portal service in proxy mode
+    set:
+      hub:
+        enabled: true
+        token: ""
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should expose the required apiportal port on a ClusterIP service
     asserts:
       - notExists:

--- a/traefik/tests/hub-hardened_test.yaml
+++ b/traefik/tests/hub-hardened_test.yaml
@@ -22,6 +22,18 @@ tests:
           path: spec.template.spec.containers[0].image
           value: registry.traefik.io/traefik-hub:v3.21.0-ea.1-hardened
 
+  - it: should use the hardened image in proxy mode
+    set:
+      hub:
+        enabled: true
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/traefik-hub:v3.21.0-ea.1-hardened
+
   - it: should append -hardened to a FIPS tag when enabled
     set:
       hub:

--- a/traefik/tests/hub-proxy-mode_test.yaml
+++ b/traefik/tests/hub-proxy-mode_test.yaml
@@ -1,0 +1,113 @@
+---
+suite: Traefik Hub proxy mode
+templates:
+  - deployment.yaml
+  - hub-license.yaml
+  - hub-apiportal.yaml
+  - requirements.yaml
+tests:
+  - it: should use the Traefik Proxy image when hub is not enabled
+    chart:
+      appVersion: v3.7.6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik:v3.7.6
+        template: deployment.yaml
+
+  - it: should use the Traefik Hub image without a token when hub is enabled
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/traefik/traefik-hub:v3.21.0-ea.1
+        template: deployment.yaml
+
+  - it: should not mount the license token in proxy mode
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub-license.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: hub-token
+          any: true
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: hub-token
+          any: true
+        template: deployment.yaml
+
+  - it: should not set any hub argument in proxy mode
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tokenFilePath=/etc/secrets/token"
+        template: deployment.yaml
+
+  - it: should not expose the api portal in proxy mode
+    set:
+      hub:
+        enabled: true
+        apimanagement:
+          enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: hub-apiportal.yaml
+
+  - it: should keep using the Traefik Hub image and license when a token is set
+    set:
+      hub:
+        enabled: true
+        token: "my-hub-license"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/traefik/traefik-hub:v3.20.6
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.tokenFilePath=/etc/secrets/token"
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: hub-token
+          any: true
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: hub-token
+          any: true
+        template: deployment.yaml
+
+  - it: should default hub.enabled to true when a token is set
+    set:
+      hub:
+        token: "my-hub-license"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/traefik/traefik-hub:v3.20.6
+        template: deployment.yaml

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -64,6 +64,25 @@ tests:
     asserts:
       - notMatchRegexRaw:
           pattern: "hardened images are hosted on a private registry"
+  - it: should inform about proxy mode when hub is enabled without a token
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Traefik Hub is running in proxy mode'
+      - matchRegexRaw:
+          pattern: 'Set `hub.token` to a Secret containing your license to enable API Gateway'
+  - it: should not inform about proxy mode when a token is set
+    set:
+      hub:
+        enabled: true
+        token: "my-hub-license"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "Traefik Hub is running in proxy mode"
   - it: should display warning when using an experimental image tag
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -30,13 +30,30 @@ tests:
         tag: experimental-master
     asserts:
       - notFailedTemplate: {}
-  - it: should fail when hub.hardened is set without a Traefik Hub license token
+  - it: should fail when hub.hardened is set without the Traefik Hub distribution
     set:
       hub:
         hardened: true
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: hub.hardened requires a Traefik Hub license token, set hub.token."
+          errorMessage: "ERROR: hub.hardened requires the Traefik Hub distribution, set hub.enabled."
+  - it: should fail when hub.hardened is set with hub explicitly disabled
+    set:
+      hub:
+        enabled: false
+        hardened: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.hardened requires the Traefik Hub distribution, set hub.enabled."
+  - it: should pass when hub.hardened is set in proxy mode
+    set:
+      hub:
+        enabled: true
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when hub.hardened is set on a Traefik Hub older than v3.21.0-ea
     set:
       hub:
@@ -756,3 +773,64 @@ tests:
           enabled: true
     asserts:
       - notFailedTemplate: {}
+  - it: should not fail when enabling Traefik Hub without a token
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when using proxy mode with Traefik Hub < v3.21.0-ea
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.20.6
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Traefik Hub proxy mode requires Traefik Hub >= v3.21.0-ea, set image.tag accordingly."
+  - it: should fail when using proxy mode with the default Traefik Hub version
+    set:
+      hub:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Traefik Hub proxy mode requires Traefik Hub >= v3.21.0-ea, set image.tag accordingly."
+  - it: should not gate on proxy mode version when a token is set
+    set:
+      hub:
+        enabled: true
+        token: "my-hub-license"
+      image:
+        tag: v3.20.5
+    asserts:
+      - notFailedTemplate: {}
+  - it: should fail when hub is explicitly disabled with a token
+    set:
+      hub:
+        enabled: false
+        token: "my-hub-license"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.enabled cannot be false when hub.token is set."
+  - it: should enforce Traefik Hub version bounds in proxy mode
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.18.0
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: this Chart supports *only* Traefik Hub >= v3.19.3."
+  - it: should resolve the Traefik Proxy version from the Traefik Hub tag in proxy mode
+    set:
+      hub:
+        enabled: true
+      image:
+        tag: v3.19.3
+      accessLog:
+        dualOutput: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: accesslog.dualOutput is only available for traefik >= v3.7.0."

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -765,8 +765,15 @@
                         }
                     }
                 },
+                "enabled": {
+                    "description": "Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik Proxy, which requires Traefik Hub \u003e= v3.21.0-ea.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "hardened": {
-                    "description": "Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub \u003e= v3.21.0-ea.",
+                    "description": "Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub \u003e= v3.21.0-ea.",
                     "type": "boolean"
                 },
                 "mcpgateway": {
@@ -1373,14 +1380,14 @@
                     "type": "string"
                 },
                 "registry": {
-                    "description": "Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set).",
+                    "description": "Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.enabled` is true).",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
                 "repository": {
-                    "description": "Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set).",
+                    "description": "Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.enabled` is true).",
                     "type": [
                         "string",
                         "null"

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into templates
 
 image:  # @schema additionalProperties: false
-  # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.token` is set).
+  # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.enabled` is true).
   registry:  # @schema type:[string, null]
-  # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.token` is set).
+  # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.enabled` is true).
   repository:  # @schema type:[string, null]
   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
   # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
@@ -1280,13 +1280,17 @@ fullnameOverride: ""
 
 # Traefik Hub configuration. See https://doc.traefik.io/traefik-hub/
 hub:  # @schema additionalProperties: false
+  # -- (bool) Install Traefik Hub. Without `hub.token`, it runs in proxy mode: a drop-in Traefik
+  # Proxy, which requires Traefik Hub >= v3.21.0-ea.
+  # @default -- `true` when `hub.token` is set
+  enabled:  # @schema type:[boolean, null]
   # -- Name of `Secret` with key 'token' set to a valid license token.
   # It enables API Gateway.
   token: ""
   # -- Mount path for token secret.
   tokenMountPath: "/etc/secrets"
   # -- Use the hardened image variant. It appends `-hardened` to the tag and defaults the image
-  # to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub >= v3.21.0-ea.
+  # to `registry.traefik.io/traefik-hub`. Requires `hub.enabled` and Traefik Hub >= v3.21.0-ea.
   hardened: false
   # -- Disables all external network connections.
   offline:  # @schema type:[boolean, null]


### PR DESCRIPTION
### What does this PR do?

Adds `hub.enabled` to install the Traefik Hub distribution without a license token, running it in proxy mode: a drop-in Traefik Proxy.

```yaml
hub:
  enabled: true
```

This installs `ghcr.io/traefik/traefik-hub` with no `--hub.*` argument, no token volume/mount and no API portal. Setting `hub.token` later enables API Gateway on the same release, without changing the image. `hub.enabled` is nullable and defaults to `true` when `hub.token` is set, so existing values files render identically.

Choosing the distribution (image registry/repository/tag, marketplace images, Hub version bounds, Hub→Proxy version mapping) now keys off `hub.enabled`, while everything licensed (CLI args, RBAC, admission, API portal, modsec/uplink guards) still keys off `hub.token`. `hub.enabled: false` with a token set is rejected.

Also gates `hub-apiportal.yaml` on `hub.token`, which previously rendered a portal whenever `hub.apimanagement.enabled` was set, with no agent behind it.

### Motivation

Traefik Hub can now run without a license (traefik/traefik-hub#1245), giving a single deployment artifact that runs as a plain proxy today and unlocks commercial capabilities later by adding a license. The chart had no way to express this: `hub.token` being set was the only thing selecting the Hub distribution, so the Hub image without a token was unreachable except by hand-setting `image.repository`, which silently misresolved the version.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
