### PR TITLE
feat(rbac): add UDPRoute permissions for Kubernetes Gateway API

### DIFF
--- a/traefik/templates/rbac/clusterrole.yaml
+++ b/traefik/templates/rbac/clusterrole.yaml
@@ -123,6 +123,7 @@ rules:
       - referencegrants
       - tcproutes
       - tlsroutes
+      - udproutes
     verbs:
       - get
       - list
@@ -137,6 +138,7 @@ rules:
       - httproutes/status
       - tcproutes/status
       - tlsroutes/status
+      - udproutes/status
     verbs:
       - update
   {{- end }}

--- a/traefik/tests/rbac-config_test.yaml
+++ b/traefik/tests/rbac-config_test.yaml
@@ -600,6 +600,7 @@ tests:
               - httproutes/status
               - tcproutes/status
               - tlsroutes/status
+              - udproutes/status
             verbs:
               - update
       - template: rbac/clusterrole.yaml
@@ -617,6 +618,7 @@ tests:
               - referencegrants
               - tcproutes
               - tlsroutes
+              - udproutes
             verbs:
               - get
               - list


### PR DESCRIPTION
### What does this PR do?

Adds get, list, and watch permissions for `udproutes`, and update permission for `udproutes/status`, to the Kubernetes Gateway provider ClusterRole.

### Motivation

Gateway API v1.6.1 graduates UDPRoute to the Standard channel. [traefik/traefik#12472](https://github.com/traefik/traefik/pull/12472) adds support for consuming UDPRoute through its Standard v1 API.

Without these permissions, Helm installations cannot watch UDPRoute resources or publish their status.

### More

- [x] Yes, I updated the tests accordingly
- [ ] Yes, I updated the schema accordingly
- [x] Yes, I ran `make test` and all the tests passed