### PR TITLE
feat(hub): :sparkles: support AWS EC2 provider

### DIFF
--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -179,6 +179,18 @@ Kubernetes: `>=1.25.0-0`
 | hub.providers.consulCatalogEnterprise.stale | bool | `false` | Use stale consistency for catalog reads. |
 | hub.providers.consulCatalogEnterprise.strictChecks | string | `"passing, warning"` | A list of service health statuses to allow taking traffic. |
 | hub.providers.consulCatalogEnterprise.watch | bool | `false` | Watch Consul API events. |
+| hub.providers.ec2.accessKeyID | string | `""` | AWS access key ID used for requests. Set together with secretAccessKey to use static credentials. |
+| hub.providers.ec2.constraints | string | `""` | Expression matched against instance tags to determine whether to create routes for an instance. |
+| hub.providers.ec2.defaultRule | string | `""` | Default rule applied to instances that do not define a router rule tag. |
+| hub.providers.ec2.enabled | bool | `false` | Enable AWS EC2 provider. |
+| hub.providers.ec2.exposedByDefault | bool | `true` | Expose instances by default. When false, only instances with the `traefik.enable=true` tag are exposed. |
+| hub.providers.ec2.filters | list | `[]` | EC2 API filters used to scope instance discovery. List of `{ name: "<filter>", values: ["<value>"] }` entries. |
+| hub.providers.ec2.ipMode | string | `""` | Default backend IP mode: private, public or ipv6. Overridable per instance with the `traefik.ec2.ipmode` tag. |
+| hub.providers.ec2.refreshSeconds | int | `15` | Polling interval, in seconds, for the EC2 API. |
+| hub.providers.ec2.region | string | `""` | AWS region used for EC2 API requests. When empty, the region is retrieved from the EC2 Instance Metadata Service. |
+| hub.providers.ec2.secretAccessKey | string | `""` | AWS secret access key used for requests. Set together with accessKeyID. |
+| hub.providers.ec2.securityGroupPortDiscovery.enabled | bool | `false` | Derive the backend port from the instance security-group rules when no port tag is set. |
+| hub.providers.ec2.securityGroupPortDiscovery.excludedPorts | list | `[]` | Ports excluded from security-group port discovery. When empty, the provider excludes privileged ports except 80 and 443. |
 | hub.providers.microcks.auth.clientId | string | `""` | Microcks API client ID. |
 | hub.providers.microcks.auth.clientSecret | string | `""` | Microcks API client secret. |
 | hub.providers.microcks.auth.endpoint | string | `""` | Microcks API endpoint. |

--- a/traefik/VALUES.md
+++ b/traefik/VALUES.md
@@ -179,7 +179,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.providers.consulCatalogEnterprise.stale | bool | `false` | Use stale consistency for catalog reads. |
 | hub.providers.consulCatalogEnterprise.strictChecks | string | `"passing, warning"` | A list of service health statuses to allow taking traffic. |
 | hub.providers.consulCatalogEnterprise.watch | bool | `false` | Watch Consul API events. |
-| hub.providers.ec2.accessKeyID | string | `""` | AWS access key ID used for requests. Set together with secretAccessKey to use static credentials. |
+| hub.providers.ec2.accessKeyID | string | `""` | AWS access key ID, set together with secretAccessKey. Readable from the Pod spec: prefer IRSA, the instance role or `env`. |
 | hub.providers.ec2.constraints | string | `""` | Expression matched against instance tags to determine whether to create routes for an instance. |
 | hub.providers.ec2.defaultRule | string | `""` | Default rule applied to instances that do not define a router rule tag. |
 | hub.providers.ec2.enabled | bool | `false` | Enable AWS EC2 provider. |
