### PR TITLE
fix(hub): 🐛 enable providers with default config

### DIFF
--- a/traefik/templates/_podtemplate.tpl
+++ b/traefik/templates/_podtemplate.tpl
@@ -909,12 +909,15 @@
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.tracing.additionalTraceHeaders.traceContext" "content" $.Values.hub.tracing.additionalTraceHeaders.traceContext) | nindent 10 }}
             {{- end }}
             {{- if .providers.consulCatalogEnterprise.enabled }}
+          - "--hub.providers.consulCatalogEnterprise"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.consulCatalogEnterprise" "content" (omit $.Values.hub.providers.consulCatalogEnterprise "enabled")) | nindent 10 }}
             {{- end }}
             {{- if .providers.microcks.enabled }}
+          - "--hub.providers.microcks"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.microcks" "content" (omit $.Values.hub.providers.microcks "enabled")) | nindent 10 }}
             {{- end }}
             {{- if .providers.nutanixPrismCentral.enabled }}
+          - "--hub.providers.nutanixPrismCentral"
               {{- include "traefik.yaml2CommandLineArgs" (dict "path" "hub.providers.nutanixPrismCentral" "content" (omit $.Values.hub.providers.nutanixPrismCentral "enabled" "allowedVpcs")) | nindent 10 }}
               {{- range $idx, $val := .providers.nutanixPrismCentral.allowedVpcs }}
                 {{- $vpcPath := printf "hub.providers.nutanixPrismCentral.allowedVpcs[%d]" $idx }}

--- a/traefik/tests/hub-apigateway-config_test.yaml
+++ b/traefik/tests/hub-apigateway-config_test.yaml
@@ -283,6 +283,16 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--hub.tracing.additionalTraceHeaders.traceContext.traceState=traceState"
+  - it: should be possible to enable Traefik Hub microcks provider with default config
+    set:
+      hub:
+        providers:
+          microcks:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.microcks"
   - it: should be possible to configure Traefik Hub microcks provider
     set:
       hub:
@@ -293,7 +303,30 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
+          content: "--hub.providers.microcks"
+      - contains:
+          path: spec.template.spec.containers[0].args
           content: "--hub.providers.microcks.endpoint=http://microcks.svc"
+  - it: should be possible to enable Traefik Hub nutanixPrismCentral provider with default config
+    set:
+      hub:
+        providers:
+          nutanixPrismCentral:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.nutanixPrismCentral"
+  - it: should be possible to enable Traefik Hub consulCatalogEnterprise provider with default config
+    set:
+      hub:
+        providers:
+          consulCatalogEnterprise:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hub.providers.consulCatalogEnterprise"
   - it: should be possible to configure Traefik Hub consulCatalogEnterprise provider
     set:
       hub:


### PR DESCRIPTION
### What does this PR do?

Allows to enable providers with default config.

### Motivation

Align hub providers with proxy on this use case.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

