### PR TITLE
ci(renovate): scope updates per chart on VALUES.md & AppVersion

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,7 +83,9 @@
       customType: 'regex',
       datasourceTemplate: 'docker',
       depNameTemplate: 'traefik',
-      managerFilePatterns: ['/VALUES.md/'],
+      // Anchored: an unanchored `/VALUES.md/` regex also matches hub-manager/VALUES.md,
+      // which would get the Traefik Proxy version written into its AppVersion badge.
+      managerFilePatterns: ['/^traefik/VALUES\\.md$/'],
       versioningTemplate: 'docker',
       matchStrings: [
         "!\\[AppVersion:\\s*(?<currentValue>[\\w+\\.\\-]*)\\]",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,12 @@
       allowedVersions: '/^v\\d+\\.\\d+\\.\\d+$/',
     },
     {
+      matchPackageNames: ['ghcr.io/traefik/hub-manager'],
+      extends: [':semanticCommitTypeAll(feat)'],
+      // Only track stable hub-manager releases (exclude commit-sha and master-* tags).
+      allowedVersions: '/^v\\d+\\.\\d+\\.\\d+$/',
+    },
+    {
       matchPackageNames: ['bpsoraggi/helm-gh-pages'],
       enabled: false,
     },
@@ -86,6 +92,17 @@
       // Anchored: an unanchored `/VALUES.md/` regex also matches hub-manager/VALUES.md,
       // which would get the Traefik Proxy version written into its AppVersion badge.
       managerFilePatterns: ['/^traefik/VALUES\\.md$/'],
+      versioningTemplate: 'docker',
+      matchStrings: [
+        "!\\[AppVersion:\\s*(?<currentValue>[\\w+\\.\\-]*)\\]",
+        "\\(https:\\/\\/img\\.shields\\.io\\/badge\\/AppVersion-(?<currentValue>[\\w+\\.\\-]*)-informational.+\\)"
+      ]
+    },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'docker',
+      depNameTemplate: 'ghcr.io/traefik/hub-manager',
+      managerFilePatterns: ['/^hub-manager/VALUES\\.md$/'],
       versioningTemplate: 'docker',
       matchStrings: [
         "!\\[AppVersion:\\s*(?<currentValue>[\\w+\\.\\-]*)\\]",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,7 @@
     {
       matchPackageNames: ['ghcr.io/traefik/hub-manager'],
       extends: [':semanticCommitTypeAll(feat)'],
-      // Only track stable hub-manager releases (exclude commit-sha and master-* tags).
+      // Only track stable releases (exclude sha and master-* tags).
       allowedVersions: '/^v\\d+\\.\\d+\\.\\d+$/',
     },
     {
@@ -89,8 +89,7 @@
       customType: 'regex',
       datasourceTemplate: 'docker',
       depNameTemplate: 'traefik',
-      // Anchored: an unanchored `/VALUES.md/` regex also matches hub-manager/VALUES.md,
-      // which would get the Traefik Proxy version written into its AppVersion badge.
+      // Anchored, else it also matches hub-manager/VALUES.md.
       managerFilePatterns: ['/^traefik/VALUES\\.md$/'],
       versioningTemplate: 'docker',
       matchStrings: [

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,9 @@ jobs:
       - name: Test changelog annotations
         run: make test-changelog
 
+      - name: Check Renovate appVersion hints
+        run: make check-renovate
+
       - name: Test if it's a release PR
         id: check
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test snapshots test-changelog
+.PHONY: lint test snapshots test-changelog check-renovate
 
 IMAGE_CHART_TESTING=quay.io/helmpack/chart-testing:v3.14.0
 IMAGE_HELM_CHANGELOG=ghcr.io/traefik/helm-changelog:v1.0.0
@@ -16,6 +16,9 @@ test-ns:
 
 test-changelog:
 	./hack/test-changelog.sh
+
+check-renovate:
+	./hack/check-renovate-hints.sh
 
 lint:
 	docker run ${DOCKER_ARGS} --env GIT_SAFE_DIR="true" --entrypoint /bin/sh --rm -v $(CURDIR):/charts -w /charts $(IMAGE_CHART_TESTING) /charts/hack/ct.sh lint

--- a/hack/check-renovate-hints.sh
+++ b/hack/check-renovate-hints.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# The customManagers:helmChartYamlAppVersions preset only updates appVersion when a
+# "# renovate: image=" comment sits right above it. Rewriting Chart.yaml drops it silently.
+rc=0
+
+for chart in traefik hub-manager; do
+  if ! grep -B1 '^appVersion:' "${chart}/Chart.yaml" | grep -q '^# renovate: image='; then
+    echo "Error: ${chart}/Chart.yaml misses '# renovate: image=' above appVersion. Restore it,"
+    echo "       or Renovate stops updating appVersion."
+    rc=1
+  fi
+done
+
+exit "${rc}"

--- a/hub-manager/Chart.yaml
+++ b/hub-manager/Chart.yaml
@@ -3,6 +3,7 @@ name: hub-manager
 description: A Helm chart for hub-manager
 type: application
 version: 1.0.0
+# renovate: image=ghcr.io/traefik/hub-manager
 appVersion: v0.45.1
 kubeVersion: '>=1.25.0-0'
 keywords:

--- a/traefik/Chart.yaml
+++ b/traefik/Chart.yaml
@@ -3,6 +3,7 @@ name: traefik
 description: A Traefik based Kubernetes ingress controller
 type: application
 version: 41.1.1
+# renovate: image=traefik
 appVersion: v3.7.9
 kubeVersion: '>=1.25.0-0'
 keywords:


### PR DESCRIPTION
## Context

The `VALUES.md` custom manager uses an unanchored regex file pattern, so it also matches `hub-manager/VALUES.md` and writes the Traefik Proxy version into its badge. And `traefik/Chart.yaml` lost its `# renovate: image=traefik` hint in #1947, so the `helmChartYamlAppVersions` preset stopped updating `appVersion`.

## Motivation

Both show up in #1954: `hub-manager` advertises `AppVersion: v3.7.10`, and `traefik/Chart.yaml` keeps `appVersion: v3.7.9` while its `VALUES.md` badge moves on.

This anchors the pattern to the traefik chart, restores the hint, and adds a dedicated manager so `hub-manager` tracks stable `ghcr.io/traefik/hub-manager` releases. A `make check-renovate` step now fails the build if the hint disappears again, since a YAML tool rewriting `Chart.yaml` drops it without any signal.
