### PR TITLE
feat(hub): add hardened image variant

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -145,6 +145,9 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
+| hub.hardened.enabled | bool | `false` | Set to true to use the hardened image variant. |
+| hub.hardened.registry | string | `"registry.traefik.io"` | Registry hosting the hardened images. |
+| hub.hardened.repository | string | `"traefik-hub"` | Repository of the hardened images. |
 | hub.mcpgateway.enabled | bool | `false` | Set to true in order to enable AI MCP Gateway. Requires a valid license token. |
 | hub.mcpgateway.maxRequestBodySize | string | `nil` | Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB). |
 | hub.namespaces | list | `[]` | By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -145,9 +145,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.apimanagement.admission.selfManagedCertificate | bool | `false` | By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details. |
 | hub.apimanagement.enabled | bool | `false` | Set to true in order to enable API Management. Requires a valid license token. |
 | hub.apimanagement.openApi.validateRequestMethodAndPath | bool | `false` | When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification |
-| hub.hardened.enabled | bool | `false` | Set to true to use the hardened image variant. |
-| hub.hardened.registry | string | `"registry.traefik.io"` | Registry hosting the hardened images. |
-| hub.hardened.repository | string | `"traefik-hub"` | Repository of the hardened images. |
+| hub.hardened | bool | `false` | Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub >= v3.21.0-ea. |
 | hub.mcpgateway.enabled | bool | `false` | Set to true in order to enable AI MCP Gateway. Requires a valid license token. |
 | hub.mcpgateway.maxRequestBodySize | string | `nil` | Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB). |
 | hub.namespaces | list | `[]` | By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |

--- a/traefik/templates/NOTES.txt
+++ b/traefik/templates/NOTES.txt
@@ -38,6 +38,15 @@ key) and set `hub.token` to that Secret's name. ⚠️
 {{- end -}}
 
 
+{{/* Warn about missing pull credentials for the hardened image (SA-attached secrets are not visible here) */}}
+{{- if and .Values.hub.hardened (empty .Values.deployment.imagePullSecrets) -}}
+{{- printf "\n" -}}
+🚨 hardened images are hosted on a private registry: pulling {{ include "traefik.image-name" . }} needs
+credentials, from `deployment.imagePullSecrets` or from the ServiceAccount used by Traefik. 🚨
+{{- printf "\n" -}}
+{{- end -}}
+
+
 {{/* Warn about potential permission issue with persistence */}}
 {{- if .Values.persistence -}}
   {{- if and .Values.persistence.enabled (empty .Values.deployment.initContainers) -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -34,7 +34,9 @@ Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwi
 Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
-{{- if .Values.oci_meta.enabled -}}
+{{- if .Values.hub.hardened.enabled -}}
+{{- printf "%s/%s:%s-hardened" .Values.hub.hardened.registry .Values.hub.hardened.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- else if .Values.oci_meta.enabled -}}
  {{- if .Values.hub.token -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.hub.image .Values.oci_meta.images.hub.tag }}
  {{- else -}}
@@ -370,7 +372,7 @@ Hash: {{ sha1sum ($cert.Cert | b64enc) }}
     {{- $found -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Validate localPlugin configuration and determine plugin type
 Returns: hostPath, inline, or localPath
 */}}
@@ -393,7 +395,7 @@ Returns: hostPath, inline, or localPath
     {{- end -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Get hostPath for a plugin (handles both old and new structure)
 */}}
 {{- define "traefik.getLocalPluginHostPath" -}}
@@ -407,7 +409,7 @@ Get hostPath for a plugin (handles both old and new structure)
     {{- end -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Get inline plugin files (new structure only)
 */}}
 {{- define "traefik.getLocalPluginInlineFiles" -}}
@@ -417,7 +419,7 @@ Get inline plugin files (new structure only)
     {{- end -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Get localPath plugin configuration (new structure only)
 */}}
 {{- define "traefik.getLocalPluginLocalPath" -}}
@@ -433,7 +435,7 @@ Get localPath plugin configuration (new structure only)
     {{- end -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Check if a volume name exists in additionalVolumes
 */}}
 {{- define "traefik.volumeExistsInAdditionalVolumes" -}}
@@ -448,7 +450,7 @@ Check if a volume name exists in additionalVolumes
     {{- $found -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Check if using old localPlugin hostPath structure (for deprecation warning)
 */}}
 {{- define "traefik.hasDeprecatedLocalPlugins" -}}

--- a/traefik/templates/_helpers.tpl
+++ b/traefik/templates/_helpers.tpl
@@ -15,15 +15,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Image defaults. An explicit image value always wins; otherwise the chart picks the
-Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwise.
+Image defaults. An explicit image value always wins; otherwise the chart picks the hardened
+default, then the Traefik Hub one when hub.token is set, then Traefik Proxy.
 */}}
 {{- define "traefik.imageRegistry" -}}
-{{- .Values.image.registry | default (ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token))) -}}
+{{- $default := ternary "ghcr.io" "docker.io" (not (empty .Values.hub.token)) -}}
+{{- .Values.image.registry | default (ternary "registry.traefik.io" $default .Values.hub.hardened) -}}
 {{- end -}}
 
 {{- define "traefik.imageRepository" -}}
-{{- .Values.image.repository | default (ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token))) -}}
+{{- $default := ternary "traefik/traefik-hub" "traefik" (not (empty .Values.hub.token)) -}}
+{{- .Values.image.repository | default (ternary "traefik-hub" $default .Values.hub.hardened) -}}
 {{- end -}}
 
 {{- define "traefik.defaultTag" -}}
@@ -34,9 +36,7 @@ Traefik Hub default when hub.token is set, and the Traefik Proxy default otherwi
 Create the chart image name.
 */}}
 {{- define "traefik.image-name" -}}
-{{- if .Values.hub.hardened.enabled -}}
-{{- printf "%s/%s:%s-hardened" .Values.hub.hardened.registry .Values.hub.hardened.repository (.Values.image.tag | default .Chart.AppVersion) }}
-{{- else if .Values.oci_meta.enabled -}}
+{{- if .Values.oci_meta.enabled -}}
  {{- if .Values.hub.token -}}
 {{- printf "%s/%s:%s" .Values.oci_meta.repo .Values.oci_meta.images.hub.image .Values.oci_meta.images.hub.tag }}
  {{- else -}}
@@ -51,7 +51,7 @@ Create the chart image name.
 {{- else if .Values.image.digest -}}
 {{- printf "%s/%s@%s" (include "traefik.imageRegistry" .) (include "traefik.imageRepository" .) .Values.image.digest }}
 {{- else -}}
-{{- printf "%s/%s:%s" (include "traefik.imageRegistry" .) (include "traefik.imageRepository" .) (.Values.image.tag | default (include "traefik.defaultTag" .)) }}
+{{- printf "%s/%s:%s%s" (include "traefik.imageRegistry" .) (include "traefik.imageRepository" .) (.Values.image.tag | default (include "traefik.defaultTag" .)) (ternary "-hardened" "" .Values.hub.hardened) }}
 {{- end -}}
 {{- end -}}
 

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -139,6 +139,10 @@
   {{- fail "ERROR: request path security options are only available for traefik >= v3.6.4." }}
 {{- end }}
 
+{{- if and $.Values.hub.hardened (not $.Values.hub.token) }}
+  {{ fail "ERROR: hub.hardened requires a Traefik Hub license token, set hub.token." }}
+{{- end }}
+
 {{- if $.Values.hub.token -}}
   {{- $hubVersion := include "traefik.hubVersion" $ }}
   {{- if not $hubVersion }}
@@ -193,6 +197,10 @@
 
   {{- if and $.Values.hub.providers.multicluster.enabled (semverCompare "<v3.20.0-ea.1" $hubVersion) }}
     {{ fail "ERROR: hub.providers.multicluster is only available for Traefik Hub >= v3.20.0-ea.1." }}
+  {{- end }}
+
+  {{- if and $.Values.hub.hardened (semverCompare "<v3.21.0-ea" $hubVersion) }}
+    {{ fail "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly." }}
   {{- end }}
 
   {{- if semverCompare "<v3.20.0-ea.7" $hubVersion }}

--- a/traefik/tests/hub-hardened_test.yaml
+++ b/traefik/tests/hub-hardened_test.yaml
@@ -11,65 +11,64 @@ tests:
           value: docker.io/traefik:v3.3.0
 
   - it: should use the hardened registry and repository when enabled
-    chart:
-      appVersion: v3.3.0
     set:
       hub:
-        hardened:
-          enabled: true
+        token: my-token
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.traefik.io/traefik-hub:v3.3.0-hardened
+          value: registry.traefik.io/traefik-hub:v3.21.0-ea.1-hardened
 
   - it: should append -hardened to a FIPS tag when enabled
     set:
       hub:
-        hardened:
-          enabled: true
+        token: my-token
+        hardened: true
       image:
-        tag: v3.3.0-fips
+        tag: v3.21.0-fips
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.traefik.io/traefik-hub:v3.3.0-fips-hardened
+          value: registry.traefik.io/traefik-hub:v3.21.0-fips-hardened
 
-  - it: should let the hardened registry be overridden
-    chart:
-      appVersion: v3.3.0
+  - it: should let the registry be overridden
     set:
       hub:
-        hardened:
-          enabled: true
-          registry: myregistry.example.com
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: myregistry.example.com/traefik-hub:v3.3.0-hardened
-
-  - it: should let the hardened repository be overridden
-    chart:
-      appVersion: v3.3.0
-    set:
-      hub:
-        hardened:
-          enabled: true
-          repository: acme/traefik-hub
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: registry.traefik.io/acme/traefik-hub:v3.3.0-hardened
-
-  - it: should ignore image registry and repository when hardened
-    set:
-      hub:
-        hardened:
-          enabled: true
+        token: my-token
+        hardened: true
       image:
-        registry: europe-west9-docker.pkg.dev/traefiklabs
-        repository: traefik-hub/traefik-hub
-        tag: latest-v3
+        registry: myregistry.example.com
+        tag: v3.21.0-ea.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.traefik.io/traefik-hub:latest-v3-hardened
+          value: myregistry.example.com/traefik-hub:v3.21.0-ea.1-hardened
+
+  - it: should let the repository be overridden
+    set:
+      hub:
+        token: my-token
+        hardened: true
+      image:
+        repository: acme/traefik-hub
+        tag: v3.21.0-ea.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/acme/traefik-hub:v3.21.0-ea.1-hardened
+
+  - it: should not append -hardened when pinning by digest
+    set:
+      hub:
+        token: my-token
+        hardened: true
+      image:
+        digest: sha256:1c5b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2
+      versionOverride: v3.21.0-ea.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/traefik-hub@sha256:1c5b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2c65b1b8b4e2

--- a/traefik/tests/hub-hardened_test.yaml
+++ b/traefik/tests/hub-hardened_test.yaml
@@ -1,0 +1,75 @@
+suite: Traefik hardened image
+templates:
+  - deployment.yaml
+tests:
+  - it: should not use the hardened image by default
+    chart:
+      appVersion: v3.3.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/traefik:v3.3.0
+
+  - it: should use the hardened registry and repository when enabled
+    chart:
+      appVersion: v3.3.0
+    set:
+      hub:
+        hardened:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/traefik-hub:v3.3.0-hardened
+
+  - it: should append -hardened to a FIPS tag when enabled
+    set:
+      hub:
+        hardened:
+          enabled: true
+      image:
+        tag: v3.3.0-fips
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/traefik-hub:v3.3.0-fips-hardened
+
+  - it: should let the hardened registry be overridden
+    chart:
+      appVersion: v3.3.0
+    set:
+      hub:
+        hardened:
+          enabled: true
+          registry: myregistry.example.com
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.example.com/traefik-hub:v3.3.0-hardened
+
+  - it: should let the hardened repository be overridden
+    chart:
+      appVersion: v3.3.0
+    set:
+      hub:
+        hardened:
+          enabled: true
+          repository: acme/traefik-hub
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/acme/traefik-hub:v3.3.0-hardened
+
+  - it: should ignore image registry and repository when hardened
+    set:
+      hub:
+        hardened:
+          enabled: true
+      image:
+        registry: europe-west9-docker.pkg.dev/traefiklabs
+        repository: traefik-hub/traefik-hub
+        tag: latest-v3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.traefik.io/traefik-hub:latest-v3-hardened

--- a/traefik/tests/notes_test.yaml
+++ b/traefik/tests/notes_test.yaml
@@ -41,6 +41,29 @@ tests:
     asserts:
       - notMatchRegexRaw:
           pattern: "DEPRECATION: providing the Traefik Hub license token inline"