@@ -188,7 +188,7 @@ Kubernetes: `>=1.25.0-0`
 | hub.providers.ec2.ipMode | string | `""` | Default backend IP mode: private, public or ipv6. Overridable per instance with the `traefik.ec2.ipmode` tag. |
 | hub.providers.ec2.refreshSeconds | int | `15` | Polling interval, in seconds, for the EC2 API. |
 | hub.providers.ec2.region | string | `""` | AWS region used for EC2 API requests. When empty, the region is retrieved from the EC2 Instance Metadata Service. |
-| hub.providers.ec2.secretAccessKey | string | `""` | AWS secret access key used for requests. Set together with accessKeyID. |
+| hub.providers.ec2.secretAccessKey | string | `""` | AWS secret access key, set together with accessKeyID. Readable from the Pod spec: prefer IRSA, the instance role or `env`. |
 | hub.providers.ec2.securityGroupPortDiscovery.enabled | bool | `false` | Derive the backend port from the instance security-group rules when no port tag is set. |
 | hub.providers.ec2.securityGroupPortDiscovery.excludedPorts | list | `[]` | Ports excluded from security-group port discovery. When empty, the provider excludes privileged ports except 80 and 443. |
 | hub.providers.microcks.auth.clientId | string | `""` | Microcks API client ID. |

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -913,6 +913,7 @@
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.consulCatalogEnterprise" "content" (omit $.Values.hub.providers.consulCatalogEnterprise "enabled")) | nindent 10 }}
             {{- end }}
             {{- if .providers.ec2.enabled }}
+          - "--hub.providers.ec2"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.ec2" "content" (omit $.Values.hub.providers.ec2 "enabled" "filters" "securityGroupPortDiscovery")) | nindent 10 }}
               {{- range $idx, $val := .providers.ec2.filters }}
                 {{- $filterPath := printf "hub.providers.ec2.filters[%d]" $idx }}

--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -912,6 +912,19 @@
           - "--hub.providers.consulCatalogEnterprise"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.consulCatalogEnterprise" "content" (omit $.Values.hub.providers.consulCatalogEnterprise "enabled")) | nindent 10 }}
             {{- end }}
