### PR TITLE
docs: :books: change metrics.prometheus labels types from string to bool

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -322,9 +322,9 @@ Kubernetes: `>=1.25.0-0`
 | metrics.otlp.pushInterval | string | `""` | Interval at which metrics are sent to the OpenTelemetry Collector. Default: 10s |
 | metrics.otlp.resourceAttributes | object | `{}` | Defines additional resource attributes to be sent to the collector. |
 | metrics.otlp.serviceName | string | `nil` | Service name used in OTLP backend. Default: traefik. |
-| metrics.prometheus.addEntryPointsLabels | string | `nil` | Enable metrics on entry points. Default: true |
-| metrics.prometheus.addRoutersLabels | string | `nil` | Enable metrics on routers. Default: false |
-| metrics.prometheus.addServicesLabels | string | `nil` | Enable metrics on services. Default: true |
+| metrics.prometheus.addEntryPointsLabels | bool | `nil` | Enable metrics on entry points. Default: true |
+| metrics.prometheus.addRoutersLabels | bool | `nil` | Enable metrics on routers. Default: false |
+| metrics.prometheus.addServicesLabels | bool | `nil` | Enable metrics on services. Default: true |
 | metrics.prometheus.buckets | string | `""` | Buckets for latency metrics. Default="0.1,0.3,1.2,5.0" |
 | metrics.prometheus.disableAPICheck | string | `nil` | When set to true, it won't check if Prometheus Operator CRDs are deployed |
 | metrics.prometheus.entryPoint | string | `"metrics"` | Entry point used to expose metrics. |

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -665,11 +665,11 @@ metrics:
   prometheus:
     # -- Entry point used to expose metrics.
     entryPoint: metrics
-    # -- Enable metrics on entry points. Default: true
+    # -- (bool) Enable metrics on entry points. Default: true
     addEntryPointsLabels:  # @schema type:[boolean, null]
-    # -- Enable metrics on routers. Default: false
+    # -- (bool) Enable metrics on routers. Default: false
     addRoutersLabels:  # @schema type:[boolean, null]
-    # -- Enable metrics on services. Default: true
+    # -- (bool) Enable metrics on services. Default: true
     addServicesLabels:  # @schema type:[boolean, null]
     # -- Buckets for latency metrics. Default="0.1,0.3,1.2,5.0"
     buckets: ""


### PR DESCRIPTION
### What does this PR do?

Corrects the documentation to give some fields under `metrics.prometheus` the correct type.

### Motivation

Install failure when using string types:
```
Upgrade failed: values don't meet the specifications of the schema(s) in the
following chart(s):
traefik:
- at '/metrics/prometheus/addEntryPointsLabels': got string, want null or
boolean
- at '/metrics/prometheus/addRoutersLabels': got string, want null or boolean
- at '/metrics/prometheus/addServicesLabels': got string, want null or
boolean
```


### More

N/A, Docs only

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