+  - it: should warn about missing pull credentials when using the hardened image
+    set:
+      hub:
+        token: "my-hub-license"
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - matchRegexRaw:
+          pattern: "hardened images are hosted on a private registry"
+  - it: should not warn about pull credentials when imagePullSecrets are set
+    set:
+      hub:
+        token: "my-hub-license"
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
+      deployment:
+        imagePullSecrets:
+          - name: my-registry-credentials
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "hardened images are hosted on a private registry"
   - it: should display warning when using an experimental image tag
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -30,6 +30,32 @@ tests:
         tag: experimental-master
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when hub.hardened is set without a Traefik Hub license token
+    set:
+      hub:
+        hardened: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.hardened requires a Traefik Hub license token, set hub.token."
+  - it: should fail when hub.hardened is set on a Traefik Hub older than v3.21.0-ea
+    set:
+      hub:
+        token: my-token
+        hardened: true
+      image:
+        tag: v3.20.6
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.hardened is only available for Traefik Hub >= v3.21.0-ea, set image.tag accordingly."
+  - it: should pass when hub.hardened is set with a supported Traefik Hub version
+    set:
+      hub:
+        token: my-token
+        hardened: true
+      image:
+        tag: v3.21.0-ea.1
+    asserts:
+      - notFailedTemplate: {}
   - it: should not pass when trying to use this Chart with unknown tag
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -765,6 +765,23 @@
                         }
                     }
                 },
+                "hardened": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Set to true to use the hardened image variant.",
+                            "type": "boolean"
+                        },
+                        "registry": {
+                            "description": "Registry hosting the hardened images.",
+                            "type": "string"
+                        },
+                        "repository": {
+                            "description": "Repository of the hardened images.",
+                            "type": "string"
+                        }
+                    }
+                },
                 "mcpgateway": {
                     "type": "object",
                     "properties": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -766,21 +766,8 @@
                     }
                 },
                 "hardened": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "description": "Set to true to use the hardened image variant.",
-                            "type": "boolean"
-                        },
-                        "registry": {
-                            "description": "Registry hosting the hardened images.",
-                            "type": "string"
-                        },
-                        "repository": {
-                            "description": "Repository of the hardened images.",
-                            "type": "string"
-                        }
-                    }
+                    "description": "Use the hardened image variant. It appends `-hardened` to the tag and defaults the image to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub \u003e= v3.21.0-ea.",
+                    "type": "boolean"
                 },
                 "mcpgateway": {
                     "type": "object",

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1285,6 +1285,13 @@ hub:  # @schema additionalProperties: false
   token: ""
   # -- Mount path for token secret.
   tokenMountPath: "/etc/secrets"
+  hardened:
+    # -- Set to true to use the hardened image variant.
+    enabled: false
+    # -- Registry hosting the hardened images.
+    registry: registry.traefik.io
+    # -- Repository of the hardened images.
+    repository: traefik-hub
   # -- Disables all external network connections.
   offline:  # @schema type:[boolean, null]
   # -- By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1285,13 +1285,9 @@ hub:  # @schema additionalProperties: false
   token: ""
   # -- Mount path for token secret.
   tokenMountPath: "/etc/secrets"
-  hardened:
-    # -- Set to true to use the hardened image variant.
-    enabled: false
-    # -- Registry hosting the hardened images.
-    registry: registry.traefik.io
-    # -- Repository of the hardened images.
-    repository: traefik-hub
+  # -- Use the hardened image variant. It appends `-hardened` to the tag and defaults the image
+  # to `registry.traefik.io/traefik-hub`. Requires a valid license token and Traefik Hub >= v3.21.0-ea.
+  hardened: false
   # -- Disables all external network connections.
   offline:  # @schema type:[boolean, null]
   # -- By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.


### PR DESCRIPTION
### What does this PR do?

Add a `hub.hardened` option to deploy the hardened image variant. When `hub.hardened.enabled` is `true`, the image is built as:

    <hub.hardened.registry>/<hub.hardened.repository>:<image.tag>-hardened

with the registry and repository defaulting to `registry.traefik.io` and `traefik-hub`. A FIPS tag (e.g. `v3.20.0-fips`) becomes `v3.20.0-fips-hardened`. In this mode `image.registry` and `image.repository` are not used; only `image.tag` provides the version.

### Motivation

Allow deploying the hardened and FIPS-hardened images.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