+            {{- if .providers.ec2.enabled }}
+              {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.ec2" "content" (omit $.Values.hub.providers.ec2 "enabled" "filters" "securityGroupPortDiscovery")) | nindent 10 }}
+              {{- range $idx, $val := .providers.ec2.filters }}
+                {{- $filterPath := printf "hub.providers.ec2.filters[%d]" $idx }}
+                {{- include "traefik.yaml2CommandLineArgs" (dict "path" $filterPath "content" $val) | nindent 10 }}
+              {{- end }}
+              {{- if .providers.ec2.securityGroupPortDiscovery.enabled }}
+          - "--hub.providers.ec2.securityGroupPortDiscovery"
+                {{- if .providers.ec2.securityGroupPortDiscovery.excludedPorts }}
+                  {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.ec2.securityGroupPortDiscovery" "content" (omit $.Values.hub.providers.ec2.securityGroupPortDiscovery "enabled")) | nindent 10 }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
             {{- if .providers.microcks.enabled }}
           - "--hub.providers.microcks"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.microcks" "content" (omit $.Values.hub.providers.microcks "enabled")) | nindent 10 }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -234,6 +234,14 @@
       {{- if not $filter.values }}
         {{ fail (printf "ERROR: hub.providers.ec2.filters[%d] requires a non-empty values list." $idx) }}
       {{- end }}
+      {{- if eq $filter.name "instance-state-name" }}
+        {{ fail (printf "ERROR: hub.providers.ec2.filters[%d] uses instance-state-name, which is reserved by the provider." $idx) }}
+      {{- end }}
+      {{- range $field, $_ := $filter }}
+        {{- if not (has $field (list "name" "values")) }}
+          {{ fail (printf "ERROR: hub.providers.ec2.filters[%d] does not support field %s, only name and values are allowed." $idx $field) }}
+        {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -222,6 +222,10 @@
     {{- end }}
   {{- end }}
 
+  {{- if and $.Values.hub.providers.ec2.enabled (semverCompare "<v3.21.0-0" $hubVersion) }}
+    {{ fail "ERROR: hub.providers.ec2 is only available for Traefik Hub >= v3.21.0." }}
+  {{- end }}
+
   {{- if and $.Values.hub.providers.nutanixPrismCentral.enabled (semverCompare "<v3.20.0-ea.1" $hubVersion) }}
     {{ fail "ERROR: hub.providers.nutanixPrismCentral is only available for Traefik Hub >= v3.20.0-ea.1." }}
   {{- end }}

--- a/traefik/templates/requirements.yaml
+++ b/traefik/templates/requirements.yaml
@@ -226,6 +226,17 @@
     {{ fail "ERROR: hub.providers.ec2 is only available for Traefik Hub >= v3.21.0." }}
   {{- end }}
 
+  {{- if $.Values.hub.providers.ec2.enabled }}
+    {{- range $idx, $filter := $.Values.hub.providers.ec2.filters }}
+      {{- if not $filter.name }}
+        {{ fail (printf "ERROR: hub.providers.ec2.filters[%d] requires a non-empty name." $idx) }}
+      {{- end }}
+      {{- if not $filter.values }}
+        {{ fail (printf "ERROR: hub.providers.ec2.filters[%d] requires a non-empty values list." $idx) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
   {{- if and $.Values.hub.providers.nutanixPrismCentral.enabled (semverCompare "<v3.20.0-ea.1" $hubVersion) }}
     {{ fail "ERROR: hub.providers.nutanixPrismCentral is only available for Traefik Hub >= v3.20.0-ea.1." }}
   {{- end }}

--- a/traefik/tests/hub-ec2-config_test.yaml
+++ b/traefik/tests/hub-ec2-config_test.yaml
@@ -1,0 +1,119 @@
+suite: Traefik Hub EC2 provider
+templates:
+  - deployment.yaml
+set:
+  image:
+    registry: ghcr.io
+    repository: traefik/traefik-hub
+    tag: v3.21.0
+  hub:
+    token: "xxx"
+tests:
+  - it: should not configure ec2 by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.region="
+
+  - it: should configure ec2 when enabled
+    set:
+      hub:
+        providers:
+          ec2:
+            enabled: true
+            region: "us-east-1"
+            accessKeyID: "AKIAEXAMPLE"
+            secretAccessKey: "secret"
+            exposedByDefault: false
+            refreshSeconds: 30
+            defaultRule: "Host(`{{ normalize .Name }}`)"
+            constraints: "Tag(`env=prod`)"
+            ipMode: "public"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.region=us-east-1"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.accessKeyID=AKIAEXAMPLE"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.secretAccessKey=secret"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.exposedByDefault=false"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.refreshSeconds=30"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.ipMode=public"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.constraints=Tag(`env=prod`)"
+
+  - it: should render each filter with its index
+    set:
+      hub:
+        providers:
+          ec2:
+            enabled: true
+            region: "eu-west-1"
+            filters:
+              - name: "tag:env"
+                values:
+                  - "production"
+                  - "staging"
+              - name: "vpc-id"
+                values:
+                  - "vpc-0123456789abcdef0"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.filters[0].name=tag:env"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.filters[0].values=production,staging"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.filters[1].name=vpc-id"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.filters[1].values=vpc-0123456789abcdef0"
+
+  - it: should enable security group port discovery with its defaults
+    set:
+      hub:
+        providers:
+          ec2:
+            enabled: true
+            region: "us-east-1"
+            securityGroupPortDiscovery:
+              enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.securityGroupPortDiscovery"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.securityGroupPortDiscovery.excludedPorts="
+
+  - it: should render explicit excludedPorts
+    set:
+      hub:
+        providers:
+          ec2:
+            enabled: true
+            region: "us-east-1"
+            securityGroupPortDiscovery:
+              enabled: true
+              excludedPorts:
+                - 22
+                - 3389
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.securityGroupPortDiscovery"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2.securityGroupPortDiscovery.excludedPorts=22,3389"

--- a/traefik/tests/hub-ec2-config_test.yaml
+++ b/traefik/tests/hub-ec2-config_test.yaml
@@ -13,7 +13,21 @@ tests:
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2"
+      - notContains:
+          path: spec.template.spec.containers[0].args
           content: "--hub.providers.ec2.region="
+
+  - it: should be possible to enable ec2 with default config
+    set:
+      hub:
+        providers:
+          ec2:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2"
 
   - it: should configure ec2 when enabled
     set:
@@ -30,6 +44,9 @@ tests:
             constraints: "Tag(`env=prod`)"
             ipMode: "public"
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.ec2"
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.providers.ec2.region=us-east-1"

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -752,6 +752,56 @@ tests:
             enabled: true
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when an ec2 filter is missing a name
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+            filters:
+              - values:
+                  - "x"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.ec2.filters[0] requires a non-empty name."
+  - it: should fail when an ec2 filter is missing values
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+            filters:
+              - name: "tag:env"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.ec2.filters[0] requires a non-empty values list."
+  - it: should pass when ec2 filters define a name
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+            filters:
+              - name: "tag:env"
+                values:
+                  - "prod"
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when using pluginRegistry sources with unused plugin
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -752,6 +752,33 @@ tests:
             enabled: true
     asserts:
       - notFailedTemplate: {}
+  - it: should fail when using ec2 provider on Traefik Hub < v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.20.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.ec2 is only available for Traefik Hub >= v3.21.0."
+  - it: should pass when using ec2 provider on Traefik Hub >= v3.21.0
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+    asserts:
+      - notFailedTemplate: {}
   - it: should fail when an ec2 filter is missing a name
     set:
       image:

--- a/traefik/tests/requirements-config_test.yaml
+++ b/traefik/tests/requirements-config_test.yaml
@@ -812,6 +812,43 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: hub.providers.ec2.filters[0] requires a non-empty values list."
+  - it: should fail when an ec2 filter uses an unsupported field
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+            filters:
+              - name: "tag:env"
+                values:
+                  - "prod"
+                unsupported: "x"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.ec2.filters[0] does not support field unsupported, only name and values are allowed."
+  - it: should fail when an ec2 filter uses the reserved instance-state-name
+    set:
+      image:
+        registry: "ghcr.io"
+        repository: "traefik/traefik-hub"
+        tag: v3.21.0
+      hub:
+        token: "xxx"
+        providers:
+          ec2:
+            enabled: true
+            filters:
+              - name: "instance-state-name"
+                values:
+                  - "running"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: hub.providers.ec2.filters[0] uses instance-state-name, which is reserved by the provider."
   - it: should pass when ec2 filters define a name
     set:
       image:

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -953,65 +953,63 @@
                             "type": "object",
                             "properties": {
                                 "accessKeyID": {
+                                    "description": "AWS access key ID used for requests. Set together with secretAccessKey to use static credentials.",
                                     "type": "string"
                                 },
                                 "constraints": {
+                                    "description": "Expression matched against instance tags to determine whether to create routes for an instance.",
                                     "type": "string"
                                 },
                                 "defaultRule": {
+                                    "description": "Default rule applied to instances that do not define a router rule tag.",
                                     "type": "string"
                                 },
                                 "enabled": {
+                                    "description": "Enable AWS EC2 provider.",
                                     "type": "boolean"
                                 },
                                 "exposedByDefault": {
+                                    "description": "Expose instances by default. When false, only instances with the `traefik.enable=true` tag are exposed.",
                                     "type": "boolean"
                                 },
                                 "filters": {
+                                    "description": "EC2 API filters used to scope instance discovery. List of `{ name: \"\u003cfilter\u003e\", values: [\"\u003cvalue\u003e\"] }` entries.",
+                                    "type": "array",
                                     "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "values": {
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
+                                        "type": "object"
+                                    }
                                 },
                                 "ipMode": {
+                                    "description": "Default backend IP mode: private, public or ipv6. Overridable per instance with the `traefik.ec2.ipmode` tag.",
+                                    "type": "string",
                                     "enum": [
                                         "",
                                         "private",
                                         "public",
                                         "ipv6"
-                                    ],
-                                    "type": "string"
+                                    ]
                                 },
                                 "refreshSeconds": {
+                                    "description": "Polling interval, in seconds, for the EC2 API.",
                                     "type": "integer"
                                 },
                                 "region": {
+                                    "description": "AWS region used for EC2 API requests. When empty, the region is retrieved from the EC2 Instance Metadata Service.",
                                     "type": "string"
                                 },
                                 "secretAccessKey": {
+                                    "description": "AWS secret access key used for requests. Set together with accessKeyID.",
                                     "type": "string"
                                 },
                                 "securityGroupPortDiscovery": {
                                     "type": "object",
                                     "properties": {
                                         "enabled": {
+                                            "description": "Derive the backend port from the instance security-group rules when no port tag is set.",
                                             "type": "boolean"
                                         },
                                         "excludedPorts": {
-                                            "items": {
-                                                "type": "integer"
-                                            },
+                                            "description": "Ports excluded from security-group port discovery. When empty, the provider excludes privileged ports except 80 and 443.",
                                             "type": "array"
                                         }
                                     },

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -953,7 +953,7 @@
                             "type": "object",
                             "properties": {
                                 "accessKeyID": {
-                                    "description": "AWS access key ID used for requests. Set together with secretAccessKey to use static credentials.",
+                                    "description": "AWS access key ID, set together with secretAccessKey. Readable from the Pod spec: prefer IRSA, the instance role or `env`.",
                                     "type": "string"
                                 },
                                 "constraints": {
@@ -998,7 +998,7 @@
                                     "type": "string"
                                 },
                                 "secretAccessKey": {
-                                    "description": "AWS secret access key used for requests. Set together with accessKeyID.",
+                                    "description": "AWS secret access key, set together with accessKeyID. Readable from the Pod spec: prefer IRSA, the instance role or `env`.",
                                     "type": "string"
                                 },
                                 "securityGroupPortDiscovery": {

--- a/traefik/values.schema.json
+++ b/traefik/values.schema.json
@@ -949,6 +949,77 @@
                                 }
                             }
                         },
+                        "ec2": {
+                            "type": "object",
+                            "properties": {
+                                "accessKeyID": {
+                                    "type": "string"
+                                },
+                                "constraints": {
+                                    "type": "string"
+                                },
+                                "defaultRule": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "exposedByDefault": {
+                                    "type": "boolean"
+                                },
+                                "filters": {
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "ipMode": {
+                                    "enum": [
+                                        "",
+                                        "private",
+                                        "public",
+                                        "ipv6"
+                                    ],
+                                    "type": "string"
+                                },
+                                "refreshSeconds": {
+                                    "type": "integer"
+                                },
+                                "region": {
+                                    "type": "string"
+                                },
+                                "secretAccessKey": {
+                                    "type": "string"
+                                },
+                                "securityGroupPortDiscovery": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "excludedPorts": {
+                                            "items": {
+                                                "type": "integer"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "microcks": {
                             "type": "object",
                             "properties": {

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1387,6 +1387,32 @@ hub:  # @schema additionalProperties: false
       strictChecks: "passing, warning"
       # -- Watch Consul API events.
       watch: false
+    ec2:
+      # -- Enable AWS EC2 provider.
+      enabled: false
+      # -- AWS region used for EC2 API requests. When empty, the region is retrieved from the EC2 Instance Metadata Service.
+      region: ""
+      # -- AWS access key ID used for requests. Set together with secretAccessKey to use static credentials.
+      accessKeyID: ""
+      # -- AWS secret access key used for requests. Set together with accessKeyID.
+      secretAccessKey: ""
+      # -- Expose instances by default. When false, only instances with the `traefik.enable=true` tag are exposed.
+      exposedByDefault: true
+      # -- Polling interval, in seconds, for the EC2 API.
+      refreshSeconds: 15
+      # -- Default rule applied to instances that do not define a router rule tag.
+      defaultRule: ""
+      # -- Expression matched against instance tags to determine whether to create routes for an instance.
+      constraints: ""
+      # -- Default backend IP mode: private, public or ipv6. Overridable per instance with the `traefik.ec2.ipmode` tag.
+      ipMode: ""
+      # -- EC2 API filters used to scope instance discovery. List of `{ name: "<filter>", values: ["<value>"] }` entries.
+      filters: []
+      securityGroupPortDiscovery:
+        # -- Derive the backend port from the instance security-group rules when no port tag is set.
+        enabled: false
+        # -- Ports excluded from security-group port discovery. When empty, the provider excludes privileged ports except 80 and 443.
+        excludedPorts: []
     microcks:
       # -- Enable Microcks provider.
       enabled: false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1387,6 +1387,7 @@ hub:  # @schema additionalProperties: false
       strictChecks: "passing, warning"
       # -- Watch Consul API events.
       watch: false
+    # @schema additionalProperties: false
     ec2:
       # -- Enable AWS EC2 provider.
       enabled: false
@@ -1405,9 +1406,10 @@ hub:  # @schema additionalProperties: false
       # -- Expression matched against instance tags to determine whether to create routes for an instance.
       constraints: ""
       # -- Default backend IP mode: private, public or ipv6. Overridable per instance with the `traefik.ec2.ipmode` tag.
-      ipMode: ""
+      ipMode: ""  # @schema enum:["", "private", "public", "ipv6"]
       # -- EC2 API filters used to scope instance discovery. List of `{ name: "<filter>", values: ["<value>"] }` entries.
-      filters: []
+      filters: []  # @schema item:object
+      # @schema additionalProperties: false
       securityGroupPortDiscovery:
         # -- Derive the backend port from the instance security-group rules when no port tag is set.
         enabled: false

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1393,9 +1393,9 @@ hub:  # @schema additionalProperties: false
       enabled: false
       # -- AWS region used for EC2 API requests. When empty, the region is retrieved from the EC2 Instance Metadata Service.
       region: ""
-      # -- AWS access key ID used for requests. Set together with secretAccessKey to use static credentials.
+      # -- AWS access key ID, set together with secretAccessKey. Readable from the Pod spec: prefer IRSA, the instance role or `env`.
       accessKeyID: ""
-      # -- AWS secret access key used for requests. Set together with accessKeyID.
+      # -- AWS secret access key, set together with accessKeyID. Readable from the Pod spec: prefer IRSA, the instance role or `env`.
       secretAccessKey: ""
       # -- Expose instances by default. When false, only instances with the `traefik.enable=true` tag are exposed.
       exposedByDefault: true


### PR DESCRIPTION
### What does this PR do?

Adds `hub.providers.ec2` so the Traefik Hub EC2 tag-based discovery provider can be configured through chart values, matching the pattern used by the other Hub providers. Modelled on #1808 (Nutanix Prism Central), including the indexed-list handling for `filters` and the allow-empty `securityGroupPortDiscovery` struct. Gated on Traefik Hub `>= v3.21.0` in `requirements.yaml`.

### Motivation

Traefik Hub gained [an EC2 tag-based discovery provider](https://doc.traefik.io/traefik-hub/api-gateway/reference/install/providers/ref-provider-ec2), but the chart had no mapping for it. Today `hub.providers.ec2` values pass schema validation — because `hub.providers` is the one permissive node in an otherwise `additionalProperties: false` chain — and are then silently never read: a user following the documented Helm example installs a gateway with no EC2 provider, no error and no warning. The interim workaround is `additionalArguments`.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed
