### PR TITLE
fix(crds/middleware): add missing ErrorRequestHeaders field

### DIFF
--- a/traefik/crds/traefik.io_middlewares.yaml
+++ b/traefik/crds/traefik.io_middlewares.yaml
@@ -299,6 +299,14 @@ spec:
                   This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
                   More info: https://doc.traefik.io/traefik/v3.7/reference/routing-configuration/http/middlewares/errorpages/
                 properties:
+                  errorRequestHeaders:
+                    description: |-
+                      ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+                      When nil (not set), all original request headers are forwarded.
+                      Set to an empty list to forward no headers, or list specific headers to forward only those.
+                    items:
+                      type: string
+                    type: array
                   query:
                     description: |-
                       Query defines the URL for the error page (hosted by service).


### PR DESCRIPTION
### What does this PR do?

Add missing ErrorRequestHeaders field to CRDs

### Motivation

It's available since Traefik Proxy [v3.7.8](https://github.com/traefik/traefik/releases/tag/v3.7.8)
