### PR TITLE
fix(rbac): :bug: align namespaced RBAC with kubernetesIngressNGINX namespace scoping

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -535,7 +535,7 @@ Kubernetes: `>=1.25.0-0`
 | providers.kubernetesIngressNGINX.upstreamKeepaliveTimeout | string | `nil` | Defines the idle timeout for keep-alive connections to upstream servers. Unitless, in seconds (default: 60) |
 | providers.kubernetesIngressNGINX.watchIngressWithoutClass | bool | `false` | Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified |
 | providers.kubernetesIngressNGINX.watchNamespace | string | `""` | Single namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector. |
-| providers.kubernetesIngressNGINX.watchNamespaceSelector | string | `""` | Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. |
+| providers.kubernetesIngressNGINX.watchNamespaceSelector | string | `""` | Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. It requires a ClusterRole to list and watch namespaces, and is therefore incompatible with `rbac.namespaced`. |
 | providers.precedence | list | `[]` | Defines the routing precedence between providers. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/overview/#routing-precedence) for the default order. |
 | rbac.aggregateTo | list | `[]` | Enable user-facing roles https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles |
 | rbac.enabled | bool | `true` | Whether Role Based Access Control objects like roles and rolebindings should be created |

--- a/traefik/templates/rbac/role.yaml
+++ b/traefik/templates/rbac/role.yaml
@@ -3,7 +3,9 @@
 {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
 {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.knative.namespaces -}}
 {{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
-{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $hubNamespaces $knativeNamespaces)) -}}
+{{/* Mirrors the --providers.kubernetesingressnginx.watchnamespace arg: a single namespace, defaulting to the release one. */}}
+{{- $ingressNGINXNamespaces := ternary (splitList "," (include "providers.kubernetesIngressNGINX.namespaces" .)) (list) .Values.providers.kubernetesIngressNGINX.enabled -}}
+{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $hubNamespaces $knativeNamespaces $ingressNGINXNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced -}}
 {{- range $allNamespaces }}
@@ -47,7 +49,7 @@ rules:
       - get
       - list
       - watch
-{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($.Values.providers.kubernetesIngressNGINX.enabled) }}
+{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) (and (has . $ingressNGINXNamespaces) $.Values.providers.kubernetesIngressNGINX.enabled) }}
   - apiGroups:
       - extensions
       - networking.k8s.io

--- a/traefik/templates/rbac/rolebinding.yaml
+++ b/traefik/templates/rbac/rolebinding.yaml
@@ -3,7 +3,8 @@
 {{- $gatewayNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.kubernetesGateway).namespaces) -}}
 {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) ((.Values.providers.knative).namespaces) -}}
 {{- $hubNamespaces := concat (include "traefik.namespace" . | list) .Values.hub.namespaces -}}
-{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $gatewayNamespaces $knativeNamespaces $hubNamespaces)) -}}
+{{- $ingressNGINXNamespaces := ternary (splitList "," (include "providers.kubernetesIngressNGINX.namespaces" .)) (list) .Values.providers.kubernetesIngressNGINX.enabled -}}
+{{- $allNamespaces := sortAlpha (uniq (concat $ingressNamespaces $CRDNamespaces $gatewayNamespaces $knativeNamespaces $hubNamespaces $ingressNGINXNamespaces)) -}}
 
 {{- if and .Values.rbac.enabled .Values.rbac.namespaced }}
 {{- range $allNamespaces }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -31,6 +31,9 @@
   {{- if .Values.providers.kubernetesGateway.enabled }}
     {{- fail "ERROR: Kubernetes Gateway provider requires ClusterRole. RBAC cannot be namespaced." }}
   {{- end }}
+  {{- if and .Values.providers.kubernetesIngressNGINX.enabled .Values.providers.kubernetesIngressNGINX.watchNamespaceSelector }}
+    {{- fail "ERROR: Kubernetes Ingress NGINX watchNamespaceSelector requires ClusterRole. RBAC cannot be namespaced." }}
+  {{- end }}
   {{- if and (not .Values.providers.kubernetesIngress.enabled) (not .Values.providers.kubernetesCRD.enabled) (not .Values.providers.kubernetesIngressNGINX.enabled) }}
     {{- fail "ERROR: namespaced rbac requires Kubernetes CRD, Kubernetes Ingress NGINX, or Kubernetes Ingress provider." }}
   {{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1089,6 +1089,66 @@ tests:
               - ingresses/status
             verbs:
               - update
+  - it: should create a Role in the namespace watched by kubernetesIngressNGINX
+    set:
+      providers:
+        kubernetesIngress:
+          enabled: false
+        kubernetesIngressNGINX:
+          enabled: true
+          watchNamespace: foo
+      rbac:
+        namespaced: true
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: rbac/role.yaml
+      - hasDocuments:
+          count: 2
+        template: rbac/rolebinding.yaml
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+        template: rbac/role.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: foo
+        template: rbac/role.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: foo
+        template: rbac/rolebinding.yaml
+        documentIndex: 1
+      - template: rbac/role.yaml
+        documentIndex: 1
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - get
+              - list
+              - watch
+      - template: rbac/role.yaml
+        documentIndex: 0
+        notContains:
+          path: rules
+          content:
+            apiGroups:
+              - extensions
+              - networking.k8s.io
+            resources:
+              - ingresses
+            verbs:
+              - get
+              - list
+              - watch
   - it: Role should not have kubernetesIngressNGINX permissions when provider is disabled
     set:
       providers:

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -1100,17 +1100,6 @@ tests:
       rbac:
         namespaced: true
     asserts:
-      - hasDocuments:
-          count: 2
-        template: rbac/role.yaml
-      - hasDocuments:
-          count: 2
-        template: rbac/rolebinding.yaml
-      - equal:
-          path: metadata.namespace
-          value: NAMESPACE
-        template: rbac/role.yaml
-        documentIndex: 0
       - equal:
           path: metadata.namespace
           value: foo
@@ -1125,7 +1114,7 @@ tests:
         documentIndex: 1
         contains:
           path: rules
-          content:
+          content: &ingressRules
             apiGroups:
               - extensions
               - networking.k8s.io
@@ -1135,20 +1124,12 @@ tests:
               - get
               - list
               - watch
+      # Ingress rules are scoped to the watched namespace, not the release one.
       - template: rbac/role.yaml
         documentIndex: 0
         notContains:
           path: rules
-          content:
-            apiGroups:
-              - extensions
-              - networking.k8s.io
-            resources:
-              - ingresses
-            verbs:
-              - get
-              - list
-              - watch
+          content: *ingressRules
   - it: Role should not have kubernetesIngressNGINX permissions when provider is disabled
     set:
       providers:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -386,6 +386,25 @@ tests:
           enabled: true
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using kubernetesIngressNGINX watchNamespaceSelector with namespaced RBACs
+    set:
+      rbac:
+        namespaced: true
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+          watchNamespaceSelector: "foo=bar"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Kubernetes Ingress NGINX watchNamespaceSelector requires ClusterRole. RBAC cannot be namespaced."
+  - it: should be possible to use kubernetesIngressNGINX watchNamespaceSelector without namespaced RBACs
+    set:
+      providers:
+        kubernetesIngressNGINX:
+          enabled: true
+          watchNamespaceSelector: "foo=bar"
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when enabling Kubernete Gateway provider with namespaced RBACs
     set:
       providers:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -397,14 +397,6 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: Kubernetes Ingress NGINX watchNamespaceSelector requires ClusterRole. RBAC cannot be namespaced."
-  - it: should be possible to use kubernetesIngressNGINX watchNamespaceSelector without namespaced RBACs
-    set:
-      providers:
-        kubernetesIngressNGINX:
-          enabled: true
-          watchNamespaceSelector: "foo=bar"
-    asserts:
-      - notFailedTemplate: {}
   - it: should fail when enabling Kubernete Gateway provider with namespaced RBACs
     set:
       providers:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -2969,7 +2969,7 @@
                             "type": "string"
                         },
                         "watchNamespaceSelector": {
-                            "description": "Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.",
+                            "description": "Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace. It requires a ClusterRole to list and watch namespaces, and is therefore incompatible with `rbac.namespaced`.",
                             "type": "string"
                         }
                     },

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -413,6 +413,7 @@ providers:
     # -- Single namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector.
     watchNamespace: ""
     # -- Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.
+    # It requires a ClusterRole to list and watch namespaces, and is therefore incompatible with `rbac.namespaced`.
     watchNamespaceSelector: ""
     publishService:
       # -- Enable publishService. Service fronting the Ingress controller, used to set the load-balancer status of Ingress objects.


### PR DESCRIPTION
### What does this PR do?

Follow-up to #1929. Fixes two gaps in `rbac.namespaced` handling for the Kubernetes Ingress NGINX provider.

**1. `watchNamespace` was not taken into account when generating Roles.** `role.yaml`/`rolebinding.yaml` build their namespace list from `kubernetesCRD.namespaces`, `kubernetesIngress.namespaces`, `knative.namespaces` and `hub.namespaces` only. With `rbac.namespaced=true` and `providers.kubernetesIngressNGINX.watchNamespace=foo`, the pod is started with `--providers.kubernetesingressnginx.watchnamespace=foo` but no Role is created in `foo`, so Traefik gets 403s on every Ingress it is supposed to watch. The namespace list now mirrors the CLI argument, and the `ingresses`/`ingresses/status` rules are scoped to that namespace instead of being granted everywhere.

**2. `watchNamespaceSelector` is incompatible with namespaced RBAC.** It requires cluster-wide `namespaces` list/watch, which a `Role` cannot grant. Unlike the `ingressclasses` lookup — which Traefik degrades gracefully on a `Forbidden` error — this path hard-fails at startup (`listing namespaces: %w`). The combination is now rejected at template time with an explicit message, and the constraint is documented on the value.

### Motivation

Raised while reviewing #1929: relaxing the namespaced-RBAC guard for NGINX-only setups makes both of these reachable. This PR is based on `master` and is independent of #1929, so the two can merge in either order.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
