### PR TITLE
fix(deployment): :bug: accept named port for healthchecksPort

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -85,7 +85,7 @@ Kubernetes: `>=1.25.0-0`
 | deployment.enabled | bool | `true` | Enable deployment |
 | deployment.goMemLimitPercentage | float | `0.9` | Percentage of memory limit to set for GOMEMLIMIT, set as decimal (0.9 = 90%, 0.95 = 95% etc). Only takes effect when resources.limits.memory is set. Set to 0 to disable (e.g. when using VPA or setting it via env) |
 | deployment.healthchecksHost | string | `""` |  |
-| deployment.healthchecksPort | string | `nil` |  |
+| deployment.healthchecksPort | string/int | `ports.traefik.port` | Override the liveness/readiness port. This is useful to integrate traefik with an external Load Balancer that performs healthchecks. |
 | deployment.healthchecksScheme | string | `nil` |  |
 | deployment.hostAliases | list | `[]` | Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) |
 | deployment.hostUsers | string | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |

--- a/traefik/tests/traefik-config_test.yaml
+++ b/traefik/tests/traefik-config_test.yaml
@@ -766,6 +766,17 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--ping.entrypoint=web"
+  - it: should support a named probe port
+    set:
+      deployment:
+        healthchecksPort: traefik
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: traefik
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: traefik
   - it: should set custom probe scheme
     set:
       additionalArguments:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -383,7 +383,9 @@
                     "type": "string"
                 },
                 "healthchecksPort": {
+                    "description": "Override the liveness/readiness port. This is useful to integrate traefik with an external Load Balancer that performs healthchecks.",
                     "type": [
+                        "string",
                         "integer",
                         "null"
                     ],

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -32,10 +32,10 @@ deployment:
   terminationGracePeriodSeconds: 60
   # -- The minimum number of seconds Traefik needs to be up and running before the DaemonSet/Deployment controller considers it available
   minReadySeconds: 0
-  ## -- Override the liveness/readiness port. This is useful to integrate traefik
-  ## with an external Load Balancer that performs healthchecks.
-  ## Default: ports.traefik.port
-  healthchecksPort:  # @schema type:[integer, null];minimum:0
+  # -- (string/int) Override the liveness/readiness port. This is useful to integrate traefik
+  # with an external Load Balancer that performs healthchecks.
+  # @default -- `ports.traefik.port`
+  healthchecksPort:  # @schema type:[string, integer, null]; minimum:0
   ## -- Override the liveness/readiness host. Useful for getting ping to respond on non-default entryPoint.
   ## Default: ports.traefik.hostIP if set, otherwise Pod IP
   healthchecksHost: ""


### PR DESCRIPTION
### What does this PR do?

Allows `deployment.healthchecksPort` to be a named port (e.g. `web`), not only a numeric one.

### Motivation

The value is rendered into the liveness/readiness probes' `httpGet.port`, which is an `IntOrString` in Kubernetes — a named container port is valid there, and the chart's container ports are named. The schema restricted it to `integer`, rejecting a valid configuration. This widens it to `[string, integer, null]`, matching the existing `targetPort` field which feeds the same kind of `IntOrString`.

### More

Adds a unit test rendering a named `healthchecksPort` into both probes. Note that `helm-unittest` does not validate against `values.schema.json` (only `helm install` / `helm lint` do), so the test guards the rendering rather than the schema relaxation itself.

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed